### PR TITLE
fix: use `monospace` as default font-family for `code` instead of unsupported `Courier`

### DIFF
--- a/packages/react-strict-dom/src/native/html.js
+++ b/packages/react-strict-dom/src/native/html.js
@@ -46,7 +46,7 @@ const styles = stylex.create({
     borderWidth: 1
   },
   code: {
-    fontFamily: Platform.select({ ios: 'Menlo', default: 'Courier' })
+    fontFamily: Platform.select({ ios: 'Menlo', default: 'monospace' })
   },
   heading: {
     fontSize: '1.5rem',


### PR DESCRIPTION
### Summary

This PR fixes the next error by using `monospace`.

![image](https://github.com/facebook/react-strict-dom/assets/20761166/bc615ac6-95ba-4749-beab-7d3bb19e199b)


### Test plan

1. Open the app on `android`
2. See the error above
3. Apply this change
4. See the applied font

