### PR TITLE
Fixing the strong tag font weight handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "fmt:report": "prettier --check \"**/*.js\" --ignore-path ./configs/.prettierignore",
     "jest": "jest --config ./configs/jest.config.js",
     "jest:report": "npm run jest",
+    "jest:update": "jest --config ./configs/jest.config.js -u",
     "lint": "npm run lint:report -- --fix",
     "lint:report": "eslint packages --config ./configs/.eslintrc",
     "test": "npm run flow && npm run lint:report && npm run jest:report",

--- a/packages/react-strict-dom/src/dom/runtime.js
+++ b/packages/react-strict-dom/src/dom/runtime.js
@@ -71,7 +71,7 @@ const styles = stylex.create({
     borderStyle: 'solid'
   },
   strong: {
-    fontWeight: 'bolder'
+    fontWeight: 'bold'
   },
   textarea: {
     borderWidth: 1,

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-dom
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-dom
@@ -5352,7 +5352,7 @@ exports[`html "span" supports inline event handlers 1`] = `
 
 exports[`html "strong" ignores and warns about unsupported attributes 1`] = `
 <strong
-  className="html-strong x1q9hu08 xttmgf0 x1hl2dhg x16tdsg8 x1vvkbs xjs9k72"
+  className="html-strong x1q9hu08 xttmgf0 x1hl2dhg x16tdsg8 x1vvkbs x117nqv4"
 />
 `;
 
@@ -5407,7 +5407,7 @@ exports[`html "strong" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-strong x1q9hu08 xttmgf0 x1hl2dhg x16tdsg8 x1vvkbs xjs9k72"
+  className="html-strong x1q9hu08 xttmgf0 x1hl2dhg x16tdsg8 x1vvkbs x117nqv4"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -5431,7 +5431,7 @@ exports[`html "strong" supports global attributes 1`] = `
 
 exports[`html "strong" supports inline event handlers 1`] = `
 <strong
-  className="html-strong x1q9hu08 xttmgf0 x1hl2dhg x16tdsg8 x1vvkbs xjs9k72"
+  className="html-strong x1q9hu08 xttmgf0 x1hl2dhg x16tdsg8 x1vvkbs x117nqv4"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}


### PR DESCRIPTION
Strong tag seems to be wrongly configured to point to `bolder` fontWeight which translates to fontWeight of 900. It should be `bold` which translates to `700`