### PR TITLE
Add 'del', 'ins', 'kbd', 's', 'u' semantic elements

### DIFF
--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -100,9 +100,10 @@ export default function App(): React.MixedElement {
           <html.div />
 
           <html.span>
-            <html.a href="https://google.com">anchor</html.a>,
-            <html.code>code</html.code>,<html.em>em</html.em>,
-            <html.strong>strong</html.strong>,
+            <html.a href="https://google.com">anchor</html.a>,<html.b>b</html.b>
+            ,<html.code>code</html.code>,<html.del>del</html.del>,
+            <html.em>em</html.em>,<html.i>i</html.i>,<html.ins>ins</html.ins>,
+            <html.kbd>kbd</html.kbd>,<html.strong>strong</html.strong>,
             <html.span>
               H<html.sub>2</html.sub>0
             </html.span>
@@ -110,6 +111,7 @@ export default function App(): React.MixedElement {
             <html.span>
               E=mc<html.sup>2</html.sup>
             </html.span>
+            ,<html.u>u</html.u>
           </html.span>
 
           <html.div />

--- a/packages/react-strict-dom/src/dom/html.js
+++ b/packages/react-strict-dom/src/dom/html.js
@@ -109,6 +109,14 @@ export const code: React$AbstractComponent<
 > = createStrict('code', defaultStyles.code);
 
 /**
+ * "del" (inline)
+ */
+export const del: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('del', defaultStyles.del);
+
+/**
  * "div" (block)
  */
 export const div: React$AbstractComponent<
@@ -217,6 +225,22 @@ export const input: React$AbstractComponent<
 > = createStrict('input', defaultStyles.input);
 
 /**
+ * "ins" (inline)
+ */
+export const ins: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('ins', defaultStyles.ins);
+
+/**
+ * "kbd" (inline)
+ */
+export const kbd: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('kbd', defaultStyles.kbd);
+
+/**
  * "label" (inline)
  */
 export const label: React$AbstractComponent<
@@ -289,6 +313,14 @@ export const pre: React$AbstractComponent<
 > = createStrict('pre', defaultStyles.pre);
 
 /**
+ * "s" (inline)
+ */
+export const s: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('s', defaultStyles.s);
+
+/**
  * "section" (block)
  */
 export const section: React$AbstractComponent<
@@ -343,6 +375,14 @@ export const textarea: React$AbstractComponent<
   StrictReactDOMTextAreaProps,
   StrictHTMLTextAreaElement
 > = createStrict('textarea', defaultStyles.textarea);
+
+/**
+ * "u" (inline)
+ */
+export const u: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('u', defaultStyles.u);
 
 /**
  * "ul" (block)

--- a/packages/react-strict-dom/src/dom/runtime.js
+++ b/packages/react-strict-dom/src/dom/runtime.js
@@ -90,6 +90,7 @@ const blockquote: StrictReactDOMPropsStyle = styles.block;
 const br: StrictReactDOMPropsStyle = null;
 const button: StrictReactDOMPropsStyle = [styles.inlineblock, styles.button];
 const code: StrictReactDOMPropsStyle = [styles.inline, styles.codePre];
+const del: StrictReactDOMPropsStyle = null;
 const div: StrictReactDOMPropsStyle = styles.block;
 const em: StrictReactDOMPropsStyle = styles.inline;
 const fieldset: StrictReactDOMPropsStyle = styles.block;
@@ -101,6 +102,8 @@ const hr: StrictReactDOMPropsStyle = [styles.block, styles.hr];
 const i: StrictReactDOMPropsStyle = styles.inline;
 const img: StrictReactDOMPropsStyle = styles.img;
 const input: StrictReactDOMPropsStyle = [styles.inlineblock, styles.input];
+const ins: StrictReactDOMPropsStyle = null;
+const kbd: StrictReactDOMPropsStyle = null;
 const label: StrictReactDOMPropsStyle = styles.inline;
 const li: StrictReactDOMPropsStyle = styles.block;
 const main: StrictReactDOMPropsStyle = styles.block;
@@ -110,6 +113,7 @@ const optgroup: StrictReactDOMPropsStyle = null;
 const option: StrictReactDOMPropsStyle = null;
 const p: StrictReactDOMPropsStyle = styles.block;
 const pre: StrictReactDOMPropsStyle = [styles.block, styles.codePre];
+const s: StrictReactDOMPropsStyle = null;
 const section: StrictReactDOMPropsStyle = styles.block;
 const select: StrictReactDOMPropsStyle = styles.inlineblock;
 const span: StrictReactDOMPropsStyle = styles.inline;
@@ -120,6 +124,7 @@ const textarea: StrictReactDOMPropsStyle = [
   styles.inlineblock,
   styles.textarea
 ];
+const u: StrictReactDOMPropsStyle = null;
 const ul: StrictReactDOMPropsStyle = styles.block;
 
 export const defaultStyles = {
@@ -133,6 +138,7 @@ export const defaultStyles = {
   br: br as typeof br,
   button: button as typeof button,
   code: code as typeof code,
+  del: del as typeof del,
   div: div as typeof div,
   em: em as typeof em,
   fieldset: fieldset as typeof fieldset,
@@ -149,6 +155,8 @@ export const defaultStyles = {
   i: i as typeof i,
   img: img as typeof img,
   input: input as typeof input,
+  ins: ins as typeof ins,
+  kbd: kbd as typeof kbd,
   label: label as typeof label,
   li: li as typeof li,
   main: main as typeof main,
@@ -158,6 +166,7 @@ export const defaultStyles = {
   option: option as typeof option,
   p: p as typeof p,
   pre: pre as typeof pre,
+  s: s as typeof s,
   section: section as typeof section,
   select: select as typeof select,
   span: span as typeof span,
@@ -165,5 +174,6 @@ export const defaultStyles = {
   sub: sub as typeof sub,
   sup: sup as typeof sup,
   textarea: textarea as typeof textarea,
+  u: u as typeof u,
   ul: ul as typeof ul
 };

--- a/packages/react-strict-dom/src/native/html.js
+++ b/packages/react-strict-dom/src/native/html.js
@@ -53,8 +53,14 @@ const styles = stylex.create({
   input: {
     borderWidth: 1
   },
+  lineThrough: {
+    textDecorationLine: 'line-through'
+  },
   textarea: {
     verticalAlign: 'top'
+  },
+  underline: {
+    textDecorationLine: 'underline'
   }
 });
 
@@ -88,6 +94,8 @@ export const button: React$AbstractComponent<
 });
 export const code: React$AbstractComponent<StrictReactDOMProps, Text> =
   createStrict('code', { style: styles.code });
+export const del: React$AbstractComponent<StrictReactDOMProps, Text> =
+  createStrict('del', { style: styles.lineThrough });
 export const div: React$AbstractComponent<StrictReactDOMProps, View> =
   createStrict('div');
 export const em: React$AbstractComponent<StrictReactDOMProps, Text> =
@@ -127,6 +135,10 @@ export const input: React$AbstractComponent<
   dir: 'auto',
   style: styles.input
 });
+export const ins: React$AbstractComponent<StrictReactDOMProps, Text> =
+  createStrict('ins', { style: styles.underline });
+export const kbd: React$AbstractComponent<StrictReactDOMProps, Text> =
+  createStrict('kbd', { style: styles.code });
 export const label: React$AbstractComponent<StrictReactDOMLabelProps, Text> =
   createStrict('label');
 export const li: React$AbstractComponent<StrictReactDOMProps, View> =
@@ -147,6 +159,8 @@ export const optgroup: React$AbstractComponent<
   StrictReactDOMOptionGroupProps,
   View
 > = createStrict('optgroup');
+export const s: React$AbstractComponent<StrictReactDOMProps, Text> =
+  createStrict('s', { style: styles.lineThrough });
 export const section: React$AbstractComponent<StrictReactDOMProps, View> =
   createStrict('section');
 export const select: React$AbstractComponent<StrictReactDOMSelectProps, View> =
@@ -166,5 +180,7 @@ export const textarea: React$AbstractComponent<
   dir: 'auto',
   style: styles.input
 });
+export const u: React$AbstractComponent<StrictReactDOMProps, View> =
+  createStrict('u', { style: styles.underline });
 export const ul: React$AbstractComponent<StrictReactDOMProps, View> =
   createStrict('ul');

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-dom
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-dom
@@ -1302,6 +1302,134 @@ exports[`html "code" supports inline event handlers 1`] = `
 />
 `;
 
+exports[`html "del" ignores and warns about unsupported attributes 1`] = `
+<del
+  className="html-del"
+/>
+`;
+
+exports[`html "del" supports global attributes 1`] = `
+<del
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  className="html-del"
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+    }
+  }
+  tabIndex={0}
+>
+  children
+</del>
+`;
+
+exports[`html "del" supports inline event handlers 1`] = `
+<del
+  className="html-del"
+  onAuxClick={[Function]}
+  onBeforeInput={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onInvalid={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onScroll={[Function]}
+  onSelect={[Function]}
+  onSelectionChange={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+/>
+`;
+
 exports[`html "div" ignores and warns about unsupported attributes 1`] = `
 <div
   className="html-div xe8uvvx x1ghz6dp x1717udv"
@@ -3398,6 +3526,262 @@ exports[`html "input" supports inline event handlers 1`] = `
 />
 `;
 
+exports[`html "ins" ignores and warns about unsupported attributes 1`] = `
+<ins
+  className="html-ins"
+/>
+`;
+
+exports[`html "ins" supports global attributes 1`] = `
+<ins
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  className="html-ins"
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+    }
+  }
+  tabIndex={0}
+>
+  children
+</ins>
+`;
+
+exports[`html "ins" supports inline event handlers 1`] = `
+<ins
+  className="html-ins"
+  onAuxClick={[Function]}
+  onBeforeInput={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onInvalid={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onScroll={[Function]}
+  onSelect={[Function]}
+  onSelectionChange={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+/>
+`;
+
+exports[`html "kbd" ignores and warns about unsupported attributes 1`] = `
+<kbd
+  className="html-kbd"
+/>
+`;
+
+exports[`html "kbd" supports global attributes 1`] = `
+<kbd
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  className="html-kbd"
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+    }
+  }
+  tabIndex={0}
+>
+  children
+</kbd>
+`;
+
+exports[`html "kbd" supports inline event handlers 1`] = `
+<kbd
+  className="html-kbd"
+  onAuxClick={[Function]}
+  onBeforeInput={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onInvalid={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onScroll={[Function]}
+  onSelect={[Function]}
+  onSelectionChange={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+/>
+`;
+
 exports[`html "label" ignores and warns about unsupported attributes 1`] = `
 <label
   className="html-label x1ghz6dp x1717udv x1hl2dhg x16tdsg8 x1vvkbs"
@@ -4439,6 +4823,134 @@ exports[`html "pre" supports inline event handlers 1`] = `
 />
 `;
 
+exports[`html "s" ignores and warns about unsupported attributes 1`] = `
+<s
+  className="html-s"
+/>
+`;
+
+exports[`html "s" supports global attributes 1`] = `
+<s
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  className="html-s"
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+    }
+  }
+  tabIndex={0}
+>
+  children
+</s>
+`;
+
+exports[`html "s" supports inline event handlers 1`] = `
+<s
+  className="html-s"
+  onAuxClick={[Function]}
+  onBeforeInput={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onInvalid={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onScroll={[Function]}
+  onSelect={[Function]}
+  onSelectionChange={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+/>
+`;
+
 exports[`html "section" ignores and warns about unsupported attributes 1`] = `
 <section
   className="html-section xe8uvvx x1ghz6dp x1717udv"
@@ -5328,6 +5840,134 @@ exports[`html "textarea" supports inline event handlers 1`] = `
 <textarea
   className="html-textarea x1ghz6dp x1717udv xmkeg23 x1y0btm7 x288g5"
   dir="auto"
+  onAuxClick={[Function]}
+  onBeforeInput={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onInvalid={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onScroll={[Function]}
+  onSelect={[Function]}
+  onSelectionChange={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+/>
+`;
+
+exports[`html "u" ignores and warns about unsupported attributes 1`] = `
+<u
+  className="html-u"
+/>
+`;
+
+exports[`html "u" supports global attributes 1`] = `
+<u
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  className="html-u"
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+    }
+  }
+  tabIndex={0}
+>
+  children
+</u>
+`;
+
+exports[`html "u" supports inline event handlers 1`] = `
+<u
+  className="html-u"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
@@ -1488,6 +1488,151 @@ exports[`html "code" supports inline event handlers 1`] = `
 />
 `;
 
+exports[`html "del" ignores and warns about unsupported attributes 1`] = `
+<Text
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "line-through",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
+exports[`html "del" supports global attributes 1`] = `
+<Text
+  accessibilityPosInSet={1}
+  accessibilitySetSize={2}
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+      "direction": "ltr",
+      "display": "none",
+      "position": "static",
+      "textDecorationLine": "line-through",
+      "userSelect": "auto",
+      "writingDirection": "ltr",
+    }
+  }
+  tabIndex={0}
+  testID="some-test-id"
+>
+  children
+</Text>
+`;
+
+exports[`html "del" supports inline event handlers 1`] = `
+<Text
+  onAuxClick={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onPress={[Function]}
+  onScroll={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "line-through",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
 exports[`html "div" ignores and warns about unsupported attributes 1`] = `
 <View
   experimental_layoutConformance="strict"
@@ -3888,6 +4033,296 @@ exports[`html "input" supports inline event handlers 1`] = `
 />
 `;
 
+exports[`html "ins" ignores and warns about unsupported attributes 1`] = `
+<Text
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "underline",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
+exports[`html "ins" supports global attributes 1`] = `
+<Text
+  accessibilityPosInSet={1}
+  accessibilitySetSize={2}
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+      "direction": "ltr",
+      "display": "none",
+      "position": "static",
+      "textDecorationLine": "underline",
+      "userSelect": "auto",
+      "writingDirection": "ltr",
+    }
+  }
+  tabIndex={0}
+  testID="some-test-id"
+>
+  children
+</Text>
+`;
+
+exports[`html "ins" supports inline event handlers 1`] = `
+<Text
+  onAuxClick={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onPress={[Function]}
+  onScroll={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "underline",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
+exports[`html "kbd" ignores and warns about unsupported attributes 1`] = `
+<Text
+  style={
+    {
+      "fontFamily": "Menlo",
+      "position": "static",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
+exports[`html "kbd" supports global attributes 1`] = `
+<Text
+  accessibilityPosInSet={1}
+  accessibilitySetSize={2}
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+      "direction": "ltr",
+      "display": "none",
+      "fontFamily": "Menlo",
+      "position": "static",
+      "userSelect": "auto",
+      "writingDirection": "ltr",
+    }
+  }
+  tabIndex={0}
+  testID="some-test-id"
+>
+  children
+</Text>
+`;
+
+exports[`html "kbd" supports inline event handlers 1`] = `
+<Text
+  onAuxClick={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onPress={[Function]}
+  onScroll={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+  style={
+    {
+      "fontFamily": "Menlo",
+      "position": "static",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
 exports[`html "label" ignores and warns about unsupported attributes 1`] = `
 <Text
   style={
@@ -5057,6 +5492,151 @@ exports[`html "pre" supports inline event handlers 1`] = `
 />
 `;
 
+exports[`html "s" ignores and warns about unsupported attributes 1`] = `
+<Text
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "line-through",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
+exports[`html "s" supports global attributes 1`] = `
+<Text
+  accessibilityPosInSet={1}
+  accessibilitySetSize={2}
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+      "direction": "ltr",
+      "display": "none",
+      "position": "static",
+      "textDecorationLine": "line-through",
+      "userSelect": "auto",
+      "writingDirection": "ltr",
+    }
+  }
+  tabIndex={0}
+  testID="some-test-id"
+>
+  children
+</Text>
+`;
+
+exports[`html "s" supports inline event handlers 1`] = `
+<Text
+  onAuxClick={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onPress={[Function]}
+  onScroll={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "line-through",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
 exports[`html "section" ignores and warns about unsupported attributes 1`] = `
 <View
   experimental_layoutConformance="strict"
@@ -6101,6 +6681,151 @@ exports[`html "textarea" supports inline event handlers 1`] = `
     {
       "borderWidth": 1,
       "position": "static",
+    }
+  }
+/>
+`;
+
+exports[`html "u" ignores and warns about unsupported attributes 1`] = `
+<Text
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "underline",
+      "userSelect": "auto",
+    }
+  }
+/>
+`;
+
+exports[`html "u" supports global attributes 1`] = `
+<Text
+  accessibilityPosInSet={1}
+  accessibilitySetSize={2}
+  aria-activedescendant="activedescendant"
+  aria-atomic={true}
+  aria-autocomplete={true}
+  aria-busy={true}
+  aria-checked={true}
+  aria-colcount={1}
+  aria-colindex={1}
+  aria-colindextext="colindextext"
+  aria-colspan={1}
+  aria-controls="controls"
+  aria-current="current"
+  aria-describedby="describedby"
+  aria-details="details"
+  aria-disabled={true}
+  aria-errormessage="errormessage"
+  aria-expanded={true}
+  aria-flowto="flowto"
+  aria-haspopup="menu"
+  aria-hidden={true}
+  aria-invalid={true}
+  aria-keyshortcuts="Shift+Space"
+  aria-label="Label"
+  aria-labelledby="labelledby"
+  aria-level={2}
+  aria-live={true}
+  aria-modal={true}
+  aria-multiline={true}
+  aria-multiselectable={true}
+  aria-orientation="portrait"
+  aria-owns="owns"
+  aria-placeholder="Placeholder"
+  aria-posinset={1}
+  aria-pressed={true}
+  aria-readonly={true}
+  aria-required={true}
+  aria-roledescription="Description"
+  aria-rowcount={1}
+  aria-rowindex={1}
+  aria-rowindextext="rowindextext"
+  aria-rowspan={1}
+  aria-selected={true}
+  aria-setsize={2}
+  aria-sort="ascending"
+  aria-valuemax={10}
+  aria-valuemin={0}
+  aria-valuenow={5}
+  aria-valuetext="Five"
+  autoCapitalize={true}
+  autoFocus={true}
+  data-testid="some-test-id"
+  dir="ltr"
+  enterKeyHint="go"
+  hidden={true}
+  id="some-id"
+  inert={true}
+  inputMode="numeric"
+  lang="en-US"
+  role="article"
+  spellCheck={true}
+  style={
+    {
+      "--custom-property": "inline",
+      "direction": "ltr",
+      "display": "none",
+      "position": "static",
+      "textDecorationLine": "underline",
+      "userSelect": "auto",
+      "writingDirection": "ltr",
+    }
+  }
+  tabIndex={0}
+  testID="some-test-id"
+>
+  children
+</Text>
+`;
+
+exports[`html "u" supports inline event handlers 1`] = `
+<Text
+  onAuxClick={[Function]}
+  onBlur={[Function]}
+  onChange={[Function]}
+  onClick={[Function]}
+  onContextMenu={[Function]}
+  onCopy={[Function]}
+  onCut={[Function]}
+  onFocus={[Function]}
+  onFocusIn={[Function]}
+  onFocusOut={[Function]}
+  onFullscreenChange={[Function]}
+  onFullscreenError={[Function]}
+  onGotPointerCapture={[Function]}
+  onInput={[Function]}
+  onKeyDown={[Function]}
+  onKeyUp={[Function]}
+  onLostPointerCapture={[Function]}
+  onMouseDown={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  onMouseMove={[Function]}
+  onMouseOut={[Function]}
+  onMouseOver={[Function]}
+  onMouseUp={[Function]}
+  onPaste={[Function]}
+  onPointerCancel={[Function]}
+  onPointerDown={[Function]}
+  onPointerEnter={[Function]}
+  onPointerLeave={[Function]}
+  onPointerMove={[Function]}
+  onPointerOut={[Function]}
+  onPointerOver={[Function]}
+  onPointerUp={[Function]}
+  onPress={[Function]}
+  onScroll={[Function]}
+  onTouchCancel={[Function]}
+  onTouchEnd={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+  onWheel={[Function]}
+  style={
+    {
+      "position": "static",
+      "textDecorationLine": "underline",
+      "userSelect": "auto",
     }
   }
 />

--- a/packages/react-strict-dom/tests/html-test.js
+++ b/packages/react-strict-dom/tests/html-test.js
@@ -22,6 +22,7 @@ const tagNames = [
   'br',
   'button',
   'code',
+  'del',
   'div',
   'em',
   'fieldset',
@@ -38,6 +39,8 @@ const tagNames = [
   'i',
   'img',
   'input',
+  'ins',
+  'kbd',
   'label',
   'main',
   'nav',
@@ -46,6 +49,7 @@ const tagNames = [
   'option',
   'p',
   'pre',
+  's',
   'section',
   'select',
   'span',
@@ -53,6 +57,7 @@ const tagNames = [
   'sub',
   'sup',
   'textarea',
+  'u',
   'ul'
 ];
 


### PR DESCRIPTION
Adds support for `del`, `ins`, `kbd`, `s`, and `u` semantic elements to web and native.

iOS rendering:

<img width="360" alt="image" src="https://github.com/facebook/react-strict-dom/assets/239676/95978e27-e83c-46a7-a5a7-b5f264185a86">