### PR TITLE
feat: Export Element and utility types from react-strict-dom

### DIFF
--- a/packages/react-strict-dom/src/dom/index.js
+++ b/packages/react-strict-dom/src/dom/index.js
@@ -12,6 +12,8 @@ import * as css from '@stylexjs/stylex';
 import { ThemeProvider } from './modules/ThemeContext';
 import { typeof ThemeProvider as TThemeProvider } from './modules/ThemeContext';
 
+export * from '../types/StrictTypes';
+
 const contexts = { ThemeProvider: ThemeProvider as TThemeProvider };
 
 export { contexts, css, html };

--- a/packages/react-strict-dom/src/native/index.js
+++ b/packages/react-strict-dom/src/native/index.js
@@ -14,6 +14,8 @@ import * as cssRaw from './stylex';
 import { ThemeProvider } from './modules/ThemeContext';
 import { typeof ThemeProvider as TThemeProvider } from './modules/ThemeContext';
 
+export * from '../types/StrictTypes';
+
 const contexts = { ThemeProvider: ThemeProvider as TThemeProvider };
 
 // Export using StyleX types as the shim has divergent types internally.

--- a/packages/react-strict-dom/src/types/StrictReactDOMAnchorProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMAnchorProps.js
@@ -9,7 +9,7 @@
 
 import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
