### PR TITLE
chore: Avoid inexact object types

### DIFF
--- a/packages/react-strict-dom/src/dom/modules/ThemeContext.js
+++ b/packages/react-strict-dom/src/dom/modules/ThemeContext.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 
 type ProviderValue = {
-  customProperties: { ... }
+  customProperties: { +[string]: ?string | number }
 };
 
 type ProviderProps = {

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -379,10 +379,10 @@ function resolveStyle<S: { +[string]: mixed }>(
  * which can be done at initialization-time (could potentially be done at
  * compile-time in the future).
  */
-function _create<S: { [string]: { ... } }>(styles: S): {
-  [string]: { ... }
+function _create<S: { +[string]: { +[string]: mixed } }>(styles: S): {
+  [string]: mixed
 } {
-  const result: { [string]: { ... } } = {};
+  const result: { [string]: mixed } = {};
   for (const styleName in styles) {
     const val = styles[styleName];
     if (typeof val === 'function') {

--- a/packages/react-strict-dom/src/types/styles.js
+++ b/packages/react-strict-dom/src/types/styles.js
@@ -19,7 +19,9 @@ import typeof TStyleX from '@stylexjs/stylex';
 
 export type Style = InlineStyles;
 
-export type Styles = StyleXArray<StyleXStyles<> | Theme<VarGroup<{ ... }>>>;
+export type Styles = StyleXArray<
+  StyleXStyles<> | Theme<VarGroup<{ +[string]: mixed }>>
+>;
 
 export type IStyleX = $ReadOnly<{
   create: TStyleX['create'],


### PR DESCRIPTION
A follow up from my previous PR #81 

This PR removes a few cases where inexact object types are used and replaces them with 
`{ +[string]: mixed }`

This is a quirk of how inexact object types work. They do not allow reading any of those additional keys which may or may not exist on the object. They only loosen the constraints for what objects can be given when such a type is used.

This is particularly problematic when `{...}` is used as a stand-in for "any object". According to flow, an exact object type *does not* satisfy `{...}`.

Using `{ +[string]: mixed }` fixes all of these problems and works in all scenarios for at least the last 30 versions of Flow.