### PR TITLE
Partial polyfill for CSS 'visibility'

### DIFF
--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -181,7 +181,7 @@ export default function App(): React.MixedElement {
           <html.textarea placeholder="textarea" />
         </ExampleBlock>
 
-        {/* block layout emulation */}
+        {/* variables & themes */}
         <ExampleBlock title="Variables & Theming">
           <html.p style={styles.inheritedText}>Global variables</html.p>
           <html.div style={styles.square} />
@@ -258,6 +258,15 @@ export default function App(): React.MixedElement {
             <html.div style={[styles.relative, styles.p50]}>
               <html.div style={[styles.square, styles.absTopLeft]} />
             </html.div>
+          </html.div>
+        </ExampleBlock>
+
+        {/* visibility */}
+        <ExampleBlock title="Visibility">
+          <html.div style={styles.flex}>
+            <html.div style={[styles.square, styles.visibilityCollapse]} />
+            <html.div style={[styles.square, styles.visibilityHidden]} />
+            <html.div style={[styles.square, styles.visibilityVisible]} />
           </html.div>
         </ExampleBlock>
 
@@ -363,7 +372,7 @@ export default function App(): React.MixedElement {
           <html.span>{imageErrorText}</html.span>
         </ExampleBlock>
 
-        {/* CSS Transitions Shim */}
+        {/* CSS transitions shim */}
         <ExampleBlock title="CSS Transitions">
           <html.p>Color</html.p>
           <html.div
@@ -649,5 +658,14 @@ const styles = css.create({
   }),
   dynamicTransform: (transform: string) => ({
     transform
-  })
+  }),
+  visibilityCollapse: {
+    visibility: 'collapse'
+  },
+  visibilityHidden: {
+    visibility: 'hidden'
+  },
+  visibilityVisible: {
+    visibility: 'visible'
+  }
 });

--- a/packages/eslint-plugin/src/valid-styles.js
+++ b/packages/eslint-plugin/src/valid-styles.js
@@ -159,6 +159,7 @@ const allowlistedStylexProps = new Set([
   'transitionTimingFunction',
   'userSelect',
   'verticalAlign',
+  'visibility',
   'width',
   'zIndex'
 ]);

--- a/packages/react-strict-dom/COMPATIBILITY.md
+++ b/packages/react-strict-dom/COMPATIBILITY.md
@@ -631,7 +631,7 @@ Note these APIs can only be accessed using `Node.getRootNode().defaultView`, in 
 | userSelect | 🟡 | 🟡 | |
 | v* units | 🟡 | 🟡 | |
 | verticalAlign | 🟡 | ❌ | |
-| visibility | ❌ | ❌ | |
+| visibility | 🟡 | 🟡 | |
 | whiteSpace | ❌ | ❌ | |
 | width | ✅ | ✅ | |
 | wordBreak | ❌ | ❌ | |

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -424,7 +424,6 @@ export function createStrictDOMComponent<T: any, P: StrictProps>(
         textAlign,
         textIndent,
         textTransform,
-        visibility,
         whiteSpace,
         ...nonTextStyles
       } = flattenStyle(extractedStyles) || {};
@@ -468,9 +467,6 @@ export function createStrictDOMComponent<T: any, P: StrictProps>(
       }
       if (textTransform != null) {
         textStyles.textTransform = textTransform;
-      }
-      if (visibility != null) {
-        textStyles.visibility = visibility;
       }
       if (whiteSpace != null) {
         textStyles.whiteSpace = whiteSpace;

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -558,6 +558,16 @@ export function props(
       } else if (styleProp === 'paddingInlineEnd') {
         flatStyle.paddingEnd = styleValue;
       }
+      // visibility polyfill
+      // note: we can't polyfill nested visibility changes
+      else if (styleProp === 'visibility') {
+        if (styleValue === 'hidden' || styleValue === 'collapse') {
+          flatStyle.opacity = 0;
+          nativeProps['aria-hidden'] = true;
+          nativeProps.pointerEvents = 'none';
+          nativeProps.tabIndex = -1;
+        }
+      }
       // everything else
       else {
         warnMsg(`Ignoring unsupported style property "${styleProp}"`);

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -515,6 +515,30 @@ exports[`properties: general vertical-align: top 1`] = `
 }
 `;
 
+exports[`properties: general visibility: collapse 1`] = `
+{
+  "aria-hidden": true,
+  "pointerEvents": "none",
+  "style": {
+    "opacity": 0,
+  },
+  "tabIndex": -1,
+}
+`;
+
+exports[`properties: general visibility: hidden 1`] = `
+{
+  "aria-hidden": true,
+  "pointerEvents": "none",
+  "style": {
+    "opacity": 0,
+  },
+  "tabIndex": -1,
+}
+`;
+
+exports[`properties: general visibility: visible 1`] = `{}`;
+
 exports[`properties: logical direction blockSize: blockSize 1`] = `
 {
   "style": {

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -1266,7 +1266,7 @@ exports[`html style polyfills "transition" properties : width transition start 1
 />
 `;
 
-exports[`html style polyfills default inherited styles 1`] = `
+exports[`html style polyfills default inherited text styles 1`] = `
 <View
   experimental_layoutConformance="strict"
   style={

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -603,6 +603,29 @@ describe('properties: general', () => {
     );
     expect(css.props.call(mockOptions, styles.top)).toMatchSnapshot('top');
   });
+
+  test('visibility', () => {
+    const styles = css.create({
+      collapse: {
+        visibility: 'collapse'
+      },
+      hidden: {
+        visibility: 'hidden'
+      },
+      visible: {
+        visibility: 'visible'
+      }
+    });
+    expect(css.props.call(mockOptions, styles.collapse)).toMatchSnapshot(
+      'collapse'
+    );
+    expect(css.props.call(mockOptions, styles.hidden)).toMatchSnapshot(
+      'hidden'
+    );
+    expect(css.props.call(mockOptions, styles.visible)).toMatchSnapshot(
+      'visible'
+    );
+  });
 });
 
 /**

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -113,7 +113,7 @@ describe('html', () => {
       expect(root.toJSON()).toMatchSnapshot();
     });
 
-    test('default inherited styles', () => {
+    test('default inherited text styles', () => {
       const inheritableStyles = {
         color: 'red',
         cursor: 'pointer',
@@ -128,7 +128,6 @@ describe('html', () => {
         textAlign: 'right',
         textIndent: '10px',
         textTransform: 'uppercase',
-        visibility: 'hidden',
         whiteSpace: ''
       };
       const root = create(


### PR DESCRIPTION
Implements a partial polyfill for non-inheritable 'visibility'. This does not polyfill the web behavior of being able to selectively override the 'visibility' of elements nested within an element with 'visibility:hidden'.

As result, this patch also removes 'visibility' from the inheritable text styles. Originally visibility was added here simply because it is considered an inheritable property on web, even though we didn't do anything with the property on native. In the context of these polyfills, we're only interested in being able to inherit text styles and cannot do anything with inherited visibility, so there is no functional change to the existing polyfill for inheritable text styles.

Also note that no attempt is made to implement 'collapse' as per W3C spec, as this behavior does not appear to be supported for flex items in Chrome anyway (which behave the same whether 'collapse' or 'hidden' is used.)