### PR TITLE
feat: polyfill for `::placeholder` using `placeholderTextColor`

### DIFF
--- a/packages/react-strict-dom/COMPATIBILITY.md
+++ b/packages/react-strict-dom/COMPATIBILITY.md
@@ -430,6 +430,7 @@ Note these APIs can only be accessed using `Node.getRootNode().defaultView`, in 
 | :active | ❌ | ❌ | |
 | :focus | ❌ | ❌ | |
 | :hover | 🟡 | 🟡 | |
+| ::placeholder | 🟡 | 🟡 | |
 | % units | ❌ | ❌ | |
 | alignContent | ✅ | ✅ | |
 | alignItems | ✅ | ✅ | |

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -306,8 +306,8 @@ function processStyle<S: { +[string]: mixed }>(style: S): S {
       ) {
         // TODO: On native, we can't apply custom styles to the text
         // besides the color. Should we warn users on native platforms?
-
         result['placeholderTextColor'] = styleValue['color'];
+        delete result['::placeholder'];
         continue;
       }
     }

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -301,6 +301,7 @@ function processStyle<S: { +[string]: mixed }>(style: S): S {
     if (propName === '::placeholder') {
       if (
         typeof styleValue === 'object' &&
+        styleValue != null &&
         Object.hasOwn(styleValue, 'color')
       ) {
         // TODO: On native, we can't apply custom styles to the text

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -298,6 +298,19 @@ function processStyle<S: { +[string]: mixed }>(style: S): S {
       }
     }
 
+    if (propName === '::placeholder') {
+      if (
+        typeof styleValue === 'object' &&
+        Object.hasOwn(styleValue, 'color')
+      ) {
+        // TODO: On native, we can't apply custom styles to the text
+        // besides the color. Should we warn users on native platforms?
+
+        result['placeholderTextColor'] = styleValue['color'];
+        continue;
+      }
+    }
+
     result[propName] = styleValue;
   }
 
@@ -598,6 +611,10 @@ export function props(
           nativeProps.pointerEvents = 'none';
           nativeProps.tabIndex = -1;
         }
+      }
+      // ::placeholder's color polyfill
+      else if (styleProp === 'placeholderTextColor') {
+        nativeProps.placeholderTextColor = styleValue;
       }
       // everything else
       else {

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -994,6 +994,12 @@ exports[`properties: logical direction textAlign: start 1`] = `
 }
 `;
 
+exports[`styles: pseudo-element ::placeholder syntax: placeholderTextColor 1`] = `
+{
+  "placeholderTextColor": "red",
+}
+`;
+
 exports[`styles: pseudo-state :hover syntax: hovered 1`] = `
 {
   "style": {

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -1360,6 +1360,27 @@ describe('styles: pseudo-state', () => {
 });
 
 /**
+ * Styles: pseudo-elements
+ */
+
+describe('styles: pseudo-element', () => {
+  test('::placeholder syntax', () => {
+    const styles = css.create({
+      root: {
+        '::placeholder': {
+          color: 'red',
+          fontWeight: 'bold'
+        }
+      }
+    });
+
+    expect(css.props.call(mockOptions, styles.root)).toMatchSnapshot(
+      'placeholderTextColor'
+    );
+  });
+});
+
+/**
  * Units: length
  */
 


### PR DESCRIPTION
This PR adds support for `::placeholder`. 

Only the `color` prop is supported `on native`, because we can't apply custom styles to the text (placeholder element)

Fixes #79

