### PR TITLE
Add Linking API combined with onPress event to mimic 'a' tag behavior

### DIFF
--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -40,7 +40,8 @@ import {
   TextInput,
   Text,
   View,
-  Pressable
+  Pressable,
+  Linking
 } from 'react-native';
 import * as stylex from '../stylex';
 
@@ -232,7 +233,7 @@ export function createStrictDOMComponent<T: any, P: StrictProps>(
       }
       if (href != null && tagName === 'a') {
         nativeProps.onPress = function (e) {
-          errorMsg('<a> "href" handling is not implemented in React Native.');
+          Linking.openUrl(href);
         };
       }
       if (tagName === 'br') {

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -233,7 +233,7 @@ export function createStrictDOMComponent<T: any, P: StrictProps>(
       }
       if (href != null && tagName === 'a') {
         nativeProps.onPress = function (e) {
-          Linking.openUrl(href);
+          Linking.openURL(href);
         };
       }
       if (tagName === 'br') {


### PR DESCRIPTION
Clicking on the 'a' tag on the native app, generates an error `<a> "href" handling is not implemented in React Native.`

This PR adds support for navigating both links and telephone numbers.

Fixes #58 