### PR TITLE
docs: fix node version typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Meta has a [bounty program](https://www.facebook.com/whitehat/) for the safe dis
 
 Visit the issue tracker to find a list of open issues that need attention.
 
-**Make sure you have npm@>=7 and node@>=0.16 installed.**
+**Make sure you have npm@>=7 and node@>=16 installed.**
 
 First, clone your fork of the `react-strict-dom` repo:
 


### PR DESCRIPTION
Fixed node version typo from 0.16 to 16 in [CONTRIBUTING.md](https://github.com/facebook/react-strict-dom/pull/28/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055)