### PR TITLE
Remove rollup configs for internal builds

### DIFF
--- a/configs/rollup.config.js
+++ b/configs/rollup.config.js
@@ -18,30 +18,6 @@ const babelPlugin = babel({
   configFile: require.resolve('./babel.config.js')
 });
 
-function internalLicensePlugin() {
-  const header = `/**
- * @noflow
- * @nolint
- * @noformat
- * @generated
- */
-/**
- * @license react-strict-dom
- * Copyright (c) Meta Platforms, Inc. and affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
-'use strict';`;
-
-  return {
-    renderChunk(source) {
-      return `${header}\n${source}`;
-    }
-  };
-}
-
 function ossLicensePlugin() {
   const header = `/**
  * @license react-strict-dom
@@ -68,32 +44,6 @@ const replacePlugin = replace({
   }
 });
 
-function replaceImports(options = {}) {
-  const { original, replacement, starAsSpecifier, defaultImportName } = options;
-
-  return {
-    name: 'replace-imports', // this name will show up in warnings and errors
-    transform(code) {
-      if (code.includes(original)) {
-        const pattern = new RegExp(`(['"])${original}(['"])`, 'g');
-        let newCode = code.replace(pattern, `$1${replacement}$2`);
-        // If starAsSpecifier and defaultImportName are provided, replace "* as starAsSpecifier" with "defaultImportName"
-        if (starAsSpecifier && defaultImportName) {
-          const importSpecifierPattern = new RegExp(
-            `\\* as ${starAsSpecifier}`,
-            'g'
-          );
-          newCode = newCode.replace(importSpecifierPattern, defaultImportName);
-        }
-        return {
-          code: newCode,
-          map: { mappings: '' }
-        };
-      }
-    }
-  };
-}
-
 const sharedPlugins = [
   babelPlugin,
   replacePlugin,
@@ -103,17 +53,6 @@ const sharedPlugins = [
 ];
 
 const ossPlugins = [...sharedPlugins, ossLicensePlugin()];
-
-const internalPlugins = [
-  ...sharedPlugins,
-  internalLicensePlugin(),
-  replaceImports({
-    original: '@stylexjs/stylex',
-    replacement: 'stylex',
-    starAsSpecifier: 'stylex',
-    defaultImportName: 'stylex'
-  })
-];
 
 const nativePlugins = [];
 
@@ -146,19 +85,6 @@ const webConfigs = [
       format: 'es'
     },
     plugins: [...ossPlugins]
-  },
-  // www build
-  {
-    external: ['react', 'react-dom', '@stylexjs/stylex'],
-    input: require.resolve('../packages/react-strict-dom/src/dom/index.js'),
-    output: {
-      file: path.join(
-        __dirname,
-        '../packages/react-strict-dom/dist/dom.www.js'
-      ),
-      format: 'es'
-    },
-    plugins: [...internalPlugins]
   }
 ];
 
@@ -178,19 +104,6 @@ const nativeConfigs = [
       format: 'es'
     },
     plugins: [...nativePlugins, ...ossPlugins]
-  },
-  // fbsource build
-  {
-    external: ['react', 'react-native', '@stylexjs/stylex'],
-    input: require.resolve('../packages/react-strict-dom/src/native/index.js'),
-    output: {
-      file: path.join(
-        __dirname,
-        '../packages/react-strict-dom/dist/native.fbsource.js'
-      ),
-      format: 'es'
-    },
-    plugins: [...nativePlugins, ...internalPlugins]
   }
 ];
 

--- a/packages/react-strict-dom/COMPATIBILITY.md
+++ b/packages/react-strict-dom/COMPATIBILITY.md
@@ -23,6 +23,7 @@ NOTE: React Native support assumes use of React Native's "Fabric" architecture, 
 | button | 🟡 | 🟡 | |
 | code | 🟡 | 🟡 | |
 | dialog | ❌ | ❌ | [#5](https://github.com/facebook/react-strict-dom/issues/5) |
+| del | 🟡 | 🟡 | |
 | div | 🟡 | 🟡 | |
 | em | 🟡 | 🟡 | |
 | footer | 🟡 | 🟡 | |
@@ -38,6 +39,8 @@ NOTE: React Native support assumes use of React Native's "Fabric" architecture, 
 | input[type="date"] | ❌ | ❌ | [#13](https://github.com/facebook/react-strict-dom/issues/13) |
 | input[type="file"] | ❌ | ❌ | [#14](https://github.com/facebook/react-strict-dom/issues/14) |
 | input[type="radio"] | ❌ | ❌ | [#15](https://github.com/facebook/react-strict-dom/issues/15) |
+| ins | 🟡 | 🟡 | |
+| kbd | 🟡 | 🟡 | |
 | label | 🟡 | 🟡 | |
 | li | 🟡 | 🟡 | |
 | main | 🟡 | 🟡 | |
@@ -48,6 +51,7 @@ NOTE: React Native support assumes use of React Native's "Fabric" architecture, 
 | p | 🟡 | 🟡 | |
 | pre | 🟡 | 🟡 | |
 | progress | ❌ | ❌ | [#9](https://github.com/facebook/react-strict-dom/issues/9) |
+| s | 🟡 | 🟡 | |
 | section | 🟡 | 🟡 | |
 | select | ❌ | ❌ | [#10](https://github.com/facebook/react-strict-dom/issues/10) |
 | span | 🟡 | 🟡 | |
@@ -56,6 +60,7 @@ NOTE: React Native support assumes use of React Native's "Fabric" architecture, 
 | sup | 🟡 | 🟡 | |
 | svg | ❌ | ❌ | [#4](https://github.com/facebook/react-strict-dom/issues/4) |
 | textarea | 🟡 | 🟡 | |
+| u | 🟡 | 🟡 | |
 | ul | 🟡 | 🟡 | |
 
 ### HTML component props

--- a/packages/react-strict-dom/src/dom/modules/ThemeContext.js
+++ b/packages/react-strict-dom/src/dom/modules/ThemeContext.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import React from 'react';
+import * as React from 'react';
 
 type ProviderValue = {
   customProperties: { ... }


### PR DESCRIPTION
Internally we could use patch files to rewrite the stylex import on web, and add the comment directives to exclude the files from linting/formatting, etc.