### PR TITLE
Feat: polyfill CSS `placeContent` support on native

### DIFF
--- a/packages/eslint-plugin/src/valid-styles.js
+++ b/packages/eslint-plugin/src/valid-styles.js
@@ -151,6 +151,7 @@ const allowlistedStylexProps = new Set([
   'paddingTop',
   'pointerEvents',
   'position',
+  'placeContent',
   'right',
   'textAlign',
   'textDecorationColor',

--- a/packages/react-strict-dom/COMPATIBILITY.md
+++ b/packages/react-strict-dom/COMPATIBILITY.md
@@ -602,7 +602,7 @@ Note these APIs can only be accessed using `Node.getRootNode().defaultView`, in 
 | paddingLeft | ✅ | ✅ | |
 | pointerRight | ✅ | ✅ | |
 | pointerTop | ✅ | ✅ | |
-| placeContent | ❌ | ❌ | |
+| placeContent | 🟡 | 🟡 | |
 | placeItems | ❌ | ❌ | |
 | placeSelf | ❌ | ❌ | |
 | pointerEvents | ✅ | ✅ | |

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -660,61 +660,41 @@ export function props(
           continue;
         }
 
-        switch (align) {
-          case 'center':
-            flatStyle.alignContent = 'center';
-            break;
-          case 'start':
-          case 'flex-start': // This value is treated like `start`
+        const commonValidProps = [
+          'end',
+          'start',
+          'center',
+          'flex-end', // This value is treated like `end`
+          'flex-start', // This value is treated like `start`
+          'space-evenly',
+          'space-around',
+          'space-between'
+        ];
+
+        if (commonValidProps.includes(align) || align === 'stretch') {
+          if (align.endsWith('start')) {
             flatStyle.alignContent = 'flex-start';
-            break;
-          case 'end':
-          case 'flex-end': // This value is treated like `end`
+          } else if (align.endsWith('end')) {
             flatStyle.alignContent = 'flex-end';
-            break;
-          case 'space-evenly':
-            flatStyle.alignContent = 'space-evenly';
-            break;
-          case 'space-between':
-            flatStyle.alignContent = 'space-between';
-            break;
-          case 'space-around':
-            flatStyle.alignContent = 'space-around';
-            break;
-          case 'stretch':
-            flatStyle.alignContent = 'stretch';
-            break;
-          default:
-            warnMsg(
-              `unsupported "${styleProp}" style property value "${align}"`
-            );
+          } else {
+            flatStyle.alignContent = align;
+          }
+        } else {
+          warnMsg(`unsupported "${styleProp}" style property value "${align}"`);
         }
 
-        switch (justify) {
-          case 'center':
-            flatStyle.justifyContent = 'center';
-            break;
-          case 'start':
-          case 'flex-start': // This value is treated like `start`
+        if (commonValidProps.includes(justify)) {
+          if (justify.endsWith('start')) {
             flatStyle.justifyContent = 'flex-start';
-            break;
-          case 'end':
-          case 'flex-end': // This value is treated like `end`
+          } else if (justify.endsWith('end')) {
             flatStyle.justifyContent = 'flex-end';
-            break;
-          case 'space-evenly':
-            flatStyle.justifyContent = 'space-evenly';
-            break;
-          case 'space-between':
-            flatStyle.justifyContent = 'space-between';
-            break;
-          case 'space-around':
-            flatStyle.justifyContent = 'space-around';
-            break;
-          default:
-            warnMsg(
-              `unsupported "${styleProp}" style property value "${justify}"`
-            );
+          } else {
+            flatStyle.justifyContent = justify;
+          }
+        } else {
+          warnMsg(
+            `unsupported "${styleProp}" style property value "${justify}"`
+          );
         }
       }
       // everything else

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -620,80 +620,21 @@ export function props(
       }
       // placeContent polyfill
       else if (styleProp === 'placeContent' && typeof styleValue === 'string') {
-        let align = '';
-        let justify = '';
-        const shorthands = styleValue.split(' ');
-
-        // .1 place-content = <'align-content'> <'justify-content'>?
-        if (shorthands.length === 2) {
-          align = shorthands[0];
-          justify = shorthands[1];
-        } else if (shorthands.length === 3) {
-          // .1.1 The fallback alignment for `first baseline` is `start`
-          // See: https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#baseline
-          if (shorthands[0] === 'first' && shorthands[1] === 'baseline') {
-            align = 'flex-start';
-          }
-          // 1.2 The fallback alignment for `last baseline` is `end`
-          // See: https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#baseline
-          else if (shorthands[0] === 'last' && shorthands[1] === 'baseline') {
-            align = 'flex-end';
-          } else {
-            warnMsg(
-              `invalid "${styleProp}" style property value "${styleValue}"`
-            );
-          }
-
-          justify = shorthands[2];
-        }
-        // .1.3 If the second value is not present, the first value is used for both,
-        // provided it is a valid value for both. If it is invalid for one or the other, the whole value will be invalid.
-        // See: https://developer.mozilla.org/en-US/docs/Web/CSS/place-content
-        else if (shorthands.length === 1) {
-          align = shorthands[0];
-          justify = align;
-        } else {
-          warnMsg(
-            `invalid "${styleProp}" style property value "${styleValue}"`
-          );
-          delete flatStyle[styleProp];
-          continue;
-        }
-
-        const commonValidProps = [
-          'end',
-          'start',
+        const supportedValues = [
           'center',
-          'flex-end', // This value is treated like `end`
-          'flex-start', // This value is treated like `start`
+          'flex-end',
+          'flex-start',
           'space-evenly',
           'space-around',
           'space-between'
         ];
 
-        if (commonValidProps.includes(align) || align === 'stretch') {
-          if (align.endsWith('start')) {
-            flatStyle.alignContent = 'flex-start';
-          } else if (align.endsWith('end')) {
-            flatStyle.alignContent = 'flex-end';
-          } else {
-            flatStyle.alignContent = align;
-          }
-        } else {
-          warnMsg(`unsupported "${styleProp}" style property value "${align}"`);
-        }
-
-        if (commonValidProps.includes(justify)) {
-          if (justify.endsWith('start')) {
-            flatStyle.justifyContent = 'flex-start';
-          } else if (justify.endsWith('end')) {
-            flatStyle.justifyContent = 'flex-end';
-          } else {
-            flatStyle.justifyContent = justify;
-          }
+        if (supportedValues.includes(styleValue)) {
+          flatStyle.alignContent = styleValue;
+          flatStyle.justifyContent = styleValue;
         } else {
           warnMsg(
-            `unsupported "${styleProp}" style property value "${justify}"`
+            `unsupported "${styleProp}" style property value "${styleValue}"`
           );
         }
       }

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -618,6 +618,105 @@ export function props(
           nativeProps.tabIndex = -1;
         }
       }
+      // placeContent polyfill
+      else if (styleProp === 'placeContent' && typeof styleValue === 'string') {
+        let align = '';
+        let justify = '';
+        const shorthands = styleValue.split(' ');
+
+        // .1 place-content = <'align-content'> <'justify-content'>?
+        if (shorthands.length === 2) {
+          align = shorthands[0];
+          justify = shorthands[1];
+        } else if (shorthands.length === 3) {
+          // .1.1 The fallback alignment for `first baseline` is `start`
+          // See: https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#baseline
+          if (shorthands[0] === 'first' && shorthands[1] === 'baseline') {
+            align = 'flex-start';
+          }
+          // 1.2 The fallback alignment for `last baseline` is `end`
+          // See: https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#baseline
+          else if (shorthands[0] === 'last' && shorthands[1] === 'baseline') {
+            align = 'flex-end';
+          } else {
+            warnMsg(
+              `invalid "${styleProp}" style property value "${styleValue}"`
+            );
+          }
+
+          justify = shorthands[2];
+        }
+        // .1.3 If the second value is not present, the first value is used for both,
+        // provided it is a valid value for both. If it is invalid for one or the other, the whole value will be invalid.
+        // See: https://developer.mozilla.org/en-US/docs/Web/CSS/place-content
+        else if (shorthands.length === 1) {
+          align = shorthands[0];
+          justify = align;
+        } else {
+          warnMsg(
+            `invalid "${styleProp}" style property value "${styleValue}"`
+          );
+          delete flatStyle[styleProp];
+          continue;
+        }
+
+        switch (align) {
+          case 'center':
+            flatStyle.alignContent = 'center';
+            break;
+          case 'start':
+          case 'flex-start': // This value is treated like `start`
+            flatStyle.alignContent = 'flex-start';
+            break;
+          case 'end':
+          case 'flex-end': // This value is treated like `end`
+            flatStyle.alignContent = 'flex-end';
+            break;
+          case 'space-evenly':
+            flatStyle.alignContent = 'space-evenly';
+            break;
+          case 'space-between':
+            flatStyle.alignContent = 'space-between';
+            break;
+          case 'space-around':
+            flatStyle.alignContent = 'space-around';
+            break;
+          case 'stretch':
+            flatStyle.alignContent = 'stretch';
+            break;
+          default:
+            warnMsg(
+              `unsupported "${styleProp}" style property value "${align}"`
+            );
+        }
+
+        switch (justify) {
+          case 'center':
+            flatStyle.justifyContent = 'center';
+            break;
+          case 'start':
+          case 'flex-start': // This value is treated like `start`
+            flatStyle.justifyContent = 'flex-start';
+            break;
+          case 'end':
+          case 'flex-end': // This value is treated like `end`
+            flatStyle.justifyContent = 'flex-end';
+            break;
+          case 'space-evenly':
+            flatStyle.justifyContent = 'space-evenly';
+            break;
+          case 'space-between':
+            flatStyle.justifyContent = 'space-between';
+            break;
+          case 'space-around':
+            flatStyle.justifyContent = 'space-around';
+            break;
+          default:
+            warnMsg(
+              `unsupported "${styleProp}" style property value "${justify}"`
+            );
+        }
+      }
       // everything else
       else {
         warnMsg(`unsupported style property "${styleProp}"`);

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -1,59 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CSS shorthand property: place-content invalid: "baseline" 1`] = `
+exports[`CSS shorthand property: place-content invalid: "multiple values" 1`] = `{}`;
+
+exports[`CSS shorthand property: place-content invalid: "stretch" on justify-content 1`] = `{}`;
+
+exports[`CSS shorthand property: place-content: valid: center 1`] = `
 {
   "style": {
+    "alignContent": "center",
     "justifyContent": "center",
   },
 }
 `;
 
-exports[`CSS shorthand property: place-content invalid: "left" on align-content 1`] = `
-{
-  "style": {
-    "justifyContent": "center",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content invalid: "right" on align-content 1`] = `{}`;
-
-exports[`CSS shorthand property: place-content invalid: "stretch" on justify-content 1`] = `
-{
-  "style": {
-    "alignContent": "stretch",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: center end 1`] = `
-{
-  "style": {
-    "alignContent": "center",
-    "justifyContent": "flex-end",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: center flex-start 1`] = `
-{
-  "style": {
-    "alignContent": "center",
-    "justifyContent": "flex-start",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: center space-evenly 1`] = `
-{
-  "style": {
-    "alignContent": "center",
-    "justifyContent": "space-evenly",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: end 1`] = `
+exports[`CSS shorthand property: place-content: valid: flex-end 1`] = `
 {
   "style": {
     "alignContent": "flex-end",
@@ -62,47 +22,11 @@ exports[`CSS shorthand property: place-content: valid: end 1`] = `
 }
 `;
 
-exports[`CSS shorthand property: place-content: valid: end center 1`] = `
-{
-  "style": {
-    "alignContent": "flex-end",
-    "justifyContent": "center",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: end space-around 1`] = `
-{
-  "style": {
-    "alignContent": "flex-end",
-    "justifyContent": "space-around",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: end space-between 1`] = `
-{
-  "style": {
-    "alignContent": "flex-end",
-    "justifyContent": "space-between",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: end space-evenly 1`] = `
-{
-  "style": {
-    "alignContent": "flex-end",
-    "justifyContent": "space-evenly",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: first baseline space-evenly 1`] = `
+exports[`CSS shorthand property: place-content: valid: flex-start 1`] = `
 {
   "style": {
     "alignContent": "flex-start",
-    "justifyContent": "space-evenly",
+    "justifyContent": "flex-start",
   },
 }
 `;
@@ -112,15 +36,6 @@ exports[`CSS shorthand property: place-content: valid: space-around 1`] = `
   "style": {
     "alignContent": "space-around",
     "justifyContent": "space-around",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: space-around start 1`] = `
-{
-  "style": {
-    "alignContent": "space-around",
-    "justifyContent": "flex-start",
   },
 }
 `;
@@ -139,60 +54,6 @@ exports[`CSS shorthand property: place-content: valid: space-evenly 1`] = `
   "style": {
     "alignContent": "space-evenly",
     "justifyContent": "space-evenly",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: space-evenly center 1`] = `
-{
-  "style": {
-    "alignContent": "space-evenly",
-    "justifyContent": "center",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: start center 1`] = `
-{
-  "style": {
-    "alignContent": "flex-start",
-    "justifyContent": "center",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: start end 1`] = `
-{
-  "style": {
-    "alignContent": "flex-start",
-    "justifyContent": "flex-end",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: start space-evenly 1`] = `
-{
-  "style": {
-    "alignContent": "flex-start",
-    "justifyContent": "space-evenly",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: start start 1`] = `
-{
-  "style": {
-    "alignContent": "flex-start",
-    "justifyContent": "flex-start",
-  },
-}
-`;
-
-exports[`CSS shorthand property: place-content: valid: stretch center 1`] = `
-{
-  "style": {
-    "alignContent": "stretch",
-    "justifyContent": "center",
   },
 }
 `;

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -1,5 +1,202 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CSS shorthand property: place-content invalid: "baseline" 1`] = `
+{
+  "style": {
+    "justifyContent": "center",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content invalid: "left" on align-content 1`] = `
+{
+  "style": {
+    "justifyContent": "center",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content invalid: "right" on align-content 1`] = `{}`;
+
+exports[`CSS shorthand property: place-content invalid: "stretch" on justify-content 1`] = `
+{
+  "style": {
+    "alignContent": "stretch",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: center end 1`] = `
+{
+  "style": {
+    "alignContent": "center",
+    "justifyContent": "flex-end",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: center flex-start 1`] = `
+{
+  "style": {
+    "alignContent": "center",
+    "justifyContent": "flex-start",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: center space-evenly 1`] = `
+{
+  "style": {
+    "alignContent": "center",
+    "justifyContent": "space-evenly",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: end 1`] = `
+{
+  "style": {
+    "alignContent": "flex-end",
+    "justifyContent": "flex-end",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: end center 1`] = `
+{
+  "style": {
+    "alignContent": "flex-end",
+    "justifyContent": "center",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: end space-around 1`] = `
+{
+  "style": {
+    "alignContent": "flex-end",
+    "justifyContent": "space-around",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: end space-between 1`] = `
+{
+  "style": {
+    "alignContent": "flex-end",
+    "justifyContent": "space-between",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: end space-evenly 1`] = `
+{
+  "style": {
+    "alignContent": "flex-end",
+    "justifyContent": "space-evenly",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: first baseline space-evenly 1`] = `
+{
+  "style": {
+    "alignContent": "flex-start",
+    "justifyContent": "space-evenly",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: space-around 1`] = `
+{
+  "style": {
+    "alignContent": "space-around",
+    "justifyContent": "space-around",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: space-around start 1`] = `
+{
+  "style": {
+    "alignContent": "space-around",
+    "justifyContent": "flex-start",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: space-between 1`] = `
+{
+  "style": {
+    "alignContent": "space-between",
+    "justifyContent": "space-between",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: space-evenly 1`] = `
+{
+  "style": {
+    "alignContent": "space-evenly",
+    "justifyContent": "space-evenly",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: space-evenly center 1`] = `
+{
+  "style": {
+    "alignContent": "space-evenly",
+    "justifyContent": "center",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: start center 1`] = `
+{
+  "style": {
+    "alignContent": "flex-start",
+    "justifyContent": "center",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: start end 1`] = `
+{
+  "style": {
+    "alignContent": "flex-start",
+    "justifyContent": "flex-end",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: start space-evenly 1`] = `
+{
+  "style": {
+    "alignContent": "flex-start",
+    "justifyContent": "space-evenly",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: start start 1`] = `
+{
+  "style": {
+    "alignContent": "flex-start",
+    "justifyContent": "flex-start",
+  },
+}
+`;
+
+exports[`CSS shorthand property: place-content: valid: stretch center 1`] = `
+{
+  "style": {
+    "alignContent": "stretch",
+    "justifyContent": "center",
+  },
+}
+`;
+
 exports[`properties: custom property css.createTheme: css.__customProperties 1`] = `
 {
   "rootColor__id__1": "red",

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -1532,3 +1532,163 @@ describe('queries: @media', () => {
     });
   });
 });
+
+/**
+ * CSS shorthand property: placeContent
+ */
+
+describe('CSS shorthand property:', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn');
+    console.warn.mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.warn.mockRestore();
+  });
+
+  test('place-content: valid', () => {
+    const styles = css.create({
+      case1: { placeContent: 'end space-between' },
+      case2: { placeContent: 'space-around start' },
+      case3: { placeContent: 'start space-evenly' },
+      case4: { placeContent: 'end center' },
+      case5: { placeContent: 'end' },
+      case6: { placeContent: 'first baseline space-evenly' },
+      case7: { placeContent: 'space-between' },
+      case8: { placeContent: 'space-around' },
+      case9: { placeContent: 'space-evenly' },
+      case10: { placeContent: 'stretch center' },
+      case11: { placeContent: 'start start' },
+      case12: { placeContent: 'start end' },
+      case13: { placeContent: 'start center' },
+      case14: { placeContent: 'end space-around' },
+      case15: { placeContent: 'center end' },
+      case16: { placeContent: 'center space-evenly' },
+      case17: { placeContent: 'center flex-start' },
+      case18: { placeContent: 'end space-evenly' },
+      case19: { placeContent: 'space-evenly center' }
+    });
+    expect(css.props.call(mockOptions, styles.case1)).toMatchSnapshot(
+      'end space-between'
+    );
+    expect(css.props.call(mockOptions, styles.case2)).toMatchSnapshot(
+      'space-around start'
+    );
+    expect(css.props.call(mockOptions, styles.case3)).toMatchSnapshot(
+      'start space-evenly'
+    );
+    expect(css.props.call(mockOptions, styles.case4)).toMatchSnapshot(
+      'end center'
+    );
+    expect(css.props.call(mockOptions, styles.case5)).toMatchSnapshot('end');
+    expect(css.props.call(mockOptions, styles.case6)).toMatchSnapshot(
+      'first baseline space-evenly'
+    );
+    expect(css.props.call(mockOptions, styles.case7)).toMatchSnapshot(
+      'space-between'
+    );
+    expect(css.props.call(mockOptions, styles.case8)).toMatchSnapshot(
+      'space-around'
+    );
+    expect(css.props.call(mockOptions, styles.case9)).toMatchSnapshot(
+      'space-evenly'
+    );
+    expect(css.props.call(mockOptions, styles.case10)).toMatchSnapshot(
+      'stretch center'
+    );
+    expect(css.props.call(mockOptions, styles.case11)).toMatchSnapshot(
+      'start start'
+    );
+    expect(css.props.call(mockOptions, styles.case12)).toMatchSnapshot(
+      'start end'
+    );
+    expect(css.props.call(mockOptions, styles.case13)).toMatchSnapshot(
+      'start center'
+    );
+    expect(css.props.call(mockOptions, styles.case14)).toMatchSnapshot(
+      'end space-around'
+    );
+    expect(css.props.call(mockOptions, styles.case15)).toMatchSnapshot(
+      'center end'
+    );
+    expect(css.props.call(mockOptions, styles.case16)).toMatchSnapshot(
+      'center space-evenly'
+    );
+    expect(css.props.call(mockOptions, styles.case17)).toMatchSnapshot(
+      'center flex-start'
+    );
+    expect(css.props.call(mockOptions, styles.case18)).toMatchSnapshot(
+      'end space-evenly'
+    );
+    expect(css.props.call(mockOptions, styles.case19)).toMatchSnapshot(
+      'space-evenly center'
+    );
+  });
+
+  /* justify-content does not take baseline values */
+  // https://reactnative.dev/docs/next/flexbox#align-content
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#syntax
+  test('place-content invalid: "baseline"', () => {
+    const styles = css.create({
+      case: {
+        placeContent: 'baseline center'
+      }
+    });
+    expect(css.props.call(mockOptions, styles.case)).toMatchSnapshot();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'unsupported "placeContent" style property value "baseline"'
+      )
+    );
+  });
+
+  /* align-content does not take left and right values */
+  // https://reactnative.dev/docs/next/flexbox#align-content
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#syntax
+  test('place-content invalid: "left" on align-content', () => {
+    const styles = css.create({
+      case: {
+        placeContent: 'left center'
+      }
+    });
+    expect(css.props.call(mockOptions, styles.case)).toMatchSnapshot();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'unsupported "placeContent" style property value "left"'
+      )
+    );
+  });
+
+  /* align-content does not take left and right values */
+  // https://reactnative.dev/docs/next/flexbox#align-content
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#syntax
+  test('place-content invalid: "right" on align-content', () => {
+    const styles = css.create({
+      case: {
+        placeContent: 'right stretch'
+      }
+    });
+    expect(css.props.call(mockOptions, styles.case)).toMatchSnapshot();
+
+    expect(console.warn).toHaveBeenCalledTimes(2);
+  });
+
+  // https://reactnative.dev/docs/next/flexbox#justify-content
+  test('place-content invalid: "stretch" on justify-content', () => {
+    const styles = css.create({
+      case: {
+        placeContent: 'stretch'
+      }
+    });
+    expect(css.props.call(mockOptions, styles.case)).toMatchSnapshot();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'unsupported "placeContent" style property value "stretch"'
+      )
+    );
+  });
+});

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -1549,145 +1549,55 @@ describe('CSS shorthand property:', () => {
 
   test('place-content: valid', () => {
     const styles = css.create({
-      case1: { placeContent: 'end space-between' },
-      case2: { placeContent: 'space-around start' },
-      case3: { placeContent: 'start space-evenly' },
-      case4: { placeContent: 'end center' },
-      case5: { placeContent: 'end' },
-      case6: { placeContent: 'first baseline space-evenly' },
-      case7: { placeContent: 'space-between' },
-      case8: { placeContent: 'space-around' },
-      case9: { placeContent: 'space-evenly' },
-      case10: { placeContent: 'stretch center' },
-      case11: { placeContent: 'start start' },
-      case12: { placeContent: 'start end' },
-      case13: { placeContent: 'start center' },
-      case14: { placeContent: 'end space-around' },
-      case15: { placeContent: 'center end' },
-      case16: { placeContent: 'center space-evenly' },
-      case17: { placeContent: 'center flex-start' },
-      case18: { placeContent: 'end space-evenly' },
-      case19: { placeContent: 'space-evenly center' }
+      case1: { placeContent: 'flex-start' },
+      case2: { placeContent: 'flex-end' },
+      case3: { placeContent: 'center' },
+      case4: { placeContent: 'space-between' },
+      case5: { placeContent: 'space-around' },
+      case6: { placeContent: 'space-evenly' }
     });
     expect(css.props.call(mockOptions, styles.case1)).toMatchSnapshot(
-      'end space-between'
+      'flex-start'
     );
     expect(css.props.call(mockOptions, styles.case2)).toMatchSnapshot(
-      'space-around start'
+      'flex-end'
     );
-    expect(css.props.call(mockOptions, styles.case3)).toMatchSnapshot(
-      'start space-evenly'
-    );
+    expect(css.props.call(mockOptions, styles.case3)).toMatchSnapshot('center');
     expect(css.props.call(mockOptions, styles.case4)).toMatchSnapshot(
-      'end center'
-    );
-    expect(css.props.call(mockOptions, styles.case5)).toMatchSnapshot('end');
-    expect(css.props.call(mockOptions, styles.case6)).toMatchSnapshot(
-      'first baseline space-evenly'
-    );
-    expect(css.props.call(mockOptions, styles.case7)).toMatchSnapshot(
       'space-between'
     );
-    expect(css.props.call(mockOptions, styles.case8)).toMatchSnapshot(
+    expect(css.props.call(mockOptions, styles.case5)).toMatchSnapshot(
       'space-around'
     );
-    expect(css.props.call(mockOptions, styles.case9)).toMatchSnapshot(
+    expect(css.props.call(mockOptions, styles.case6)).toMatchSnapshot(
       'space-evenly'
     );
-    expect(css.props.call(mockOptions, styles.case10)).toMatchSnapshot(
-      'stretch center'
-    );
-    expect(css.props.call(mockOptions, styles.case11)).toMatchSnapshot(
-      'start start'
-    );
-    expect(css.props.call(mockOptions, styles.case12)).toMatchSnapshot(
-      'start end'
-    );
-    expect(css.props.call(mockOptions, styles.case13)).toMatchSnapshot(
-      'start center'
-    );
-    expect(css.props.call(mockOptions, styles.case14)).toMatchSnapshot(
-      'end space-around'
-    );
-    expect(css.props.call(mockOptions, styles.case15)).toMatchSnapshot(
-      'center end'
-    );
-    expect(css.props.call(mockOptions, styles.case16)).toMatchSnapshot(
-      'center space-evenly'
-    );
-    expect(css.props.call(mockOptions, styles.case17)).toMatchSnapshot(
-      'center flex-start'
-    );
-    expect(css.props.call(mockOptions, styles.case18)).toMatchSnapshot(
-      'end space-evenly'
-    );
-    expect(css.props.call(mockOptions, styles.case19)).toMatchSnapshot(
-      'space-evenly center'
-    );
   });
 
-  /* justify-content does not take baseline values */
-  // https://reactnative.dev/docs/next/flexbox#align-content
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#syntax
-  test('place-content invalid: "baseline"', () => {
-    const styles = css.create({
-      case: {
-        placeContent: 'baseline center'
-      }
-    });
-    expect(css.props.call(mockOptions, styles.case)).toMatchSnapshot();
-
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'unsupported "placeContent" style property value "baseline"'
-      )
-    );
-  });
-
-  /* align-content does not take left and right values */
-  // https://reactnative.dev/docs/next/flexbox#align-content
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#syntax
-  test('place-content invalid: "left" on align-content', () => {
-    const styles = css.create({
-      case: {
-        placeContent: 'left center'
-      }
-    });
-    expect(css.props.call(mockOptions, styles.case)).toMatchSnapshot();
-
-    expect(console.warn).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'unsupported "placeContent" style property value "left"'
-      )
-    );
-  });
-
-  /* align-content does not take left and right values */
-  // https://reactnative.dev/docs/next/flexbox#align-content
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/place-content#syntax
-  test('place-content invalid: "right" on align-content', () => {
-    const styles = css.create({
-      case: {
-        placeContent: 'right stretch'
-      }
-    });
-    expect(css.props.call(mockOptions, styles.case)).toMatchSnapshot();
-
-    expect(console.warn).toHaveBeenCalledTimes(2);
-  });
-
+  // justifyContent doesn't support `stretch`
   // https://reactnative.dev/docs/next/flexbox#justify-content
   test('place-content invalid: "stretch" on justify-content', () => {
     const styles = css.create({
-      case: {
-        placeContent: 'stretch'
-      }
+      case: { placeContent: 'stretch' }
     });
     expect(css.props.call(mockOptions, styles.case)).toMatchSnapshot();
 
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining(
         'unsupported "placeContent" style property value "stretch"'
+      )
+    );
+  });
+
+  test('place-content invalid: "multiple values"', () => {
+    const styles = css.create({
+      case: { placeContent: 'flex-start center' }
+    });
+    expect(css.props.call(mockOptions, styles.case)).toMatchSnapshot();
+
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'unsupported "placeContent" style property value "flex-start center"'
       )
     );
   });


### PR DESCRIPTION
### Summary
This PR adds the polyfill for [`placeContent`](https://developer.mozilla.org/en-US/docs/Web/CSS/place-content)

### Test plan

EDIT:  We only support single values that are common to both properties (alignContent, justifyContent)