-export type StrictReactDOMAnchorProps = {|
+export type StrictReactDOMAnchorProps = $ReadOnly<{
   ...StrictReactDOMProps,
   download?: string,
   href?: string,
@@ -24,4 +24,4 @@ export type StrictReactDOMAnchorProps = {|
     | 'unsafe-url',
   rel?: string,
   target?: '_self' | '_blank' | '_parent' | '_top'
-|};
+}>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMButtonProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMButtonProps.js
@@ -9,8 +9,8 @@
 
 import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
-export type StrictReactDOMButtonProps = {|
+export type StrictReactDOMButtonProps = $ReadOnly<{
   ...StrictReactDOMProps,
   disabled?: boolean,
   type?: 'button' | 'submit'
-|};
+}>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMImageProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMImageProps.js
@@ -18,10 +18,8 @@ export type StrictReactDOMImageProps = $ReadOnly<{
   fetchPriority?: 'high' | 'low' | 'auto',
   height?: number,
   loading?: 'eager' | 'lazy',
-  // $FlowFixMe
-  onError?: any,
-  // $FlowFixMe
-  onLoad?: any,
+  onError?: $FlowFixMe,
+  onLoad?: $FlowFixMe,
   referrerPolicy?:
     | 'no-referrer'
     | 'no-referrer-when-downgrade'

--- a/packages/react-strict-dom/src/types/StrictReactDOMInputProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMInputProps.js
@@ -9,7 +9,7 @@
 
 import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
-export type StrictReactDOMInputProps = {|
+export type StrictReactDOMInputProps = $ReadOnly<{
   ...StrictReactDOMProps,
   checked?: boolean | 'mixed',
   defaultChecked?: boolean,
@@ -20,18 +20,12 @@ export type StrictReactDOMInputProps = {|
   min?: string | number,
   minLength?: number,
   multiple?: boolean,
-  // $FlowFixMe
-  onBeforeInput?: any,
-  // $FlowFixMe
-  onChange?: any,
-  // $FlowFixMe
-  onInput?: any,
-  // $FlowFixMe
-  onInvalid?: any,
-  // $FlowFixMe
-  onSelect?: any,
-  // $FlowFixMe
-  onSelectionChange?: any,
+  onBeforeInput?: $FlowFixMe,
+  onChange?: $FlowFixMe,
+  onInput?: $FlowFixMe,
+  onInvalid?: $FlowFixMe,
+  onSelect?: $FlowFixMe,
+  onSelectionChange?: $FlowFixMe,
   placeholder?: Stringish,
   readOnly?: number,
   required?: number,
@@ -57,4 +51,4 @@ export type StrictReactDOMInputProps = {|
     | 'url'
     | 'week',
   value?: Stringish | boolean | number
-|};
+}>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMLabelProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMLabelProps.js
@@ -9,7 +9,7 @@
 
 import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
-export type StrictReactDOMLabelProps = {|
+export type StrictReactDOMLabelProps = $ReadOnly<{
   ...StrictReactDOMProps,
   for?: string
-|};
+}>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMOptionGroupProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMOptionGroupProps.js
@@ -9,8 +9,8 @@
 
 import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
-export type StrictReactDOMOptionGroupProps = {|
+export type StrictReactDOMOptionGroupProps = $ReadOnly<{
   ...StrictReactDOMProps,
   disabled?: boolean,
   label?: Stringish
-|};
+}>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMOptionProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMOptionProps.js
@@ -9,10 +9,10 @@
 
 import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
-export type StrictReactDOMOptionProps = {|
+export type StrictReactDOMOptionProps = $ReadOnly<{
   ...StrictReactDOMProps,
   disabled?: boolean,
   label?: Stringish,
   selected?: boolean,
   value?: Stringish
-|};
+}>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMSelectProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMSelectProps.js
@@ -9,18 +9,13 @@
 
 import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
-export type StrictReactDOMSelectProps = {|
+export type StrictReactDOMSelectProps = $ReadOnly<{
   ...StrictReactDOMProps,
   multiple?: boolean,
   required?: boolean,
-  // $FlowFixMe
-  onBeforeInput?: any,
-  // $FlowFixMe
-  onChange?: any,
-  // $FlowFixMe
-  onInput?: any,
-  // $FlowFixMe
-  onInvalid?: any,
-  // $FlowFixMe
-  onSelect?: any
-|};
+  onBeforeInput?: $FlowFixMe,
+  onChange?: $FlowFixMe,
+  onInput?: $FlowFixMe,
+  onInvalid?: $FlowFixMe,
+  onSelect?: $FlowFixMe
+}>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMTextAreaProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMTextAreaProps.js
@@ -9,27 +9,21 @@
 
 import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
-export type StrictReactDOMTextAreaProps = {|
+export type StrictReactDOMTextAreaProps = $ReadOnly<{
   ...StrictReactDOMProps,
   defaultValue?: Stringish,
   disabled?: boolean,
   maxLength?: number,
   minLength?: number,
-  // $FlowFixMe
-  onBeforeInput?: any,
-  // $FlowFixMe
-  onChange?: any,
-  // $FlowFixMe
-  onInput?: any,
-  // $FlowFixMe
-  onInvalid?: any,
-  // $FlowFixMe
-  onSelect?: any,
-  // $FlowFixMe
-  onSelectionChange?: any,
+  onBeforeInput?: $FlowFixMe,
+  onChange?: $FlowFixMe,
+  onInput?: $FlowFixMe,
+  onInvalid?: $FlowFixMe,
+  onSelect?: $FlowFixMe,
+  onSelectionChange?: $FlowFixMe,
   placeholder?: Stringish,
   readOnly?: boolean,
   required?: boolean,
   rows?: number,
   value?: Stringish
-|};
+}>;

--- a/packages/react-strict-dom/src/types/StrictTypes.js
+++ b/packages/react-strict-dom/src/types/StrictTypes.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+export type { StrictElement } from './StrictElement';
+export type { StrictHTMLElement } from './StrictHTMLElement';
+export type {
+  StrictHTMLInputElement,
+  StrictHTMLOptionElement,
+  StrictHTMLSelectElement,
+  StrictHTMLTextAreaElement
+} from './StrictHTMLFormElements';
+export type { StrictHTMLImageElement } from './StrictHTMLImageElement';
+export type { StrictNode } from './StrictNode';


### PR DESCRIPTION
Resolves #88 

Creates a new file called `StrictTypes` that re-exports all the element types, DOM Props and Strict Props.

The `index.js` for both `dom` and `native` are then able to re-export this one common file.

After this PR, all the various Element or other types that might be need can be imported directly from `'react-strict-dom'`.