### PR TITLE
fix: same 'html' types across dom and native

### DIFF
--- a/packages/react-strict-dom/src/dom/html.js
+++ b/packages/react-strict-dom/src/dom/html.js
@@ -27,6 +27,7 @@ import type { StrictReactDOMTextAreaProps } from '../types/StrictReactDOMTextAre
 
 import { createStrictDOMComponent as createStrict } from './modules/createStrictDOMComponent';
 import { defaultStyles } from './runtime';
+import type { StrictHTMLOptionElement } from '../types/StrictHTMLFormElements';
 
 /**
  * "a" (inline)
@@ -293,8 +294,11 @@ export const optgroup: React$AbstractComponent<
  */
 export const option: React$AbstractComponent<
   StrictReactDOMOptionProps,
-  StrictHTMLElement
-> = createStrict('option', defaultStyles.option);
+  StrictHTMLOptionElement
+> = createStrict<StrictHTMLOptionElement, StrictReactDOMOptionProps>(
+  'option',
+  defaultStyles.option
+);
 
 /**
  * "p" (block)

--- a/packages/react-strict-dom/src/native/html.js
+++ b/packages/react-strict-dom/src/native/html.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict
  */
 
 import type { StrictReactDOMProps } from '../types/StrictReactDOMProps';
@@ -18,11 +18,20 @@ import type { StrictReactDOMOptionProps } from '../types/StrictReactDOMOptionPro
 import type { StrictReactDOMOptionGroupProps } from '../types/StrictReactDOMOptionGroupProps';
 import type { StrictReactDOMSelectProps } from '../types/StrictReactDOMSelectProps';
 import type { StrictReactDOMTextAreaProps } from '../types/StrictReactDOMTextAreaProps';
-import typeof { Pressable, Text, TextInput, View } from 'react-native';
 
+// $FlowFixMe[nonstrict-import]
 import { createStrictDOMComponent as createStrict } from './modules/createStrictDOMComponent';
+// $FlowFixMe[nonstrict-import]
 import { Platform } from 'react-native';
 import * as stylex from './stylex';
