### PR TITLE
feat: add support to `textAlignVertical`

### DIFF
--- a/packages/eslint-plugin/src/valid-styles.js
+++ b/packages/eslint-plugin/src/valid-styles.js
@@ -167,7 +167,8 @@ const allowlistedStylexProps = new Set([
   'transitionProperty',
   'transitionTimingFunction',
   'userSelect',
-  'verticalAlign',
+  'verticalAlign', // android-only
+  'textAlignVertical', // android-only
   'visibility',
   'whiteSpace', // web-only
   'width',

--- a/packages/react-strict-dom/COMPATIBILITY.md
+++ b/packages/react-strict-dom/COMPATIBILITY.md
@@ -639,6 +639,7 @@ Note these APIs can only be accessed using `Node.getRootNode().defaultView`, in 
 | userSelect | 🟡 | 🟡 | |
 | v* units | 🟡 | 🟡 | |
 | verticalAlign | 🟡 | ❌ | |
+| textAlignVertical | 🟡 | ❌ | |
 | visibility | 🟡 | 🟡 | |
 | whiteSpace | ❌ | ❌ | |
 | width | ✅ | ✅ | |

--- a/packages/react-strict-dom/src/native/html.js
+++ b/packages/react-strict-dom/src/native/html.js
@@ -57,6 +57,7 @@ const styles = stylex.create({
     textDecorationLine: 'line-through'
   },
   textarea: {
+    borderWidth: 1,
     verticalAlign: 'top'
   },
   underline: {
@@ -178,7 +179,7 @@ export const textarea: React$AbstractComponent<
   TextInput
 > = createStrict('textarea', {
   dir: 'auto',
-  style: styles.input
+  style: styles.textarea
 });
 export const u: React$AbstractComponent<StrictReactDOMProps, View> =
   createStrict('u', { style: styles.underline });

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -125,6 +125,7 @@ const stylePropertyAllowlistSet = new Set<string>([
   'top',
   'userSelect',
   'verticalAlign', // Android Only
+  'textAlignVertical', // Android Only
   'width',
   // 'writingDirection', // iOS Only
   'zIndex'

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -373,6 +373,38 @@ exports[`properties: general position: sticky 1`] = `
 }
 `;
 
+exports[`properties: general text-align-vertical: auto 1`] = `
+{
+  "style": {
+    "textAlignVertical": "auto",
+  },
+}
+`;
+
+exports[`properties: general text-align-vertical: bottom 1`] = `
+{
+  "style": {
+    "textAlignVertical": "bottom",
+  },
+}
+`;
+
+exports[`properties: general text-align-vertical: center 1`] = `
+{
+  "style": {
+    "textAlignVertical": "center",
+  },
+}
+`;
+
+exports[`properties: general text-align-vertical: top 1`] = `
+{
+  "style": {
+    "textAlignVertical": "top",
+  },
+}
+`;
+
 exports[`properties: general text-shadow 1`] = `
 {
   "style": {

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -604,6 +604,23 @@ describe('properties: general', () => {
     expect(css.props.call(mockOptions, styles.top)).toMatchSnapshot('top');
   });
 
+  test('text-align-vertical', () => {
+    const styles = css.create({
+      auto: { textAlignVertical: 'auto' },
+      top: { textAlignVertical: 'top' },
+      bottom: { textAlignVertical: 'bottom' },
+      center: { textAlignVertical: 'center' }
+    });
+    expect(css.props.call(mockOptions, styles.auto)).toMatchSnapshot('auto');
+    expect(css.props.call(mockOptions, styles.top)).toMatchSnapshot('top');
+    expect(css.props.call(mockOptions, styles.bottom)).toMatchSnapshot(
+      'bottom'
+    );
+    expect(css.props.call(mockOptions, styles.center)).toMatchSnapshot(
+      'center'
+    );
+  });
+
   test('visibility', () => {
     const styles = css.create({
       collapse: {


### PR DESCRIPTION
### Summary

As the title says, this PR add support to `textAlignVertical` style.

Additional to it, also fix the `verticalAlign` styles not being applied to the `textarea` element