### PR TITLE
Allow .web.jsx, .web.ts, .web.tsx to be ignored in RSD ESLint Plugin

### DIFF
--- a/packages/eslint-plugin/src/valid-styles.js
+++ b/packages/eslint-plugin/src/valid-styles.js
@@ -20,8 +20,8 @@ import type {
   SpreadElement
 } from 'estree';
 
-// Ignore .web.js files since they indicate web usage only
-const ALLOWED_FILE = '.web.js';
+// List of web-specific file extensions to ignore since they indicate web usage only
+const ALLOWED_FILES = ['.web.js', '.web.jsx', '.web.ts', '.web.tsx'];
 
 const allowlistedStylexProps = new Set([
   'alignContent',
@@ -232,7 +232,11 @@ const rule: RuleModule = {
     }
   },
   create(context: RuleContext) {
-    if (context.getFilename().endsWith(ALLOWED_FILE)) {
+    if (
+      ALLOWED_FILES.some((allowedFile) =>
+        context.getFilename().endsWith(allowedFile)
+      )
+    ) {
       return {};
     }
 


### PR DESCRIPTION
# Why

At the moment, only `.web.js` is ignored for the 'valid-styles' rule but in TypeScript projects, you'd want to ignore `.web.ts` etc. files as well.


# How
Renaming `ALLOWED_FILE` to `ALLOWED_FILES` and making it an array of allowed web file extension suffixes.
`.web.jsx`, `.web.ts`, `.web.tsx` are all allowed now because styles can be defined both in pure JS/TS files and JSX counterparts.