+import type { StrictHTMLElement } from '../types/StrictHTMLElement';
+import type {
+  StrictHTMLInputElement,
+  StrictHTMLOptionElement,
+  StrictHTMLTextAreaElement
+} from '../types/StrictHTMLFormElements';
+import type { StrictHTMLImageElement } from '../types/StrictHTMLImageElement';
+import type { StrictHTMLSelectElement } from '../types/StrictHTMLFormElements';
 
 const styles = stylex.create({
   bold: {
@@ -69,118 +78,204 @@ const headingProps = {
   style: styles.heading
 };
 
-export const a: React$AbstractComponent<StrictReactDOMAnchorProps, Text> =
-  createStrict('a', { dir: 'auto', style: styles.a });
-export const article: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('article');
-export const aside: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('aside');
-export const b: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('b', { style: styles.bold });
-export const bdi: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('bdi', { dir: 'auto' });
-export const bdo: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('bdo', { dir: 'auto' });
-export const blockquote: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('blockquote');
-export const br: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('br');
+export const a: React$AbstractComponent<
+  StrictReactDOMAnchorProps,
+  StrictHTMLElement
+> = createStrict('a', { dir: 'auto', style: styles.a });
+export const article: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('article');
+export const aside: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('aside');
+export const b: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('b', { style: styles.bold });
+export const bdi: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('bdi', { dir: 'auto' });
+export const bdo: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('bdo', { dir: 'auto' });
+export const blockquote: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('blockquote');
+export const br: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('br');
 export const button: React$AbstractComponent<
   StrictReactDOMButtonProps,
-  Pressable
+  StrictHTMLElement
 > = createStrict('button', {
   style: styles.button,
   type: 'button'
 });
-export const code: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('code', { style: styles.code });
-export const del: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('del', { style: styles.lineThrough });
-export const div: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('div');
-export const em: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('em', { style: styles.italic });
-export const fieldset: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('fieldset');
-export const footer: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('footer');
-export const form: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('form');
-export const h1: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('h1', headingProps);
-export const h2: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('h2', headingProps);
-export const h3: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('h3', headingProps);
-export const h4: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('h4', headingProps);
-export const h5: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('h5', headingProps);
-export const h6: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('h6', headingProps);
-export const header: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('header');
-export const hr: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('hr', { style: styles.hr });
-export const i: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('i', { style: styles.italic });
+export const code: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('code', { style: styles.code });
+export const del: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('del', { style: styles.lineThrough });
+export const div: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('div');
+export const em: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('em', { style: styles.italic });
+export const fieldset: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('fieldset');
+export const footer: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('footer');
+export const form: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('form');
+export const h1: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('h1', headingProps);
+export const h2: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('h2', headingProps);
+export const h3: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('h3', headingProps);
+export const h4: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('h4', headingProps);
+export const h5: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('h5', headingProps);
+export const h6: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('h6', headingProps);
+export const header: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('header');
+export const hr: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('hr', { style: styles.hr });
+export const i: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('i', { style: styles.italic });
 export const img: React$AbstractComponent<
   StrictReactDOMImageProps,
-  typeof Image
+  StrictHTMLImageElement
 > = createStrict('img');
 export const input: React$AbstractComponent<
   StrictReactDOMInputProps,
-  TextInput
+  StrictHTMLInputElement
 > = createStrict('input', {
   dir: 'auto',
   style: styles.input
 });
-export const ins: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('ins', { style: styles.underline });
-export const kbd: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('kbd', { style: styles.code });
-export const label: React$AbstractComponent<StrictReactDOMLabelProps, Text> =
-  createStrict('label');
-export const li: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('li');
-export const main: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('main');
-export const nav: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('nav');
-export const ol: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('ol');
-export const p: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('p');
-export const pre: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('pre', { style: styles.code });
-export const option: React$AbstractComponent<StrictReactDOMOptionProps, Text> =
-  createStrict('option');
+export const ins: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('ins', { style: styles.underline });
+export const kbd: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('kbd', { style: styles.code });
+export const label: React$AbstractComponent<
+  StrictReactDOMLabelProps,
+  StrictHTMLElement
+> = createStrict('label');
+export const li: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('li');
+export const main: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('main');
+export const nav: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('nav');
+export const ol: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('ol');
+export const p: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('p');
+export const pre: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('pre', { style: styles.code });
+export const option: React$AbstractComponent<
+  StrictReactDOMOptionProps,
+  StrictHTMLOptionElement
+> = createStrict('option');
 export const optgroup: React$AbstractComponent<
   StrictReactDOMOptionGroupProps,
-  View
+  StrictHTMLElement
 > = createStrict('optgroup');
-export const s: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('s', { style: styles.lineThrough });
-export const section: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('section');
-export const select: React$AbstractComponent<StrictReactDOMSelectProps, View> =
-  createStrict('select');
-export const span: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('span', { dir: 'auto' });
-export const strong: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('strong', { style: styles.bold });
-export const sub: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('sub');
-export const sup: React$AbstractComponent<StrictReactDOMProps, Text> =
-  createStrict('sup');
+export const s: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('s', { style: styles.lineThrough });
+export const section: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('section');
+export const select: React$AbstractComponent<
+  StrictReactDOMSelectProps,
+  StrictHTMLSelectElement
+> = createStrict('select');
+export const span: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('span', { dir: 'auto' });
+export const strong: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('strong', { style: styles.bold });
+export const sub: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('sub');
+export const sup: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('sup');
 export const textarea: React$AbstractComponent<
   StrictReactDOMTextAreaProps,
-  TextInput
+  StrictHTMLTextAreaElement
 > = createStrict('textarea', {
   dir: 'auto',
   style: styles.input
 });
-export const u: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('u', { style: styles.underline });
-export const ul: React$AbstractComponent<StrictReactDOMProps, View> =
-  createStrict('ul');
+export const u: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('u', { style: styles.underline });
+export const ul: React$AbstractComponent<
+  StrictReactDOMProps,
+  StrictHTMLElement
+> = createStrict('ul');

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 import type { StrictProps } from '../../types/StrictProps';
@@ -46,8 +46,8 @@ import * as stylex from '../stylex';
 
 type ReactNativeProps = {
   ...StrictProps,
-  accessibilityPosInSet?: any,
-  accessibilitySetSize?: any,
+  accessibilityPosInSet?: $FlowFixMe,
+  accessibilitySetSize?: $FlowFixMe,
   caretHidden?: ?boolean,
   experimental_layoutConformance?: 'strict',
   multiline?: ?boolean,
@@ -62,9 +62,9 @@ type ReactNativeProps = {
   ) => void,
   onKeyPress?: ?(event: KeyPressEvent) => mixed,
   onLoad?: ?(event: ImageLoadEvent) => void,
-  onPress?: any,
+  onPress?: $FlowFixMe,
   onSubmitEditing?: ?(event: EditingEvent) => mixed,
-  ref?: any,
+  ref?: $FlowFixMe,
   secureTextEntry?: ?boolean,
   style?: ViewStyleProp | TextStyleProp,
   testID?: ?string
@@ -122,7 +122,7 @@ function isString(str: mixed): boolean %checks {
   return typeof str === 'string';
 }
 
-function validateStrictProps(props: any) {
+function validateStrictProps(props: $FlowFixMe) {
   Object.keys(props).forEach((key) => {
     const isValidProp = isPropAllowed(key);
     const isUnsupportedProp = unsupportedProps.has(key);
@@ -153,7 +153,7 @@ function resolveTransitionProperty(property: mixed): string[] {
 
 const DisplayModeInsideContext = React.createContext('flow');
 
-export function createStrictDOMComponent<T: any, P: StrictProps>(
+export function createStrictDOMComponent<T, P: StrictProps>(
   tagName: string,
   defaultProps?: P
 ): React.AbstractComponent<P, T> {

--- a/packages/react-strict-dom/src/types/StrictHTMLFormElements.js
+++ b/packages/react-strict-dom/src/types/StrictHTMLFormElements.js
@@ -36,10 +36,10 @@ export interface StrictHTMLInputElement
 export interface StrictHTMLOptionElement extends StrictHTMLElement {
   defaultSelected: boolean;
   disabled: boolean;
-  index: number;
-  label: string;
-  selected: boolean;
-  text: string;
+  +index: number;
+  +label: string;
+  +selected: boolean;
+  +text: string;
   value: string;
 }
 

--- a/packages/react-strict-dom/src/types/StrictReactDOMProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMProps.js
@@ -7,8 +7,6 @@
  * @flow strict
  */
 
-import type { StrictElement } from './StrictElement';
-import type { ReactRef } from './Utilities';
 import type { Styles } from './styles';
 
 type IDRef = string;
@@ -231,7 +229,6 @@ export type StrictReactDOMProps = $ReadOnly<{
     | 'decimal'
     | 'search',
   lang?: string,
-  ref?: ReactRef<StrictElement>,
   role?: AriaRole,
   spellCheck?: boolean,
   style?: ?Styles,

--- a/packages/react-strict-dom/src/types/flowtests/html-types-match.js.flow
+++ b/packages/react-strict-dom/src/types/flowtests/html-types-match.js.flow
@@ -1,0 +1,258 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import typeof * as DomHTML from '../../dom/html';
+import typeof * as NativeHTML from '../../native/html';
+
+declare var domHTML: DomHTML;
+domHTML as NativeHTML;
+declare var nativeHTML: NativeHTML;
+nativeHTML as DomHTML;
+
+// Adding all the individual keys as an extra layer of testing
+
+declare var a_dom: DomHTML['a'];
+(a_dom as NativeHTML['a']);
+declare var a_native: NativeHTML['a'];
+(a_native as DomHTML['a']);
+
+declare var article_dom: DomHTML['article'];
+(article_dom as NativeHTML['article']);
+declare var article_native: NativeHTML['article'];
+(article_native as DomHTML['article']);
+
+declare var aside_dom: DomHTML['aside'];
+(aside_dom as NativeHTML['aside']);
+declare var aside_native: NativeHTML['aside'];
+(aside_native as DomHTML['aside']);
+
+declare var b_dom: DomHTML['b'];
+(b_dom as NativeHTML['b']);
+declare var b_native: NativeHTML['b'];
+(b_native as DomHTML['b']);
+
+declare var bdi_dom: DomHTML['bdi'];
+(bdi_dom as NativeHTML['bdi']);
+declare var bdi_native: NativeHTML['bdi'];
+(bdi_native as DomHTML['bdi']);
+
+declare var bdo_dom: DomHTML['bdo'];
+(bdo_dom as NativeHTML['bdo']);
+declare var bdo_native: NativeHTML['bdo'];
+(bdo_native as DomHTML['bdo']);
+
+declare var blockquote_dom: DomHTML['blockquote'];
+(blockquote_dom as NativeHTML['blockquote']);
+declare var blockquote_native: NativeHTML['blockquote'];
+(blockquote_native as DomHTML['blockquote']);
+
+declare var br_dom: DomHTML['br'];
+(br_dom as NativeHTML['br']);
+declare var br_native: NativeHTML['br'];
+(br_native as DomHTML['br']);
+
+declare var button_dom: DomHTML['button'];
+(button_dom as NativeHTML['button']);
+declare var button_native: NativeHTML['button'];
+(button_native as DomHTML['button']);
+
+declare var code_dom: DomHTML['code'];
+(code_dom as NativeHTML['code']);
+declare var code_native: NativeHTML['code'];
+(code_native as DomHTML['code']);
+
+declare var del_dom: DomHTML['del'];
+(del_dom as NativeHTML['del']);
+declare var del_native: NativeHTML['del'];
+(del_native as DomHTML['del']);
+
+declare var div_dom: DomHTML['div'];
+(div_dom as NativeHTML['div']);
+declare var div_native: NativeHTML['div'];
+(div_native as DomHTML['div']);
+
+declare var em_dom: DomHTML['em'];
+(em_dom as NativeHTML['em']);
+declare var em_native: NativeHTML['em'];
+(em_native as DomHTML['em']);
+
+declare var fieldset_dom: DomHTML['fieldset'];
+(fieldset_dom as NativeHTML['fieldset']);
+declare var fieldset_native: NativeHTML['fieldset'];
+(fieldset_native as DomHTML['fieldset']);
+
+declare var footer_dom: DomHTML['footer'];
+(footer_dom as NativeHTML['footer']);
+declare var footer_native: NativeHTML['footer'];
+(footer_native as DomHTML['footer']);
+
+declare var form_dom: DomHTML['form'];
+(form_dom as NativeHTML['form']);
+declare var form_native: NativeHTML['form'];
+(form_native as DomHTML['form']);
+
+declare var h1_dom: DomHTML['h1'];
+(h1_dom as NativeHTML['h1']);
+declare var h1_native: NativeHTML['h1'];
+(h1_native as DomHTML['h1']);
+
+declare var h2_dom: DomHTML['h2'];
+(h2_dom as NativeHTML['h2']);
+declare var h2_native: NativeHTML['h2'];
+(h2_native as DomHTML['h2']);
+
+declare var h3_dom: DomHTML['h3'];
+(h3_dom as NativeHTML['h3']);
+declare var h3_native: NativeHTML['h3'];
+(h3_native as DomHTML['h3']);
+
+declare var h4_dom: DomHTML['h4'];
+(h4_dom as NativeHTML['h4']);
+declare var h4_native: NativeHTML['h4'];
+(h4_native as DomHTML['h4']);
+
+declare var h5_dom: DomHTML['h5'];
+(h5_dom as NativeHTML['h5']);
+declare var h5_native: NativeHTML['h5'];
+(h5_native as DomHTML['h5']);
+
+declare var h6_dom: DomHTML['h6'];
+(h6_dom as NativeHTML['h6']);
+declare var h6_native: NativeHTML['h6'];
+(h6_native as DomHTML['h6']);
+
+declare var header_dom: DomHTML['header'];
+(header_dom as NativeHTML['header']);
+declare var header_native: NativeHTML['header'];
+(header_native as DomHTML['header']);
+
+declare var hr_dom: DomHTML['hr'];
+(hr_dom as NativeHTML['hr']);
+declare var hr_native: NativeHTML['hr'];
+(hr_native as DomHTML['hr']);
+
+declare var i_dom: DomHTML['i'];
+(i_dom as NativeHTML['i']);
+declare var i_native: NativeHTML['i'];
+(i_native as DomHTML['i']);
+
+declare var img_dom: DomHTML['img'];
+(img_dom as NativeHTML['img']);
+declare var img_native: NativeHTML['img'];
+(img_native as DomHTML['img']);
+
+declare var input_dom: DomHTML['input'];
+(input_dom as NativeHTML['input']);
+declare var input_native: NativeHTML['input'];
+(input_native as DomHTML['input']);
+
+declare var ins_dom: DomHTML['ins'];
+(ins_dom as NativeHTML['ins']);
+declare var ins_native: NativeHTML['ins'];
+(ins_native as DomHTML['ins']);
+
+declare var kbd_dom: DomHTML['kbd'];
+(kbd_dom as NativeHTML['kbd']);
+declare var kbd_native: NativeHTML['kbd'];
+(kbd_native as DomHTML['kbd']);
+
+declare var label_dom: DomHTML['label'];
+(label_dom as NativeHTML['label']);
+declare var label_native: NativeHTML['label'];
+(label_native as DomHTML['label']);
+
+declare var li_dom: DomHTML['li'];
+(li_dom as NativeHTML['li']);
+declare var li_native: NativeHTML['li'];
+(li_native as DomHTML['li']);
+
+declare var main_dom: DomHTML['main'];
+(main_dom as NativeHTML['main']);
+declare var main_native: NativeHTML['main'];
+(main_native as DomHTML['main']);
+
+declare var nav_dom: DomHTML['nav'];
+(nav_dom as NativeHTML['nav']);
+declare var nav_native: NativeHTML['nav'];
+(nav_native as DomHTML['nav']);
+
+declare var ol_dom: DomHTML['ol'];
+(ol_dom as NativeHTML['ol']);
+declare var ol_native: NativeHTML['ol'];
+(ol_native as DomHTML['ol']);
+
+declare var p_dom: DomHTML['p'];
+(p_dom as NativeHTML['p']);
+declare var p_native: NativeHTML['p'];
+(p_native as DomHTML['p']);
+
+declare var pre_dom: DomHTML['pre'];
+(pre_dom as NativeHTML['pre']);
+declare var pre_native: NativeHTML['pre'];
+(pre_native as DomHTML['pre']);
+
+declare var option_dom: DomHTML['option'];
+(option_dom as NativeHTML['option']);
+declare var option_native: NativeHTML['option'];
+(option_native as DomHTML['option']);
+
+declare var optgroup_dom: DomHTML['optgroup'];
+(optgroup_dom as NativeHTML['optgroup']);
+declare var optgroup_native: NativeHTML['optgroup'];
+(optgroup_native as DomHTML['optgroup']);
+
+declare var s_dom: DomHTML['s'];
+(s_dom as NativeHTML['s']);
+declare var s_native: NativeHTML['s'];
+(s_native as DomHTML['s']);
+
+declare var section_dom: DomHTML['section'];
+(section_dom as NativeHTML['section']);
+declare var section_native: NativeHTML['section'];
+(section_native as DomHTML['section']);
+
+declare var select_dom: DomHTML['select'];
+(select_dom as NativeHTML['select']);
+declare var select_native: NativeHTML['select'];
+(select_native as DomHTML['select']);
+
+declare var span_dom: DomHTML['span'];
+(span_dom as NativeHTML['span']);
+declare var span_native: NativeHTML['span'];
+(span_native as DomHTML['span']);
+
+declare var strong_dom: DomHTML['strong'];
+(strong_dom as NativeHTML['strong']);
+declare var strong_native: NativeHTML['strong'];
+(strong_native as DomHTML['strong']);
+
+declare var sub_dom: DomHTML['sub'];
+(sub_dom as NativeHTML['sub']);
+declare var sub_native: NativeHTML['sub'];
+(sub_native as DomHTML['sub']);
+
+declare var sup_dom: DomHTML['sup'];
+(sup_dom as NativeHTML['sup']);
+declare var sup_native: NativeHTML['sup'];
+(sup_native as DomHTML['sup']);
+
+declare var textarea_dom: DomHTML['textarea'];
+(textarea_dom as NativeHTML['textarea']);
+declare var textarea_native: NativeHTML['textarea'];
+(textarea_native as DomHTML['textarea']);
+
+declare var u_dom: DomHTML['u'];
+(u_dom as NativeHTML['u']);
+declare var u_native: NativeHTML['u'];
+(u_native as DomHTML['u']);
+
+declare var ul_dom: DomHTML['ul'];
+(ul_dom as NativeHTML['ul']);
+declare var ul_native: NativeHTML['ul'];
+(ul_native as DomHTML['ul']);


### PR DESCRIPTION
The Native version of the `html` module was using RN types instead of the common `StrictHTML*` types.

This PR fixes everything to use the same common types. Now shared code across web and native can confidently use the same types for refs, and event targets.

Our types are already constrained versions of the DOM types.