### PR TITLE
Add Node.js benchmarks for native

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -13,3 +13,57 @@ jobs:
         build-script: "build"
         pattern: "./packages/react-strict-dom/dist/{dom/index.js,dom/runtime.js,native/index.js}"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+
+  benchmarks:
+    name: benchmarks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 50
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20.x'
+    - name: 'Setup temporary files'
+      run: |
+        echo "BASE_SHA=$(echo ${{ github.event.pull_request.base.sha }} | cut -c1-8)" >> $GITHUB_ENV
+        echo "PATCH_SHA=$(echo ${{ github.event.pull_request.head.sha }} | cut -c1-8)" >> $GITHUB_ENV
+        echo "BASELINE_JSON=$(mktemp)" >> $GITHUB_ENV
+        echo "PATCH_JSON=$(mktemp)" >> $GITHUB_ENV
+        echo "PR_COMMENT=$(mktemp)" >>  $GITHUB_ENV
+    - name: 'Benchmark: baseline'
+      run: |
+        git checkout ${{ github.event.pull_request.base.sha }}
+        npm install
+        npm run build
+        if npm run benchmark -w react-strict-dom > ${{ env.BASELINE_JSON }}; then
+          echo "Benchmark ran successfully on base branch"
+        else
+          echo "{}" > ${{ env.BASELINE_JSON }}  # Empty JSON as default
+          echo "Benchmark script not found on base branch, using default values"
+        fi
+    - name: 'Benchmark: patch'
+      run: |
+        git checkout ${{ github.event.pull_request.head.sha }}
+        npm install
+        npm run build
+        npm run benchmark -w react-strict-dom > ${{ env.PATCH_JSON }}
+    - name: 'Collect results'
+      run: |
+        echo "## RSD benchmarks (for native)" >> pr_comment
+        echo "### Base ${BASE_SHA}" >> pr_comment
+        tail -n +2 ${{ env.BASELINE_JSON }} >> pr_comment
+        echo "### Patch ${PATCH_SHA}" >> pr_comment
+        tail -n +2 ${{ env.PATCH_JSON }} >> pr_comment
+        cat pr_comment > ${{ env.PR_COMMENT }}
+    - name: 'Post comment'
+      uses: actions/github-script@v4.0.2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: require('fs').readFileSync('${{ env.PR_COMMENT }}').toString()
+          });

--- a/.github/workflows/react-integration.yml
+++ b/.github/workflows/react-integration.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '18.x'
+        node-version: '20.x'
     - run: npm install
     - run: npm install --force --include-workspace-root --workspaces react@next react-dom@next react-native@nightly react-test-renderer@next
     # Run the unit tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '18.x'
+        node-version: '20.x'
     - run: npm install
     - run: npm run fmt:report
 
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '18.x'
+        node-version: '20.x'
     - run: npm install
     - run: npm run build
     - run: npm run flow
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '18.x'
+        node-version: '20.x'
     - run: npm install
     - run: npm run lint:report
 
@@ -45,7 +45,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '18.x'
+        node-version: '20.x'
     - run: npm install
     - run: npm run build
     - run: npm run jest:report -- --runInBand

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 build
 coverage
 dist
