### PR TITLE
Polyfill CSS caretColor support on native android

### DIFF
--- a/packages/eslint-plugin/src/valid-styles.js
+++ b/packages/eslint-plugin/src/valid-styles.js
@@ -78,6 +78,7 @@ const allowlistedStylexProps = new Set([
   'boxShadow', // web-only
   'boxSizing',
   'clipPath', // web-only
+  'caretColor', // web-only
   'color',
   'cursor', // web-only
   'direction', // web-only

--- a/packages/react-strict-dom/COMPATIBILITY.md
+++ b/packages/react-strict-dom/COMPATIBILITY.md
@@ -503,7 +503,7 @@ Note these APIs can only be accessed using `Node.getRootNode().defaultView`, in 
 | boxSizing | 🟡 Partial | 🟡 Partial | |
 | brightness() | ❌ | ❌ | |
 | calc() | ❌ | ❌ | |
-| caretColor | ❌ | ❌ | |
+| caretColor | 🟡 | ❌ | |
 | clamp() | ❌ | ❌ | |
 | clipPath | ❌ | ❌ | |
 | color | ✅ | ✅ | |

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -591,7 +591,6 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       // This is where we hack in a shim for `transitionProperty`,
       // `transitionDuration`, `transitionDelay`, `transitionTimingFunction`.
       const {
-        caretColor,
         transitionDelay,
         transitionDuration,
         transitionProperty,
@@ -620,15 +619,11 @@ export function createStrictDOMComponent<T, P: StrictProps>(
           : null
       });
 
-      delete styleProps.style.caretColor;
       delete styleProps.style.transitionDelay;
       delete styleProps.style.transitionDuration;
       delete styleProps.style.transitionProperty;
       delete styleProps.style.transitionTimingFunction;
 
-      if (caretColor === 'transparent' && nativeComponent === TextInput) {
-        nativeProps.caretHidden = true;
-      }
       if (animatedPropertyValues.length > 0) {
         for (const animatedProperty of animatedPropertyValues) {
           // $FlowFixMe[incompatible-type]

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -21,7 +21,6 @@ type StyleOptions = {
 };
 
 const passthroughProperties = [
-  'caretColor',
   'transitionDelay',
   'transitionDuration',
   'transitionProperty',

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -664,6 +664,26 @@ export function props(
           );
         }
       }
+      // caretColor polyfill
+      else if (styleProp === 'caretColor') {
+        nativeProps.cursorColor = styleValue;
+        if (styleValue === 'transparent') {
+          nativeProps.caretHidden = true;
+        } else if (
+          typeof styleValue === 'undefined' ||
+          // None of these values are supported in RN
+          styleValue === 'auto' ||
+          styleValue === 'inherit' ||
+          styleValue === 'initial' ||
+          styleValue === 'currentcolor' ||
+          styleValue === 'unset'
+        ) {
+          warnMsg(
+            `unsupported style value in "caretColor:${String(styleValue)}"`
+          );
+          delete nativeProps['cursorColor'];
+        }
+      }
       // everything else
       else {
         warnMsg(`unsupported style property "${styleProp}"`);

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -966,9 +966,23 @@ exports[`<html.*> prop polyfills global "tabIndex" prop 1`] = `
 />
 `;
 
+exports[`<html.*> style polyfills "caretColor" red 1`] = `
+<TextInput
+  cursorColor="red"
+  dir="auto"
+  style={
+    {
+      "borderWidth": 1,
+      "position": "static",
+    }
+  }
+/>
+`;
+
 exports[`<html.*> style polyfills "caretColor" transparent 1`] = `
 <TextInput
   caretHidden={true}
+  cursorColor="transparent"
   dir="auto"
   style={
     {

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -162,6 +162,20 @@ describe('<html.*>', () => {
       expect(root.toJSON()).toMatchSnapshot();
     });
 
+    test('"caretColor" red', () => {
+      const root = create(<html.input style={{ caretColor: 'red' }} />);
+      expect(root.toJSON()).toMatchSnapshot();
+    });
+
+    test('"caretColor" on unsupported values', () => {
+      create(<html.input style={{ caretColor: 'inherit' }} />);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'unsupported style value in "caretColor:inherit"'
+        )
+      );
+    });
+
     test('"transition" properties ', () => {
       const { Easing } = require('react-native');
 


### PR DESCRIPTION
### Summary

As the title says, this PR uses the [cursorColor](https://reactnative.dev/docs/next/textinput#cursorcolor-android) on `android` to polyfill `caretColor`

#### Test plan
I've added two tests