### PR TITLE
Add support for html.strike

### DIFF
--- a/packages/react-strict-dom/src/dom/html.js
+++ b/packages/react-strict-dom/src/dom/html.js
@@ -313,6 +313,14 @@ export const span: React$AbstractComponent<
 > = createStrict('span', defaultStyles.span);
 
 /**
+ * "strike" (inline)
+ */
+export const strike: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('strike', defaultStyles.strike);
+
+/**
  * "strong" (inline)
  */
 export const strong: React$AbstractComponent<

--- a/packages/react-strict-dom/src/dom/runtime.js
+++ b/packages/react-strict-dom/src/dom/runtime.js
@@ -113,6 +113,7 @@ const pre: StrictReactDOMPropsStyle = [styles.block, styles.codePre];
 const section: StrictReactDOMPropsStyle = styles.block;
 const select: StrictReactDOMPropsStyle = styles.inlineblock;
 const span: StrictReactDOMPropsStyle = styles.inline;
+const strike: StrictReactDOMPropsStyle = styles.inline;
 const strong: StrictReactDOMPropsStyle = [styles.inline, styles.strong];
 const sub: StrictReactDOMPropsStyle = styles.inline;
 const sup: StrictReactDOMPropsStyle = styles.inline;
@@ -161,6 +162,7 @@ export const defaultStyles = {
   section: section as typeof section,
   select: select as typeof select,
   span: span as typeof span,
+  strike: strike as typeof strike,
   strong: strong as typeof strong,
   sub: sub as typeof sub,
   sup: sup as typeof sup,

--- a/packages/react-strict-dom/src/native/html.js
+++ b/packages/react-strict-dom/src/native/html.js
@@ -53,6 +53,9 @@ const styles = stylex.create({
   input: {
     borderWidth: 1
   },
+  strike: {
+    textDecorationLine: 'line-through'
+  },
   textarea: {
     verticalAlign: 'top'
   }
@@ -153,6 +156,8 @@ export const select: React$AbstractComponent<StrictReactDOMSelectProps, View> =
   createStrict('select');
 export const span: React$AbstractComponent<StrictReactDOMProps, Text> =
   createStrict('span', { dir: 'auto' });
+export const strike: React$AbstractComponent<StrictReactDOMProps, Text> =
+  createStrict('strike', { style: styles.strike });
 export const strong: React$AbstractComponent<StrictReactDOMProps, Text> =
   createStrict('strong', { style: styles.bold });
 export const sub: React$AbstractComponent<StrictReactDOMProps, Text> =

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-dom
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-dom
@@ -4838,6 +4838,134 @@ exports[`html "span" supports inline event handlers 1`] = `
 />
 `;
 
+exports[`html "strike" ignores and warns about unsupported attributes 1`] = `
+<strike
+  className="html-strike x1ghz6dp x1717udv x1hl2dhg x16tdsg8 x1vvkbs"
+/>
+`;
+
+exports[`html "strike" supports global attributes 1`] = `
+<strike
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  className="html-strike x1ghz6dp x1717udv x1hl2dhg x16tdsg8 x1vvkbs"
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+    }
+  }
+  tabIndex={0}
+>
+  children
+</strike>
+`;
+
+exports[`html "strike" supports inline event handlers 1`] = `
+<strike
+  className="html-strike x1ghz6dp x1717udv x1hl2dhg x16tdsg8 x1vvkbs"
+  onAuxClick={[Function]}
+  onBeforeInput={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onInvalid={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onScroll={[Function]}
+  onSelect={[Function]}
+  onSelectionChange={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+/>
+`;
+
 exports[`html "strong" ignores and warns about unsupported attributes 1`] = `
 <strong
   className="html-strong x1ghz6dp x1717udv x1hl2dhg x16tdsg8 x1vvkbs xjs9k72"

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
@@ -5502,6 +5502,151 @@ exports[`html "span" supports inline event handlers 1`] = `
 />
 `;
 
+exports[`html "strike" ignores and warns about unsupported attributes 1`] = `
+<Text
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "line-through",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
+exports[`html "strike" supports global attributes 1`] = `
+<Text
+  accessibilityPosInSet={1}
+  accessibilitySetSize={2}
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+      "direction": "ltr",
+      "display": "none",
+      "position": "static",
+      "textDecorationLine": "line-through",
+      "userSelect": "auto",
+      "writingDirection": "ltr",
+    }
+  }
+  tabIndex={0}
+  testID="some-test-id"
+>
+  children
+</Text>
+`;
+
+exports[`html "strike" supports inline event handlers 1`] = `
+<Text
+  onAuxClick={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onPress={[Function]}
+  onScroll={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "line-through",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
 exports[`html "strong" ignores and warns about unsupported attributes 1`] = `
 <Text
   style={

--- a/packages/react-strict-dom/tests/html-test.js
+++ b/packages/react-strict-dom/tests/html-test.js
@@ -49,6 +49,7 @@ const tagNames = [
   'section',
   'select',
   'span',
+  'strike',
   'strong',
   'sub',
   'sup',


### PR DESCRIPTION
- Added "strike" boilerplate to web and native files
- Added strike to the `tagNames` array in html-test.js so basic tests can run
- Ran tests, generated snapshots
- Attempted to add a `<strike>` example to the Examples app, but there's some sneaky stylesheet somewhere that adds "text-decoration: none" to everything by default, and I can't change it without removing it at the source (which I can't find) or hard-coding the text-decoration (which defeats the purpose(?))