### PR TITLE
Android doesn't like the string '0' when it expects a number

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -288,6 +288,12 @@ function processStyle<S: { +[string]: mixed }>(style: S): S {
         continue;
       }
 
+      // RN on Android doesn't like the string '0'
+      if (styleValue === '0') {
+        result[propName] = 0;
+        continue;
+      }
+
       const maybeLengthUnitValue = CSSLengthUnitValue.parse(styleValue);
       if (maybeLengthUnitValue != null) {
         result[propName] =

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -1010,6 +1010,15 @@ exports[`styles: pseudo-state :hover syntax: not hovered 1`] = `
 }
 `;
 
+exports[`units: length '0' is resolved to the number 0 1`] = `
+{
+  "style": {
+    "borderRadius": 0,
+    "width": 0,
+  },
+}
+`;
+
 exports[`units: length 10 "em" units are resolved to pixels 1`] = `
 {
   "style": {

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -1394,6 +1394,18 @@ describe('units: length', () => {
       )
     ).toMatchSnapshot();
   });
+
+  test("'0' is resolved to the number 0", () => {
+    const styles = css.create({
+      zeroStringTest: {
+        borderRadius: '0',
+        width: '0'
+      }
+    });
+    expect(
+      css.props.call(mockOptions, styles.zeroStringTest)
+    ).toMatchSnapshot();
+  });
 });
 
 /**


### PR DESCRIPTION
On Android, we get a RedBox if `'0'` is passed as value to props that expect a number e.g., `borderRadius`:

![Screenshot_1713265966](https://github.com/facebook/react-strict-dom/assets/4123478/c75c3b96-472e-4c61-b1ef-6c93f4fa1199)