### PR TITLE
Fix `transform` style processing for native

### DIFF
--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -42,6 +42,7 @@ import {
   Pressable
 } from 'react-native';
 import * as stylex from '../stylex';
+import { parseTransform } from './parseTransform';
 
 type ReactNativeProps = {
   ...StrictProps,
@@ -637,6 +638,14 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         }
         if (nativeComponent === Pressable) {
           nativeComponent = AnimatedPressable;
+        }
+      } else {
+        // shim for `transform` property was done with the animated property in the if condition
+        // above, but if we have reached till here, it means that we are not yet able to shim `transform`
+        // property and going to check it here now.
+        const transformValue = styleProps.style.transform;
+        if (transformValue != null && typeof transformValue === 'string') {
+          styleProps.style.transform = parseTransform(transformValue);
         }
       }
 

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -24,7 +24,8 @@ const passthroughProperties = [
   'transitionDelay',
   'transitionDuration',
   'transitionProperty',
-  'transitionTimingFunction'
+  'transitionTimingFunction',
+  'transform' // passing through `transform` at this stage, because we will check it together with transitionProperty later.
 ];
 
 export function useStyleProps(

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -26,6 +26,7 @@ import {
   stringContainsVariables
 } from './customProperties';
 import { CSSUnparsedValue } from './typed-om/CSSUnparsedValue';
+import { parseTransform } from '../modules/parseTransform';
 
 const stylePropertyAllowlistSet = new Set<string>([
   'alignContent',
@@ -318,6 +319,7 @@ function resolveStyle<S: { +[string]: mixed }>(
   options: SpreadOptions
 ): S {
   const customProperties = options.customProperties || {};
+  const passThroughProperties = options.passthroughProperties || [];
   const result: { [string]: mixed } = {};
   const stylesToReprocess: { [string]: mixed } = {};
   const propNames = Object.keys(style);
@@ -381,6 +383,15 @@ function resolveStyle<S: { +[string]: mixed }>(
           continue;
         }
       }
+    }
+
+    if (
+      propName === 'transform' &&
+      typeof styleValue === 'string' &&
+      passThroughProperties.indexOf('transform') === -1
+    ) {
+      result[propName] = parseTransform(styleValue);
+      continue;
     }
 
     // resolve length units

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -454,7 +454,28 @@ exports[`properties: general textShadow 2`] = `
 exports[`properties: general transform: matrix 1`] = `
 {
   "style": {
-    "transform": "matrix(0.1, 1, -0.3, 1, 0, 0)",
+    "transform": [
+      {
+        "matrix": [
+          0.1,
+          1,
+          0,
+          0,
+          -0.3,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+        ],
+      },
+    ],
   },
 }
 `;
@@ -462,11 +483,32 @@ exports[`properties: general transform: matrix 1`] = `
 exports[`properties: general transform: mixed 1`] = `
 {
   "style": {
-    "transform": "
-          rotateX(1deg) rotateY(2deg) rotateZ(3deg) rotate3d(1deg, 2deg, 3deg)
-          scale(1) scaleX(2) scaleY(3) scaleZ(4) scale3d(1,2,3)
-          translateX(1px) translateY(1em) translateZ(1rem) translate3d(1px, 1em, 1rem)
-        ",
+    "transform": [
+      {
+        "rotateX": "1deg",
+      },
+      {
+        "rotateY": "2deg",
+      },
+      {
+        "rotateZ": "3deg",
+      },
+      {
+        "scale": 1,
+      },
+      {
+        "scaleX": 2,
+      },
+      {
+        "scaleY": 3,
+      },
+      {
+        "scaleZ": 4,
+      },
+      {
+        "translateX": 1,
+      },
+    ],
   },
 }
 `;
@@ -474,7 +516,7 @@ exports[`properties: general transform: mixed 1`] = `
 exports[`properties: general transform: none 1`] = `
 {
   "style": {
-    "transform": "none",
+    "transform": [],
   },
 }
 `;
@@ -482,7 +524,11 @@ exports[`properties: general transform: none 1`] = `
 exports[`properties: general transform: perspective 1`] = `
 {
   "style": {
-    "transform": "perspective(10px)",
+    "transform": [
+      {
+        "perspective": 10,
+      },
+    ],
   },
 }
 `;
@@ -490,7 +536,20 @@ exports[`properties: general transform: perspective 1`] = `
 exports[`properties: general transform: rotate 1`] = `
 {
   "style": {
-    "transform": "rotate(10deg) rotateX(20deg) rotateY(30deg) rotateZ(40deg) rotate3d(0, 0.5, 1, 90deg)",
+    "transform": [
+      {
+        "rotate": "10deg",
+      },
+      {
+        "rotateX": "20deg",
+      },
+      {
+        "rotateY": "30deg",
+      },
+      {
+        "rotateZ": "40deg",
+      },
+    ],
   },
 }
 `;
@@ -498,7 +557,20 @@ exports[`properties: general transform: rotate 1`] = `
 exports[`properties: general transform: rotate 2`] = `
 {
   "style": {
-    "transform": "rotate(10deg) rotateX(20deg) rotateY(30deg) rotateZ(40deg) rotate3d(0, 0.5, 1, 90deg)",
+    "transform": [
+      {
+        "rotate": "10deg",
+      },
+      {
+        "rotateX": "20deg",
+      },
+      {
+        "rotateY": "30deg",
+      },
+      {
+        "rotateZ": "40deg",
+      },
+    ],
   },
 }
 `;
@@ -506,7 +578,17 @@ exports[`properties: general transform: rotate 2`] = `
 exports[`properties: general transform: scale 1`] = `
 {
   "style": {
-    "transform": "scale(1, 2) scaleX(1) scaleY(2) scaleZ(3) scale3d(1, 2, 3)",
+    "transform": [
+      {
+        "scaleX": 1,
+      },
+      {
+        "scaleY": 2,
+      },
+      {
+        "scaleZ": 3,
+      },
+    ],
   },
 }
 `;
@@ -514,7 +596,14 @@ exports[`properties: general transform: scale 1`] = `
 exports[`properties: general transform: skew 1`] = `
 {
   "style": {
-    "transform": "skew(10deg, 15deg) skewX(20deg) skewY(30deg)",
+    "transform": [
+      {
+        "skewX": "20deg",
+      },
+      {
+        "skewY": "30deg",
+      },
+    ],
   },
 }
 `;
@@ -522,7 +611,14 @@ exports[`properties: general transform: skew 1`] = `
 exports[`properties: general transform: translate 1`] = `
 {
   "style": {
-    "transform": "translate(10px, 20px) translateX(11px) translateY(12px) translateZ(13px) translate3d(20px, 30px, 40px)",
+    "transform": [
+      {
+        "translateX": 11,
+      },
+      {
+        "translateY": 12,
+      },
+    ],
   },
 }
 `;

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -1236,7 +1236,14 @@ exports[`<html.*> style polyfills "transition" properties : transition property 
   style={
     {
       "position": "static",
-      "transform": "translateY(50px) rotateX(90deg)",
+      "transform": [
+        {
+          "translateY": 50,
+        },
+        {
+          "rotateX": "90deg",
+        },
+      ],
     }
   }
 />


### PR DESCRIPTION
**Issue Description:**
    - We are using Animated view for the implementation of button component internally which is shared between web and native both
    - This button component uses a `transform` css property which is written using stylex and the value of transform property is of type string. The value is something like this:
    ```
    const styles = stylex.create({
      root: {
        transform: 'scale(0.5)'
      }
    })
    ```
    - Although react-native added support for string `transform` in the [past](https://github.com/facebook/react-native/pull/34660/files), string is not yet supported for Animated views
    - Since our button component uses animated view with string `transform` value, this results in a redblock error for us.
    
 **FIX:**
    - In this PR, I am attempting to always parse `transform` property and convert it to into an array of object which works fine with react-native.
    - The change is being done in the stylex `props` function in [native](https://github.com/facebook/react-strict-dom/blob/main/packages/react-strict-dom/src/native/stylex/index.js#L464) which is responsible for shimming the style values compatible with react native