### PR TITLE
Fix polyfill for unitless lineHeight

### DIFF
--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -185,31 +185,21 @@ export default function App(): React.MixedElement {
           <html.textarea placeholder="textarea" />
         </ExampleBlock>
 
-        {/* variables & themes */}
-        <ExampleBlock title="Variables & Theming">
-          <html.p style={styles.inheritedText}>Global variables</html.p>
-          <html.div style={styles.square} />
-
-          <html.p style={[themedTokens, styles.inheritedText]}>
-            Direct theming
-          </html.p>
-          <html.div style={[themedTokens, styles.square]} />
-
-          <html.div style={themedTokens}>
-            <html.p style={styles.inheritedText}>Inherit theming</html.p>
-            <html.div style={styles.square} />
-          </html.div>
-
-          <html.div style={themedTokens}>
-            <html.div style={themedTokensAlt}>
-              <html.p style={styles.inheritedText}>Nested theming</html.p>
-              <html.div style={styles.square} />
-            </html.div>
-          </html.div>
+        <ExampleBlock title="CSS Animations">
+          <html.div
+            style={[
+              styles.square,
+              styles.bgRed,
+              animate && styles.keyframeAnimation
+            ]}
+          />
+          <html.button onClick={() => setAnimate(!animate)}>
+            {animate ? 'Reset' : 'Start'}
+          </html.button>
         </ExampleBlock>
 
         {/* block layout emulation */}
-        <ExampleBlock title="Layout">
+        <ExampleBlock title="CSS Layout">
           <html.p>display:block emulation</html.p>
           <html.div>
             <html.div style={styles.square} />
@@ -253,8 +243,8 @@ export default function App(): React.MixedElement {
           </html.div>
         </ExampleBlock>
 
-        {/* positioning (static by default) */}
-        <ExampleBlock title="Position">
+        {/* CSS positioning (static by default) */}
+        <ExampleBlock title="CSS Position">
           <html.div style={[styles.p50, styles.relative]}>
             <html.div style={styles.p50}>
               <html.div style={[styles.square, styles.absTopLeft]} />
@@ -265,115 +255,16 @@ export default function App(): React.MixedElement {
           </html.div>
         </ExampleBlock>
 
-        {/* visibility */}
-        <ExampleBlock title="Visibility">
-          <html.div style={styles.flex}>
-            <html.div style={[styles.square, styles.visibilityCollapse]} />
-            <html.div style={[styles.square, styles.visibilityHidden]} />
-            <html.div style={[styles.square, styles.visibilityVisible]} />
+        {/* CSS text */}
+        <ExampleBlock title="CSS Text styles">
+          <html.div style={styles.lineHeightUnitless}>
+            <html.span style={styles.text}>
+              <html.span style={styles.text}>line-height</html.span> (unitless)
+            </html.span>
           </html.div>
-        </ExampleBlock>
-
-        {/* event emulation */}
-        <ExampleBlock title="Events">
-          <html.input
-            onChange={(e) => {
-              console.log(e.type, e.target.value);
-            }}
-            onKeyDown={(e) => {
-              console.log(e.type, e.key);
-            }}
-            onInput={(e) => {
-              console.log(e.type, e.target.value);
-            }}
-          />
-          <html.textarea
-            onChange={(e) => {
-              console.log(e.type, e.target.value);
-            }}
-            onKeyDown={(e) => {
-              console.log(e.type, e.key);
-            }}
-            onInput={(e) => {
-              console.log(e.type, e.target.value);
-            }}
-          />
-          <html.div
-            onClick={(e) => {
-              setClickData((data) => ({
-                color: data.color === 'red' ? 'blue' : 'red',
-                text: 'click'
-              }));
-              setClickEventData({
-                altKey: e.altKey,
-                button: e.button,
-                ctrlKey: e.ctrlKey,
-                metaKey: e.metaKey,
-                pageX: e.pageX,
-                pageY: e.pageY,
-                shiftKey: e.shiftKey
-              });
-            }}
-            style={[styles.h100, styles.dynamicBg(clickData.color)]}
-          >
-            <html.span style={styles.bgWhite}>{clickData.text}</html.span>
-            <html.div style={styles.flex}>
-              <html.div style={styles.flexGrow}>
-                <html.div>
-                  <html.span>
-                    {clickEventData.altKey ? '✅' : '🚫'} altKey
-                  </html.span>
-                </html.div>
-                <html.div>
-                  <html.span>
-                    {clickEventData.ctrlKey ? '✅' : '🚫'} ctrlKey
-                  </html.span>
-                </html.div>
-                <html.div>
-                  <html.span>
-                    {clickEventData.metaKey ? '✅' : '🚫'} metaKey
-                  </html.span>
-                </html.div>
-                <html.div>
-                  <html.span>
-                    {clickEventData.shiftKey ? '✅' : '🚫'} shiftKey
-                  </html.span>
-                </html.div>
-              </html.div>
-              <html.div style={styles.flexGrow}>
-                <html.div>
-                  <html.span>button: {clickEventData.button}</html.span>
-                </html.div>
-                <html.div>
-                  <html.span>pageX: {clickEventData.pageX}</html.span>
-                </html.div>
-                <html.div>
-                  <html.span>pageY: {clickEventData.pageY}</html.span>
-                </html.div>
-              </html.div>
-            </html.div>
+          <html.div style={styles.lineHeightEm}>
+            <html.span style={styles.text}>line-height (em)</html.span>
           </html.div>
-
-          <html.img
-            onLoad={(e) => {
-              setImageLoadText(`${e.type}: loaded`);
-            }}
-            width={150}
-            height={150}
-            src="http://placehold.jp/150x150.png"
-            style={styles.objContain}
-          />
-          <html.span>{imageLoadText}</html.span>
-          <html.img
-            onError={(e) => {
-              setImageErrorText(`${e.type}: errored`);
-            }}
-            width={150}
-            height={150}
-            src="http://error"
-            style={styles.objContain}
-          />
-          <html.span>{imageErrorText}</html.span>
         </ExampleBlock>
 
         {/* CSS transitions shim */}
@@ -492,20 +383,144 @@ export default function App(): React.MixedElement {
             Toggle
           </html.button>
         </ExampleBlock>
-        <ExampleBlock title="Keyframe Animations">
-          <html.div
-            style={[
-              styles.square,
-              styles.bgRed,
-              animate && styles.keyframeAnimation
-            ]}
-          />
-          <html.button onClick={() => setAnimate(!animate)}>
-            {animate ? 'Reset' : 'Start'}
-          </html.button>
+
+        {/* visibility */}
+        <ExampleBlock title="CSS Visibility">
+          <html.div style={styles.flex}>
+            <html.div style={[styles.square, styles.visibilityCollapse]} />
+            <html.div style={[styles.square, styles.visibilityHidden]} />
+            <html.div style={[styles.square, styles.visibilityVisible]} />
+          </html.div>
         </ExampleBlock>
-        <ExampleBlock title="Hover">
+
+        {/* variables & themes */}
+        <ExampleBlock title="CSS Variables & Theming">
+          <html.p style={styles.inheritedText}>Global variables</html.p>
+          <html.div style={styles.square} />
+
+          <html.p style={[themedTokens, styles.inheritedText]}>
+            Direct theming
+          </html.p>
+          <html.div style={[themedTokens, styles.square]} />
+
+          <html.div style={themedTokens}>
+            <html.p style={styles.inheritedText}>Inherit theming</html.p>
+            <html.div style={styles.square} />
+          </html.div>
+
+          <html.div style={themedTokens}>
+            <html.div style={themedTokensAlt}>
+              <html.p style={styles.inheritedText}>Nested theming</html.p>
+              <html.div style={styles.square} />
+            </html.div>
+          </html.div>
+        </ExampleBlock>
+
+        {/* hover */}
+        <ExampleBlock title="CSS :hover">
           <html.div style={styles.squareHover} />
+        </ExampleBlock>
+
+        {/* event emulation */}
+        <ExampleBlock title="DOM Events">
+          <html.input
+            onChange={(e) => {
+              console.log(e.type, e.target.value);
+            }}
+            onKeyDown={(e) => {
+              console.log(e.type, e.key);
+            }}
+            onInput={(e) => {
+              console.log(e.type, e.target.value);
+            }}
+          />
+          <html.textarea
+            onChange={(e) => {
+              console.log(e.type, e.target.value);
+            }}
+            onKeyDown={(e) => {
+              console.log(e.type, e.key);
+            }}
+            onInput={(e) => {
+              console.log(e.type, e.target.value);
+            }}
+          />
+          <html.div
+            onClick={(e) => {
+              setClickData((data) => ({
+                color: data.color === 'red' ? 'blue' : 'red',
+                text: 'click'
+              }));
+              setClickEventData({
+                altKey: e.altKey,
+                button: e.button,
+                ctrlKey: e.ctrlKey,
+                metaKey: e.metaKey,
+                pageX: e.pageX,
+                pageY: e.pageY,
+                shiftKey: e.shiftKey
+              });
+            }}
+            style={[styles.h100, styles.dynamicBg(clickData.color)]}
+          >
+            <html.span style={styles.bgWhite}>{clickData.text}</html.span>
+            <html.div style={styles.flex}>
+              <html.div style={styles.flexGrow}>
+                <html.div>
+                  <html.span>
+                    {clickEventData.altKey ? '✅' : '🚫'} altKey
+                  </html.span>
+                </html.div>
+                <html.div>
+                  <html.span>
+                    {clickEventData.ctrlKey ? '✅' : '🚫'} ctrlKey
+                  </html.span>
+                </html.div>
+                <html.div>
+                  <html.span>
+                    {clickEventData.metaKey ? '✅' : '🚫'} metaKey
+                  </html.span>
+                </html.div>
+                <html.div>
+                  <html.span>
+                    {clickEventData.shiftKey ? '✅' : '🚫'} shiftKey
+                  </html.span>
+                </html.div>
+              </html.div>
+              <html.div style={styles.flexGrow}>
+                <html.div>
+                  <html.span>button: {clickEventData.button}</html.span>
+                </html.div>
+                <html.div>
+                  <html.span>pageX: {clickEventData.pageX}</html.span>
+                </html.div>
+                <html.div>
+                  <html.span>pageY: {clickEventData.pageY}</html.span>
+                </html.div>
+              </html.div>
+            </html.div>
+          </html.div>
+
+          <html.img
+            onLoad={(e) => {
+              setImageLoadText(`${e.type}: loaded`);
+            }}
+            width={150}
+            height={150}
+            src="http://placehold.jp/150x150.png"
+            style={styles.objContain}
+          />
+          <html.span>{imageLoadText}</html.span>
+          <html.img
+            onError={(e) => {
+              setImageErrorText(`${e.type}: errored`);
+            }}
+            width={150}
+            height={150}
+            src="http://error"
+            style={styles.objContain}
+          />
+          <html.span>{imageErrorText}</html.span>
         </ExampleBlock>
       </html.div>
     </ScrollView>
@@ -671,5 +686,21 @@ const styles = css.create({
   },
   visibilityVisible: {
     visibility: 'visible'
+  },
+  lineHeightUnitless: {
+    lineHeight: 2,
+    borderWidth: 1,
+    borderColor: 'black',
+    borderStyle: 'solid'
+  },
+  lineHeightEm: {
+    lineHeight: '2em',
+    borderWidth: 1,
+    borderColor: 'black',
+    borderStyle: 'solid'
+  },
+  text: {
+    fontSize: '2em',
+    backgroundColor: 'rgba(255,0,0,0.25)'
   }
 });

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -272,6 +272,7 @@ exports[`properties: general line-height: rem 1`] = `
 exports[`properties: general line-height: unitless number 1`] = `
 {
   "style": {
+    "fontSize": 16,
     "lineHeight": 24,
   },
 }
@@ -280,6 +281,7 @@ exports[`properties: general line-height: unitless number 1`] = `
 exports[`properties: general line-height: unitless string 1`] = `
 {
   "style": {
+    "fontSize": 16,
     "lineHeight": 24,
   },
 }

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -1291,11 +1291,11 @@ exports[`html style polyfills default inherited text styles 1`] = `
           "color": "red",
           "direction": "rtl",
           "fontFamily": "Arial",
-          "fontSize": "1em",
+          "fontSize": 32,
           "fontStyle": "italic",
           "fontVariant": "variant",
           "fontWeight": "300",
-          "lineHeight": 1.6,
+          "lineHeight": 48,
           "position": "static",
           "textAlign": "right",
           "textTransform": "uppercase",
@@ -1303,7 +1303,29 @@ exports[`html style polyfills default inherited text styles 1`] = `
         }
       }
     >
-      Text should inherit div styles
+      Text should 
+      <Text
+        dir="auto"
+        style={
+          {
+            "color": "red",
+            "direction": "rtl",
+            "fontFamily": "Arial",
+            "fontSize": 64,
+            "fontStyle": "italic",
+            "fontVariant": "variant",
+            "fontWeight": "300",
+            "lineHeight": 96,
+            "position": "static",
+            "textAlign": "right",
+            "textTransform": "uppercase",
+            "userSelect": "auto",
+          }
+        }
+      >
+        inherit
+      </Text>
+       div styles
     </Text>
     <TextInput
       dir="auto"
@@ -1314,11 +1336,11 @@ exports[`html style polyfills default inherited text styles 1`] = `
           "color": "red",
           "direction": "rtl",
           "fontFamily": "Arial",
-          "fontSize": "1em",
+          "fontSize": 16,
           "fontStyle": "italic",
           "fontVariant": "variant",
           "fontWeight": "300",
-          "lineHeight": 1.6,
+          "lineHeight": 24,
           "position": "static",
           "textAlign": "right",
           "textTransform": "uppercase",

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -309,9 +309,11 @@ describe('properties: general', () => {
   test('line-height', () => {
     const styles = css.create({
       numeric: {
+        fontSize: 16,
         lineHeight: 1.5
       },
       string: {
+        fontSize: 16,
         lineHeight: '1.5'
       },
       rem: {

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -114,26 +114,39 @@ describe('html', () => {
     });
 
     test('default inherited text styles', () => {
-      const inheritableStyles = {
-        color: 'red',
-        cursor: 'pointer',
-        direction: 'rtl',
-        fontFamily: 'Arial',
-        fontSize: '1em',
-        fontStyle: 'italic',
-        fontVariant: 'variant',
-        fontWeight: 'bold',
-        letterSpace: '10px',
-        lineHeight: 1.6,
-        textAlign: 'right',
-        textIndent: '10px',
-        textTransform: 'uppercase',
-        whiteSpace: ''
-      };
+      const styles = css.create({
+        inheritable: {
+          color: 'red',
+          cursor: 'pointer',
+          direction: 'rtl',
+          fontFamily: 'Arial',
+          fontSize: '1em',
+          fontStyle: 'italic',
+          fontVariant: 'variant',
+          fontWeight: 'bold',
+          letterSpace: '10px',
+          lineHeight: 1.5,
+          textAlign: 'right',
+          textIndent: '10px',
+          textTransform: 'uppercase',
+          whiteSpace: 'pre'
+        },
+        alsoInheritable: {
+          fontWeight: 300
+        },
+        text: {
+          fontSize: '2em'
+        }
+      });
+      // This also tests that unitless line-height is correctly inherited, including
+      // through nested text elements.
       const root = create(
-        <html.div style={inheritableStyles}>
-          <html.div style={{ fontWeight: 300 }}>
-            <html.span>Text should inherit div styles</html.span>
+        <html.div style={styles.inheritable}>
+          <html.div style={styles.alsoInheritable}>
+            <html.span style={styles.text}>
+              Text should <html.span style={styles.text}>inherit</html.span> div
+              styles
+            </html.span>
             <html.input placeholder="Input should inherit div styles" />
           </html.div>
         </html.div>


### PR DESCRIPTION
When a unitless lineHeight is inherited, it multiples the value of the fontSize of the inheriting element. But when an em value is inherited, it multiples the value of the fontSize of the element it was originally applied to, not the one on the inheriting element.

This patch fixes the resolved values to match web's computed values, but React Native itself renders line-height differently from web, as you can see in these screenshots. Text elements have a semi-transparent red background. React Native changes the shape of the text element box when the line box size changes, and the line box of the parent text seems to grow to match the largest nested line box.

**Web**

<img width="354" alt="image" src="https://github.com/facebook/react-strict-dom/assets/239676/0ebd21bf-6365-4472-a60d-5886772a49da">

**Native**

<img width="423" alt="image" src="https://github.com/facebook/react-strict-dom/assets/239676/8d8e2238-f05e-406b-949f-430983c8a5a0">