+logs
 node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,13 @@ To run all these automated tests:
 npm run test
 ```
 
+To run the benchmarks for React Native:
+
+```
+npm run benchmark -w react-strict-dom
+```
+
+
 ## Development
 
 Build and automatically rebuild the library on changes:

--- a/configs/.eslintrc
+++ b/configs/.eslintrc
@@ -36,10 +36,12 @@
   },
   "ignorePatterns": [
     "apps",
+    "build",
     "coverage",
     "dist",
     "docs",
     "flow-typed",
+    "logs",
     "node_modules"
   ],
   "globals": {

--- a/configs/.prettierignore
+++ b/configs/.prettierignore
@@ -1,3 +1,5 @@
+build
 coverage
 dist
+log
 node_modules

--- a/configs/rollup.config.js
+++ b/configs/rollup.config.js
@@ -6,6 +6,7 @@
  */
 
 import { babel } from '@rollup/plugin-babel';
+import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 import resolve from '@rollup/plugin-node-resolve';
@@ -104,6 +105,34 @@ const nativeConfigs = [
       format: 'es'
     },
     plugins: [...nativePlugins, ...ossPlugins]
+  },
+  // Build for Node.js benchmarks
+  {
+    external: ['react'],
+    input: require.resolve('../packages/react-strict-dom/src/native/index.js'),
+    output: {
+      file: path.join(
+        __dirname,
+        '../packages/react-strict-dom/build/native-bench.js'
+      ),
+      format: 'commonjs'
+    },
+    plugins: [
+      // alias react-native to mock
+      alias({
+        entries: [
+          {
+            find: 'react-native',
+            replacement: path.resolve(
+              __dirname,
+              '../packages/react-strict-dom/tests/benchmarks/react-native.js'
+            )
+          }
+        ]
+      }),
+      ...nativePlugins,
+      ...ossPlugins
+    ]
   }
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7875,6 +7875,16 @@
         }
       ]
     },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha512-l9MlfN4M1K/H2fbhfMy3B7vJd6AGKJVQn2h6Sg/Yx+KckoUA7ewS5Vv6TjSq18ooE1kS9hhAlQRH3AkXIh/aOQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
+      }
+    },
     "node_modules/better-opn": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/better-opn/-/better-opn-3.0.2.tgz",
@@ -16956,6 +16966,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
+    },
     "node_modules/plist": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
@@ -19780,7 +19796,8 @@
         "postcss-value-parser": "^4.1.0"
       },
       "devDependencies": {
-        "@stylexjs/babel-plugin": "0.6.0"
+        "@stylexjs/babel-plugin": "0.6.0",
+        "benchmark": "^2.1.4"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/packages/react-strict-dom/package.json
+++ b/packages/react-strict-dom/package.json
@@ -11,10 +11,11 @@
     "!**/__tests__"
   ],
   "scripts": {
-    "prebuild": "npm run clean && gen-types -i src/ -o dist",
+    "benchmark": "node tests/benchmarks/benchmarks.node.js",
     "build": "rollup --config ../../configs/rollup.config.js",
     "clean": "del-cli \"./dist/*\"",
-    "dev": "npm run build -- --watch"
+    "dev": "npm run build -- --watch",
+    "prebuild": "npm run clean && gen-types -i src/ -o dist"
   },
   "dependencies": {
     "@stylexjs/stylex": "0.6.0",
@@ -22,7 +23,8 @@
     "postcss-value-parser": "^4.1.0"
   },
   "devDependencies": {
-    "@stylexjs/babel-plugin": "0.6.0"
+    "@stylexjs/babel-plugin": "0.6.0",
+    "benchmark": "^2.1.4"
   },
   "peerDependencies": {
     "react": ">=18.2.0",

--- a/packages/react-strict-dom/tests/benchmarks/benchmarks.node.js
+++ b/packages/react-strict-dom/tests/benchmarks/benchmarks.node.js
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const Benchmark = require('benchmark');
+
+const { css } = require('../../build/native-bench');
+
+/**
+ * Test helpers
+ */
+
+const suite = new Benchmark.Suite('react-strict-dom-benchmarks');
+const test = (...args) => suite.add(...args);
+
+function jsonReporter(suite) {
+  const benchmarks = [];
+  const config = {
+    folder: 'logs',
+    callback(results, name, folder) {
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = String(now.getMonth() + 1).padStart(2, '0'); // Month is 0-indexed
+      const day = String(now.getDate() + 8).padStart(2, '0'); // Add 8 days
+      const hours = String(now.getHours()).padStart(2, '0');
+      const minutes = String(now.getMinutes()).padStart(2, '0');
+      const timestamp = `${year}${month}${day}-${hours}${minutes}`;
+
+      // Write the results log
+      const dirpath = `${process.cwd()}/${folder}`;
+      const filepath = `${dirpath}/${name}-${timestamp}.log`;
+      if (!fs.existsSync(dirpath)) {
+        fs.mkdirSync(dirpath);
+      }
+      fs.writeFileSync(filepath, `${JSON.stringify(results, null, 2)}\n`);
+
+      // Print the markdown table
+      let markdown = '';
+      markdown += '| Benchmark | ops/sec | deviation (%) | samples |\n';
+      markdown += '| :---      |    ---: |          ---: |    ---: |\n';
+      markdown += results
+        .map((data) => {
+          const { name, deviation, ops, samples } = data;
+          const prettyOps = parseInt(ops, 10).toLocaleString();
+          return `| ${name} | ${prettyOps} | ${deviation} | ${samples} |`;
+        })
+        .join('\n');
+      console.log(markdown);
+    }
+  };
+
+  suite.on('cycle', (event) => {
+    benchmarks.push(event.target);
+  });
+
+  suite.on('error', (event) => {
+    throw new Error(String(event.target.error));
+  });
+
+  suite.on('complete', () => {
+    const timestamp = Date.now();
+    const result = benchmarks.map((bench) => {
+      if (bench.error) {
+        return {
+          name: bench.name,
+          id: bench.id,
+          error: bench.error
+        };
+      }
+
+      return {
+        name: bench.name,
+        id: bench.id,
+        samples: bench.stats.sample.length,
+        deviation: bench.stats.rme.toFixed(2),
+        ops: bench.hz.toFixed(bench.hz < 100 ? 2 : 0),
+        timestamp
+      };
+    });
+    config.callback(result, suite.name, config.folder);
+  });
+}
+
+jsonReporter(suite);
+
+/**
+ * Fixtures
+ */
+
+const smallStyle = {
+  backgroundColor: 'red',
+  color: 'green'
+};
+
+const smallStyleAlt = {
+  backgroundColor: 'yellow',
+  color: 'blue'
+};
+
+const bigStyle = {
+  backgroundColor: 'purple',
+  borderColor: 'orange',
+  borderStyle: 'solid',
+  borderWidth: '1rem',
+  boxSizing: 'content-box',
+  display: 'block',
+  marginBlockEnd: '2rem',
+  marginBlockStart: '2rem',
+  marginInline: '3rem',
+  paddingBlock: '1rem',
+  paddingInlineEnd: '0.5em',
+  paddingInlineStart: '0.5em',
+  verticalAlign: 'top',
+  textDecorationLine: 'underline'
+};
+
+const complexStyle = {
+  backgroundColor: 'purple',
+  borderColor: 'orange',
+  borderStyle: 'solid',
+  borderWidth: '1rem',
+  boxSizing: 'content-box',
+  color: {
+    default: 'pink',
+    ':hover': 'var(--testColor)'
+  },
+  display: 'block',
+  fontSize: '1rem',
+  marginBlockEnd: '2rem',
+  marginBlockStart: '2rem',
+  marginInline: '3rem',
+  paddingBlock: '1rem',
+  paddingInlineEnd: '0.5em',
+  paddingInlineStart: '0.5em',
+  textDecorationLine: 'underline',
+  verticalAlign: 'top',
+  width: 300,
+  // todo update to modern syntax
+  '@media (min-width: 1000px)': {
+    width: 500
+  }
+};
+
+/**
+ * css.create()
+ */
+
+test('css.create() small style', () => {
+  css.create({
+    smallStyle: smallStyle
+  });
+});
+
+test('css.create() small styles', () => {
+  css.create({
+    smallStyle: smallStyle,
+    smallStyleAlt: smallStyleAlt
+  });
+});
+
+test('css.create() big style', () => {
+  css.create({
+    bigStyle: bigStyle
+  });
+});
+
+test('css.create() complex style', () => {
+  css.create({
+    complexStyle: complexStyle
+  });
+});
+
+/**
+ * css.props()
+ */
+
+const styles = css.create({
+  smallStyle: smallStyle,
+  smallStyleAlt: smallStyleAlt,
+  bigStyle: bigStyle,
+  complexStyle: complexStyle
+});
+
+const arrayOfStyle = [
+  styles.bigStyle,
+  false,
+  false,
+  false,
+  false,
+  [
+    styles.smallStyle,
+    false,
+    [false, false, styles.smallStyleAlt, false, [styles.complexStyle]]
+  ]
+];
+
+const options = {
+  customProperties: {
+    testColor: 'cyan'
+  },
+  fontScale: 1,
+  hover: true,
+  inheritedFontSize: 16,
+  viewportHeight: 600,
+  viewportWidth: 1024
+};
+
+// BASIC
+
+test('css.props() small style', () => {
+  css.props.call(options, styles.smallStyle);
+});
+
+test('css.props() large style', () => {
+  css.props.call(options, styles.bigStyle);
+});
+
+// SMALL MERGE
+
+test('css.props() small merge', () => {
+  css.props.call(options, [styles.smallStyle, styles.smallStyleAlt]);
+});
+
+// LARGE MERGE
+
+test('css.props() large merge', () => {
+  css.props.call(options, arrayOfStyle);
+});
+
+suite.run();

--- a/packages/react-strict-dom/tests/benchmarks/react-native.js
+++ b/packages/react-strict-dom/tests/benchmarks/react-native.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * React Native mock for Node.js benchmarks
+ */
+
+const Animated = {
+  createAnimatedComponent(c) {
+    return c;
+  },
+  Image: 'Animated.Image',
+  View: 'Animated.View',
+  Text: 'Animated.Text',
+  Value: () => {
+    return {
+      interpolate: (value) => value
+    };
+  },
+  timing: () => {
+    return {
+      start: () => {}
+    };
+  },
+  delay: () => {},
+  sequence: () => {
+    return {
+      start: () => {}
+    };
+  }
+};
+
+const Easing = {
+  linear: () => {},
+  ease: () => {},
+  bezier: () => {},
+  in: () => {},
+  out: () => {},
+  inOut: () => {}
+};
+
+const Image = 'Image';
+
+const Linking = {
+  openURL: () => {}
+};
+
+const Platform = {
+  select(obj) {
+    return obj.android || obj.ios || obj.native || obj.default;
+  }
+};
+
+const PixelRatio = {
+  getFontScale: () => 1
+};
+
+const Pressable = 'Pressable';
+
+const StyleSheet = {
+  create(styles) {
+    return styles;
+  },
+  flatten(style) {
+    if (!style) {
+      return undefined;
+    }
+    if (!Array.isArray(style)) {
+      return style;
+    }
+    const result = {};
+    for (let i = 0, styleLength = style.length; i < styleLength; ++i) {
+      const computedStyle = this.flatten(style[i]);
+      if (computedStyle) {
+        for (const key in computedStyle) {
+          const value = computedStyle[key];
+          result[key] = value;
+        }
+      }
+    }
+    return result;
+  }
+};
+
+const TextInput = 'TextInput';
+
+const Text = 'Text';
+
+const View = 'View';
+
+const useWindowDimensions = () => ({ width: 2000, height: 1000 });
+
+module.exports = {
+  Animated,
+  Easing,
+  Image,
+  Linking,
+  Platform,
+  PixelRatio,
+  Pressable,
+  StyleSheet,
+  TextInput,
+  Text,
+  View,
+  useWindowDimensions
+};


### PR DESCRIPTION
These benchmarks are based on those in styleq, which were used to improve the performance of the StyleX runtime 5-8x. We currently track the performance of `css.create` and `css.props` calls.