### PR TITLE
Fix custom snapshot resolver consistency

### DIFF
--- a/configs/jest-dom-resolver.js
+++ b/configs/jest-dom-resolver.js
@@ -34,7 +34,7 @@ module.exports = {
     return testPath;
   },
 
-  testPathForConsistencyCheck: path.posix.join(
+  testPathForConsistencyCheck: path.join(
     'consistency_check',
     '__tests__',
     'example.test.js'

--- a/configs/jest-native-resolver.js
+++ b/configs/jest-native-resolver.js
@@ -34,7 +34,7 @@ module.exports = {
     return testPath;
   },
 
-  testPathForConsistencyCheck: path.posix.join(
+  testPathForConsistencyCheck: path.join(
     'consistency_check',
     '__tests__',
     'example.test.js'


### PR DESCRIPTION
I reported the issue in https://github.com/facebook/react-strict-dom/issues/46
There was an issue with tests not running in the "Windows" environment.
"posix" may be removed unless there is a specific reason for it to only be included in "testPathForConsistencyCheck".

If there is a reason, please let me know.
