### PR TITLE
Provide structured error/warn messages

### DIFF
--- a/packages/react-strict-dom/README.md
+++ b/packages/react-strict-dom/README.md
@@ -146,14 +146,17 @@ function App() {
 
 ### Supressing logs on React Native
 
-RSD provides comprehensive runtime warnings and errors to inform developers of about prop and style incompatibilities on native. If there are certain logs that you wish to suppress, this can be done by configuring the [React Native LogBox](https://reactnative.dev/docs/debugging#logbox) at the root of the native app. For example:
+RSD provides comprehensive runtime warnings and errors to inform developers of about prop and style incompatibilities on native. If there are certain logs that you wish to suppress, this can be done by configuring the [React Native LogBox](https://reactnative.dev/docs/debugging#logbox) at the root of the native app. Messages follow a common structure, which allows for precise or general suppression. For example:
 
 ```js
 import { LogBox } from 'react-native';
 
 LogBox.ignoreLogs([
-  /Failed prop type: .*/,
-  "React Strict DOM: css.keyframes is not supported in React Native."
+  // Precise
+  'React Strict DOM: unsupported prop "onInvalid"',
+  'React Strict DOM: unsupported style value in "display:inline-flex"',
+  // General
+  /React Strict DOM: unsupported style property .*/,
 ]);
 ```
 

--- a/packages/react-strict-dom/src/dom/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/dom/modules/createStrictDOMComponent.js
@@ -21,7 +21,7 @@ function validateStrictProps(props: any) {
   Object.keys(props).forEach((key) => {
     const isValid = isPropAllowed(key);
     if (!isValid) {
-      errorMsg(`"${key}" is not a valid prop`);
+      errorMsg(`invalid prop "${key}"`);
       delete props[key];
     }
   });

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -127,11 +127,11 @@ function validateStrictProps(props: any) {
     const isValidProp = isPropAllowed(key);
     const isUnsupportedProp = unsupportedProps.has(key);
     if (!isValidProp) {
-      errorMsg(`"${key}" is not a valid prop`);
+      errorMsg(`invalid prop "${key}"`);
       delete props[key];
     }
     if (isUnsupportedProp) {
-      errorMsg(`"${key}" is not supported yet on native.`);
+      errorMsg(`unsupported prop "${key}"`);
       delete props[key];
     }
   });
@@ -578,9 +578,7 @@ export function createStrictDOMComponent<T: any, P: StrictProps>(
         displayValue !== 'block'
       ) {
         errorMsg(
-          `A "display" style value of ${String(
-            displayValue
-          )} is not supported in React Native`
+          `unsupported style value in "display:${String(displayValue)}"`
         );
       }
 

--- a/packages/react-strict-dom/src/native/modules/useStyleTransition.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleTransition.js
@@ -113,7 +113,7 @@ export function useStyleTransition(
   }
   if (valueRef.current?.length !== transitionProperties.length) {
     warnMsg(
-      'The number of transition properties must be the same before and after the transition. The transition will not animate.'
+      'invalid style transition. The number of transition properties must be the same before and after the transition.'
     );
     return [];
   }

--- a/packages/react-strict-dom/src/native/stylex/customProperties.js
+++ b/packages/react-strict-dom/src/native/stylex/customProperties.js
@@ -65,7 +65,7 @@ function resolveVariableReferenceValue(
     }
   }
 
-  errorMsg(`Unrecognized custom property "${variable.variable}"`);
+  errorMsg(`unrecognized custom property "${variable.variable}"`);
 
   return null;
 }

--- a/packages/react-strict-dom/src/native/stylex/fixContentBox.js
+++ b/packages/react-strict-dom/src/native/stylex/fixContentBox.js
@@ -92,9 +92,9 @@ export function fixContentBox(flatStyle: FlatStyle): FlatStyle {
       }
       if (typeof styleValue !== 'number') {
         warnMsg(
-          `"boxSizing:'content-box'" does not support value "${String(
+          `unsupported style value in "${styleProp}:${String(
             styleValue
-          )}" for property "${styleProp}". Expected a value that resolves to a number. Percentage values can only be used with "boxSizing:'border-box'".`
+          )}" when used with "boxSizing:'content-box'". Expected a value that resolves to a number. Percentage values can only be used with "boxSizing:'border-box'".`
         );
         return flatStyle;
       }

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -237,7 +237,7 @@ function processStyle<S: { +[string]: mixed }>(style: S): S {
 
     // React Native shadows on iOS cannot polyfill box-shadow
     if (propName === 'boxShadow' && typeof styleValue === 'string') {
-      warnMsg('"boxShadow" is not supported in React Native.');
+      warnMsg('unsupported style property "boxShadow".');
       delete result.boxShadow;
       continue;
     }
@@ -273,7 +273,7 @@ function processStyle<S: { +[string]: mixed }>(style: S): S {
         const parsedShadow = parseShadow(styleValue);
         if (parsedShadow.length > 1) {
           warnMsg(
-            'Multiple "textShadow" values are not supported in React Native.'
+            'unsupported multiple values for style property "textShadow".'
           );
         }
         const { offsetX, offsetY, blurRadius, color } = parsedShadow[0];
@@ -409,7 +409,7 @@ type Keyframes = {
 };
 
 function _keyframes(k: Keyframes): Keyframes {
-  errorMsg('css.keyframes is not supported in React Native.');
+  errorMsg('css.keyframes() is not supported.');
   return k;
 }
 export const keyframes: (Keyframes) => string = _keyframes as $FlowFixMe;
@@ -601,7 +601,7 @@ export function props(
       }
       // everything else
       else {
-        warnMsg(`Ignoring unsupported style property "${styleProp}"`);
+        warnMsg(`unsupported style property "${styleProp}"`);
       }
 
       delete flatStyle[styleProp];
@@ -614,9 +614,7 @@ export function props(
     // We check this at resolve time to ensure the render-time styles are safe.
     if (!isReactNativeStyleValue(styleValue)) {
       warnMsg(
-        `Ignoring unsupported style value "${String(
-          styleValue
-        )}" for property "${styleProp}"`
+        `unsupported style value in "${styleProp}:${String(styleValue)}"`
       );
       delete flatStyle[styleProp];
       continue;
@@ -654,12 +652,12 @@ export function props(
     if (positionValue === 'fixed') {
       flatStyle.position = 'absolute';
       warnMsg(
-        '"position" value of "fixed" is not supported in React Native. Falling back to "absolute".'
+        'unsupported style value in "position:fixed". Falling back to "position:absolute".'
       );
     } else if (positionValue === 'sticky') {
       flatStyle.position = 'relative';
       warnMsg(
-        '"position" value of "sticky" is not supported in React Native. Falling back to "relative".'
+        'unsupported style value in "position:sticky". Falling back to "position:relative".'
       );
     }
 

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -1092,7 +1092,7 @@ describe('properties: custom property', () => {
       css.props.call({ ...mockOptions, customProperties }, underTest)
     ).toMatchSnapshot();
     expect(console.error).toHaveBeenCalledWith(
-      'React Strict DOM: Unrecognized custom property "--unprovided"'
+      'React Strict DOM: unrecognized custom property "--unprovided"'
     );
   });
 


### PR DESCRIPTION
Improve the DX of using LogBox suppression in React Native by using a common structure for error/warn messages. This allows for easier configuration to suppress either specific messages, or categories of messages, e.g., "all unsupported properties" or "all unsupported values".