### PR TITLE
Adding regex handling for negative signs

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/CSSLengthUnitValue.js
+++ b/packages/react-strict-dom/src/native/stylex/CSSLengthUnitValue.js
@@ -9,7 +9,7 @@
 
 import type { SpreadOptions } from './SpreadOptions';
 
-const LENGTH_REGEX = /^([0-9]*[.]?[0-9]+)(em|px|rem|vh|vmax|vmin|vw)$/;
+const LENGTH_REGEX = /^(-?[0-9]*[.]?[0-9]+)(em|px|rem|vh|vmax|vmin|vw)$/;
 
 type CSSLengthUnitType = 'em' | 'px' | 'rem' | 'vh' | 'vmax' | 'vmin' | 'vw';
 
@@ -20,8 +20,10 @@ export class CSSLengthUnitValue {
     if (match == null) {
       return null;
     }
+
     const [, value, unit] = match;
     const parsedValue = parseFloat(value);
+
     // $FlowFixMe
     return [parsedValue, unit];
   }

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -1030,6 +1030,7 @@ exports[`units: length '0' is resolved to the number 0 1`] = `
 exports[`units: length 10 "em" units are resolved to pixels 1`] = `
 {
   "style": {
+    "height": -160,
     "width": 160,
   },
 }
@@ -1046,6 +1047,7 @@ exports[`units: length 10 "em" units based on inherited font-size 1`] = `
 exports[`units: length 10 "px" units are resolved to pixels 1`] = `
 {
   "style": {
+    "height": -10,
     "width": 10,
   },
 }
@@ -1054,6 +1056,7 @@ exports[`units: length 10 "px" units are resolved to pixels 1`] = `
 exports[`units: length 10 "rem" units are resolved to pixels 1`] = `
 {
   "style": {
+    "height": -160,
     "width": 160,
   },
 }
@@ -1062,6 +1065,7 @@ exports[`units: length 10 "rem" units are resolved to pixels 1`] = `
 exports[`units: length 10 "vh" units are resolved to pixels 1`] = `
 {
   "style": {
+    "height": -60,
     "width": 60,
   },
 }
@@ -1070,6 +1074,7 @@ exports[`units: length 10 "vh" units are resolved to pixels 1`] = `
 exports[`units: length 10 "vmax" units are resolved to pixels 1`] = `
 {
   "style": {
+    "height": -60,
     "width": 60,
   },
 }
@@ -1078,6 +1083,7 @@ exports[`units: length 10 "vmax" units are resolved to pixels 1`] = `
 exports[`units: length 10 "vmin" units are resolved to pixels 1`] = `
 {
   "style": {
+    "height": -32,
     "width": 32,
   },
 }
@@ -1086,6 +1092,7 @@ exports[`units: length 10 "vmin" units are resolved to pixels 1`] = `
 exports[`units: length 10 "vw" units are resolved to pixels 1`] = `
 {
   "style": {
+    "height": -32,
     "width": 32,
   },
 }

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -1402,11 +1402,13 @@ describe('styles: pseudo-element', () => {
 describe('units: length', () => {
   const unitsToTest = ['em', 'px', 'rem', 'vh', 'vmax', 'vmin', 'vw'];
   const value = 10;
+  const negativeValue = -1 * value;
 
   for (const unitToTest of unitsToTest) {
     test(`${value} "${unitToTest}" units are resolved to pixels`, () => {
       const styles = css.create({
         underTest: {
+          height: `${negativeValue}${unitToTest}`,
           width: `${value}${unitToTest}`
         }
       });


### PR DESCRIPTION
## Context
Add parsing for signage in string length unit values:
- Adding parsing for (+/-) signs
- Multiplying parsed float by -1 if sign = "-"
- Updated tests and snapshots

## Testing
Modifying tests to account for positive and negative signs 

Ran `npm run jest /packages/react-strict-dom/tests/css-test.native.js`
