### PR TITLE
Delete unused tag in examples app

### DIFF
--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -151,8 +151,6 @@ export default function App(): React.MixedElement {
           <html.div />
           <html.button>button</html.button>
           <html.div />
-          {/*<html.input placeholder="input type:date" type="date" />*/}
-          <html.div />
           <html.input placeholder="input type:email" type="email" />
           <html.div />
           <html.input placeholder="input type:number" type="number" />


### PR DESCRIPTION
I see an issue that currently not support date type (#13 ).

But there is code line in App.js in exapmples app.

So reduce confusion for another user, delete unused data type input.

Thank you
