### PR TITLE
fix: typos in names of `{row,column}Gap` properties

### DIFF
--- a/packages/react-strict-dom/COMPATIBILITY.md
+++ b/packages/react-strict-dom/COMPATIBILITY.md
@@ -535,8 +535,8 @@ Note these APIs can only be accessed using `Node.getRootNode().defaultView`, in 
 | fontVariant | ✅ | ✅ | |
 | fontWeight | 🟡 | 🟡 | |
 | gap | ✅ | ✅ | |
-| gapColumn | ✅ | ✅ | |
-| gapRow | ✅ | ✅ | |
+| columnGap | ✅ | ✅ | |
+| rowGap | ✅ | ✅ | |
 | grayscale() | ❌ | ❌ | |
 | height | ✅ | ✅ | |
 | hue-rotate() | ❌ | ❌ | |

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -74,8 +74,8 @@ const stylePropertyAllowlistSet = new Set<string>([
   'fontWeight',
   'fontVariant',
   'gap',
-  'gapColumn',
-  'gapRow',
+  'columnGap',
+  'rowGap',
   'height',
   // 'includeFontPadding', Android Only
   'justifyContent',


### PR DESCRIPTION
As title says. `gap{Row,Column}` -> `{row,column}Gap`

Related PR: https://github.com/facebook/react-strict-dom/pull/85