### PR TITLE
Relax the Flow types for props

### DIFF
--- a/packages/react-strict-dom/src/types/StrictReactDOMAnchorProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMAnchorProps.js
@@ -11,9 +11,9 @@ import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
 export type StrictReactDOMAnchorProps = $ReadOnly<{
   ...StrictReactDOMProps,
-  download?: string,
+  download?: ?string,
   href?: string,
-  referrerPolicy?:
+  referrerPolicy?: ?(
     | 'no-referrer'
     | 'no-referrer-when-downgrade'
     | 'origin'
@@ -21,7 +21,8 @@ export type StrictReactDOMAnchorProps = $ReadOnly<{
     | 'same-origin'
     | 'strict-origin'
     | 'strict-origin-when-cross-origin'
-    | 'unsafe-url',
-  rel?: string,
-  target?: '_self' | '_blank' | '_parent' | '_top'
+    | 'unsafe-url'
+  ),
+  rel?: ?string,
+  target?: ?('_self' | '_blank' | '_parent' | '_top')
 }>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMButtonProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMButtonProps.js
@@ -11,6 +11,6 @@ import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
 export type StrictReactDOMButtonProps = $ReadOnly<{
   ...StrictReactDOMProps,
-  disabled?: boolean,
-  type?: 'button' | 'submit'
+  disabled?: ?boolean,
+  type?: ?('button' | 'submit')
 }>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMImageProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMImageProps.js
@@ -11,16 +11,16 @@ import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
 export type StrictReactDOMImageProps = $ReadOnly<{
   ...StrictReactDOMProps,
-  alt?: Stringish,
-  crossOrigin?: 'anonymous' | 'use-credentials',
-  decoding?: 'sync' | 'async' | 'auto',
-  draggable?: boolean,
-  fetchPriority?: 'high' | 'low' | 'auto',
+  alt?: ?Stringish,
+  crossOrigin?: ?('anonymous' | 'use-credentials'),
+  decoding?: ?('async' | 'auto' | 'sync'),
+  draggable?: ?boolean,
+  fetchPriority?: ?('high' | 'low' | 'auto'),
   height?: number,
-  loading?: 'eager' | 'lazy',
+  loading?: ?('eager' | 'lazy'),
   onError?: $FlowFixMe,
   onLoad?: $FlowFixMe,
-  referrerPolicy?:
+  referrerPolicy?: ?(
     | 'no-referrer'
     | 'no-referrer-when-downgrade'
     | 'origin'
@@ -28,7 +28,8 @@ export type StrictReactDOMImageProps = $ReadOnly<{
     | 'same-origin'
     | 'strict-origin'
     | 'strict-origin-when-cross-origin'
-    | 'unsafe-url',
+    | 'unsafe-url'
+  ),
   src?: string,
   srcSet?: string,
   width?: number

--- a/packages/react-strict-dom/src/types/StrictReactDOMInputProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMInputProps.js
@@ -11,25 +11,25 @@ import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
 export type StrictReactDOMInputProps = $ReadOnly<{
   ...StrictReactDOMProps,
-  checked?: boolean | 'mixed',
-  defaultChecked?: boolean,
-  defaultValue?: Stringish,
-  disabled?: boolean,
-  max?: string | number,
-  maxLength?: number,
-  min?: string | number,
-  minLength?: number,
-  multiple?: boolean,
+  checked?: ?(boolean | 'mixed'),
+  defaultChecked?: ?boolean,
+  defaultValue?: ?Stringish,
+  disabled?: ?boolean,
+  max?: ?(string | number),
+  maxLength?: ?number,
+  min?: ?(string | number),
+  minLength?: ?number,
+  multiple?: ?boolean,
   onBeforeInput?: $FlowFixMe,
   onChange?: $FlowFixMe,
   onInput?: $FlowFixMe,
   onInvalid?: $FlowFixMe,
   onSelect?: $FlowFixMe,
   onSelectionChange?: $FlowFixMe,
-  placeholder?: Stringish,
-  readOnly?: number,
-  required?: number,
-  step?: number | 'any',
+  placeholder?: ?Stringish,
+  readOnly?: ?number,
+  required?: ?number,
+  step?: ?(number | 'any'),
   type?:
     | 'checkbox'
     | 'color'
@@ -50,5 +50,5 @@ export type StrictReactDOMInputProps = $ReadOnly<{
     | 'time'
     | 'url'
     | 'week',
-  value?: Stringish | boolean | number
+  value?: ?(Stringish | boolean | number)
 }>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMOptionGroupProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMOptionGroupProps.js
@@ -11,6 +11,6 @@ import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
 export type StrictReactDOMOptionGroupProps = $ReadOnly<{
   ...StrictReactDOMProps,
-  disabled?: boolean,
-  label?: Stringish
+  disabled?: ?boolean,
+  label?: ?Stringish
 }>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMOptionProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMOptionProps.js
@@ -11,8 +11,8 @@ import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
 export type StrictReactDOMOptionProps = $ReadOnly<{
   ...StrictReactDOMProps,
-  disabled?: boolean,
-  label?: Stringish,
-  selected?: boolean,
-  value?: Stringish
+  disabled?: ?boolean,
+  label?: ?Stringish,
+  selected?: ?boolean,
+  value?: ?Stringish
 }>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMProps.js
@@ -12,53 +12,53 @@ import type { Styles } from './styles';
 type IDRef = string;
 
 type AriaProps = $ReadOnly<{
-  'aria-activedescendant'?: IDRef,
-  'aria-atomic'?: boolean,
-  'aria-autocomplete'?: 'none' | 'inline' | 'list' | 'both',
-  'aria-busy'?: boolean,
-  'aria-checked'?: boolean | 'mixed',
-  'aria-colcount'?: number,
-  'aria-colindex'?: number,
-  'aria-colindextext'?: Stringish,
-  'aria-colspan'?: number,
-  'aria-controls'?: IDRef,
-  'aria-current'?: boolean | 'page' | 'step' | 'location' | 'date' | 'time',
-  'aria-describedby'?: IDRef,
-  'aria-details'?: IDRef,
-  'aria-disabled'?: boolean,
-  'aria-errormessage'?: IDRef,
-  'aria-expanded'?: boolean,
-  'aria-flowto'?: IDRef,
-  'aria-haspopup'?: 'menu' | 'listbox' | 'tree' | 'grid' | 'dialog',
-  'aria-hidden'?: boolean,
-  'aria-invalid'?: boolean | 'grammar' | 'spelling',
-  'aria-keyshortcuts'?: string,
-  'aria-label'?: Stringish,
-  'aria-labelledby'?: IDRef,
-  'aria-level'?: number,
-  'aria-live'?: 'off' | 'assertive' | 'polite',
-  'aria-modal'?: boolean,
-  'aria-multiline'?: boolean,
-  'aria-multiselectable'?: boolean,
-  'aria-orientation'?: 'horizontal' | 'vertical',
-  'aria-owns'?: IDRef,
-  'aria-placeholder'?: Stringish,
-  'aria-posinset'?: number,
-  'aria-pressed'?: boolean | 'mixed',
-  'aria-readonly'?: boolean,
-  'aria-required'?: boolean,
-  'aria-roledescription'?: Stringish,
-  'aria-rowcount'?: number,
-  'aria-rowindex'?: number,
-  'aria-rowindextext'?: Stringish,
-  'aria-rowspan'?: number,
-  'aria-selected'?: boolean,
-  'aria-setsize'?: number,
-  'aria-sort'?: 'none' | 'ascending' | 'descending' | 'other',
-  'aria-valuemax'?: number,
-  'aria-valuemin'?: number,
-  'aria-valuenow'?: number,
-  'aria-valuetext'?: Stringish
+  'aria-activedescendant'?: ?IDRef,
+  'aria-atomic'?: ?boolean,
+  'aria-autocomplete'?: ?('none' | 'inline' | 'list' | 'both'),
+  'aria-busy'?: ?boolean,
+  'aria-checked'?: ?(boolean | 'mixed'),
+  'aria-colcount'?: ?number,
+  'aria-colindex'?: ?number,
+  'aria-colindextext'?: ?Stringish,
+  'aria-colspan'?: ?number,
+  'aria-controls'?: ?IDRef,
+  'aria-current'?: ?(boolean | 'page' | 'step' | 'location' | 'date' | 'time'),
+  'aria-describedby'?: ?IDRef,
+  'aria-details'?: ?IDRef,
+  'aria-disabled'?: ?boolean,
+  'aria-errormessage'?: ?IDRef,
+  'aria-expanded'?: ?boolean,
+  'aria-flowto'?: ?IDRef,
+  'aria-haspopup'?: ?('menu' | 'listbox' | 'tree' | 'grid' | 'dialog'),
+  'aria-hidden'?: ?boolean,
+  'aria-invalid'?: ?(boolean | 'grammar' | 'spelling'),
+  'aria-keyshortcuts'?: ?string,
+  'aria-label'?: ?Stringish,
+  'aria-labelledby'?: ?IDRef,
+  'aria-level'?: ?number,
+  'aria-live'?: ?('off' | 'assertive' | 'polite'),
+  'aria-modal'?: ?boolean,
+  'aria-multiline'?: ?boolean,
+  'aria-multiselectable'?: ?boolean,
+  'aria-orientation'?: ?('horizontal' | 'vertical'),
+  'aria-owns'?: ?IDRef,
+  'aria-placeholder'?: ?Stringish,
+  'aria-posinset'?: ?number,
+  'aria-readonly'?: ?boolean,
+  'aria-pressed'?: ?(boolean | 'mixed'),
+  'aria-required'?: ?boolean,
+  'aria-roledescription'?: ?Stringish,
+  'aria-rowcount'?: ?number,
+  'aria-rowindex'?: ?number,
+  'aria-rowindextext'?: ?Stringish,
+  'aria-rowspan'?: ?number,
+  'aria-selected'?: ?boolean,
+  'aria-setsize'?: ?number,
+  'aria-sort'?: ?('none' | 'ascending' | 'descending' | 'other'),
+  'aria-valuemax'?: ?number,
+  'aria-valuemin'?: ?number,
+  'aria-valuenow'?: ?number,
+  'aria-valuetext'?: ?Stringish
 }>;
 
 // Excludes all abstract roles that should not be used by authors.
@@ -202,24 +202,32 @@ export type StrictReactDOMProps = $ReadOnly<{
   ...AriaProps,
   ...EventProps,
   ...ReactStrictDOMDataProps,
-  autoCapitalize?: 'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters',
-  autoFocus?: boolean,
+  autoCapitalize?: ?(
+    | 'off'
+    | 'none'
+    | 'on'
+    | 'sentences'
+    | 'words'
+    | 'characters'
+  ),
+  autoFocus?: ?boolean,
   children?: React$Node,
-  'data-testid'?: string,
-  dir?: 'auto' | 'ltr' | 'rtl',
-  elementTiming?: string,
-  enterKeyHint?:
+  'data-testid'?: ?string,
+  dir?: ?('auto' | 'ltr' | 'rtl'),
+  elementTiming?: ?string,
+  enterKeyHint?: ?(
     | 'enter'
     | 'done'
     | 'go'
     | 'next'
     | 'previous'
     | 'search'
-    | 'send',
-  hidden?: true | 'hidden' | 'until-found',
-  id?: string,
-  inert?: boolean,
-  inputMode?:
+    | 'send'
+  ),
+  hidden?: ?(true | 'hidden' | 'until-found'),
+  id?: ?string,
+  inert?: ?boolean,
+  inputMode?: ?(
     | 'none'
     | 'text'
     | 'tel'
@@ -227,11 +235,12 @@ export type StrictReactDOMProps = $ReadOnly<{
     | 'email'
     | 'numeric'
     | 'decimal'
-    | 'search',
-  lang?: string,
-  role?: AriaRole,
-  spellCheck?: boolean,
+    | 'search'
+  ),
+  lang?: ?string,
+  role?: ?AriaRole,
+  spellCheck?: ?boolean,
   style?: ?Styles,
-  suppressHydrationWarning?: boolean,
+  suppressHydrationWarning?: ?boolean,
   tabIndex?: ?(0 | -1)
 }>;

--- a/packages/react-strict-dom/src/types/StrictReactDOMSelectProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMSelectProps.js
@@ -11,8 +11,8 @@ import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
 export type StrictReactDOMSelectProps = $ReadOnly<{
   ...StrictReactDOMProps,
-  multiple?: boolean,
-  required?: boolean,
+  multiple?: ?boolean,
+  required?: ?boolean,
   onBeforeInput?: $FlowFixMe,
   onChange?: $FlowFixMe,
   onInput?: $FlowFixMe,

--- a/packages/react-strict-dom/src/types/StrictReactDOMTextAreaProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMTextAreaProps.js
@@ -11,19 +11,19 @@ import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
 export type StrictReactDOMTextAreaProps = $ReadOnly<{
   ...StrictReactDOMProps,
-  defaultValue?: Stringish,
-  disabled?: boolean,
-  maxLength?: number,
-  minLength?: number,
+  defaultValue?: ?Stringish,
+  disabled?: ?boolean,
+  maxLength?: ?number,
+  minLength?: ?number,
   onBeforeInput?: $FlowFixMe,
   onChange?: $FlowFixMe,
   onInput?: $FlowFixMe,
   onInvalid?: $FlowFixMe,
   onSelect?: $FlowFixMe,
   onSelectionChange?: $FlowFixMe,
-  placeholder?: Stringish,
-  readOnly?: boolean,
-  required?: boolean,
-  rows?: number,
-  value?: Stringish
+  placeholder?: ?Stringish,
+  readOnly?: ?boolean,
+  required?: ?boolean,
+  rows?: ?number,
+  value?: ?Stringish
 }>;


### PR DESCRIPTION
Allow `null` or `undefined` values in most cases.

Allows for code like this, where `props.role` might be undefined:

```jsx
<html.div role={props.role} />
```

This works with React DOM, because the props are any-typed.