### PR TITLE
Fix link to `compatibility.md`

### DIFF
--- a/packages/react-strict-dom/README.md
+++ b/packages/react-strict-dom/README.md
@@ -111,7 +111,7 @@ function App() {
 
 ## Compatibility
 
-Please see [COMPATIBILITY.md](./COMPATIBILITY.md) for a detailed look at API compatibility for native.  Please read the linked issues for details on the most significant issues, and register your interest (e.g., thumbsup reaction) in supporting these features on native platforms.
+Please see [COMPATIBILITY.md](https://github.com/facebook/react-strict-dom/blob/main/packages/react-strict-dom/COMPATIBILITY.md) for a detailed look at API compatibility for native.  Please read the linked issues for details on the most significant issues, and register your interest (e.g., thumbsup reaction) in supporting these features on native platforms.
 
 ## License
 


### PR DESCRIPTION
If anyone would like to read the package README on `npm` directly, pressing on `COMPATIBILITY` will return **404**

<img width="573" alt="image" src="https://github.com/facebook/react-strict-dom/assets/2805320/c55ae079-9954-41d9-bd91-cab19ada5788">
