### PR TITLE
Fix `transform` style processing for native

### DIFF
--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -8,7 +8,7 @@
  */
 
 import type { StrictProps } from '../../types/StrictProps';
-import type { Style } from '../../types/styles';
+import type { Style, Transform } from '../../types/styles';
 import type {
   ChangeEvent,
   EditingEvent,
@@ -602,10 +602,13 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       const transitionProperties = resolvedTransitionProperty.flatMap(
         (property) => {
           const value = styleProps.style[property];
-          if (isString(value) || isNumber(value)) {
+          if (isString(value) || isNumber(value) || Array.isArray(value)) {
             return [{ property, value }];
           }
-          return [] as Array<{ property: string, value: string | number }>;
+          return [] as Array<{
+            property: string,
+            value: string | number | Transform[]
+          }>;
         }
       );
       const animatedPropertyValues = useStyleTransition({

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -21,6 +21,7 @@ import { errorMsg, warnMsg } from '../../shared/logUtils';
 import { fixContentBox } from './fixContentBox';
 import { flattenStyle } from './flattenStyleXStyles';
 import { parseTimeValue } from './parseTimeValue';
+import { parseTransform } from './parseTransform';
 import {
   resolveVariableReferences,
   stringContainsVariables
@@ -381,6 +382,11 @@ function resolveStyle<S: { +[string]: mixed }>(
           continue;
         }
       }
+    }
+
+    if (propName === 'transform' && typeof styleValue === 'string') {
+      result[propName] = parseTransform(styleValue);
+      continue;
     }
 
     // resolve length units

--- a/packages/react-strict-dom/src/native/stylex/parseTransform.js
+++ b/packages/react-strict-dom/src/native/stylex/parseTransform.js
@@ -7,21 +7,7 @@
  * @flow strict
  */
 
-type Transform =
-  | { matrix: number[] }
-  | { perspective: number }
-  | { rotate: string }
-  | { rotateX: string }
-  | { rotateY: string }
-  | { rotateZ: string }
-  | { scale: number }
-  | { scaleX: number }
-  | { scaleY: number }
-  | { scaleZ: number }
-  | { translateX: number }
-  | { translateY: number }
-  | { skewX: string }
-  | { skewY: string };
+import type { Transform } from '../../types/styles';
 
 export function parseTransform(transform: string): Transform[] {
   const transforms = transform

--- a/packages/react-strict-dom/src/types/styles.js
+++ b/packages/react-strict-dom/src/types/styles.js
@@ -17,6 +17,22 @@ import type {
 
 import typeof TStyleX from '@stylexjs/stylex';
 
+export type Transform =
+  | { matrix: number[] }
+  | { perspective: number }
+  | { rotate: string }
+  | { rotateX: string }
+  | { rotateY: string }
+  | { rotateZ: string }
+  | { scale: number }
+  | { scaleX: number }
+  | { scaleY: number }
+  | { scaleZ: number }
+  | { translateX: number }
+  | { translateY: number }
+  | { skewX: string }
+  | { skewY: string };
+
 export type Style = InlineStyles;
 
 export type Styles = StyleXArray<

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -454,7 +454,28 @@ exports[`properties: general textShadow 2`] = `
 exports[`properties: general transform: matrix 1`] = `
 {
   "style": {
-    "transform": "matrix(0.1, 1, -0.3, 1, 0, 0)",
+    "transform": [
+      {
+        "matrix": [
+          0.1,
+          1,
+          0,
+          0,
+          -0.3,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+          0,
+          0,
+          0,
+          0,
+          1,
+        ],
+      },
+    ],
   },
 }
 `;
@@ -462,11 +483,32 @@ exports[`properties: general transform: matrix 1`] = `
 exports[`properties: general transform: mixed 1`] = `
 {
   "style": {
-    "transform": "
-          rotateX(1deg) rotateY(2deg) rotateZ(3deg) rotate3d(1deg, 2deg, 3deg)
-          scale(1) scaleX(2) scaleY(3) scaleZ(4) scale3d(1,2,3)
-          translateX(1px) translateY(1em) translateZ(1rem) translate3d(1px, 1em, 1rem)
-        ",
+    "transform": [
+      {
+        "rotateX": "1deg",
+      },
+      {
+        "rotateY": "2deg",
+      },
+      {
+        "rotateZ": "3deg",
+      },
+      {
+        "scale": 1,
+      },
+      {
+        "scaleX": 2,
+      },
+      {
+        "scaleY": 3,
+      },
+      {
+        "scaleZ": 4,
+      },
+      {
+        "translateX": 1,
+      },
+    ],
   },
 }
 `;
@@ -474,7 +516,7 @@ exports[`properties: general transform: mixed 1`] = `
 exports[`properties: general transform: none 1`] = `
 {
   "style": {
-    "transform": "none",
+    "transform": [],
   },
 }
 `;
@@ -482,7 +524,11 @@ exports[`properties: general transform: none 1`] = `
 exports[`properties: general transform: perspective 1`] = `
 {
   "style": {
-    "transform": "perspective(10px)",
+    "transform": [
+      {
+        "perspective": 10,
+      },
+    ],
   },
 }
 `;
@@ -490,7 +536,20 @@ exports[`properties: general transform: perspective 1`] = `
 exports[`properties: general transform: rotate 1`] = `
 {
   "style": {
-    "transform": "rotate(10deg) rotateX(20deg) rotateY(30deg) rotateZ(40deg) rotate3d(0, 0.5, 1, 90deg)",
+    "transform": [
+      {
+        "rotate": "10deg",
+      },
+      {
+        "rotateX": "20deg",
+      },
+      {
+        "rotateY": "30deg",
+      },
+      {
+        "rotateZ": "40deg",
+      },
+    ],
   },
 }
 `;
@@ -498,7 +557,20 @@ exports[`properties: general transform: rotate 1`] = `
 exports[`properties: general transform: rotate 2`] = `
 {
   "style": {
-    "transform": "rotate(10deg) rotateX(20deg) rotateY(30deg) rotateZ(40deg) rotate3d(0, 0.5, 1, 90deg)",
+    "transform": [
+      {
+        "rotate": "10deg",
+      },
+      {
+        "rotateX": "20deg",
+      },
+      {
+        "rotateY": "30deg",
+      },
+      {
+        "rotateZ": "40deg",
+      },
+    ],
   },
 }
 `;
@@ -506,7 +578,17 @@ exports[`properties: general transform: rotate 2`] = `
 exports[`properties: general transform: scale 1`] = `
 {
   "style": {
-    "transform": "scale(1, 2) scaleX(1) scaleY(2) scaleZ(3) scale3d(1, 2, 3)",
+    "transform": [
+      {
+        "scaleX": 1,
+      },
+      {
+        "scaleY": 2,
+      },
+      {
+        "scaleZ": 3,
+      },
+    ],
   },
 }
 `;
@@ -514,7 +596,14 @@ exports[`properties: general transform: scale 1`] = `
 exports[`properties: general transform: skew 1`] = `
 {
   "style": {
-    "transform": "skew(10deg, 15deg) skewX(20deg) skewY(30deg)",
+    "transform": [
+      {
+        "skewX": "20deg",
+      },
+      {
+        "skewY": "30deg",
+      },
+    ],
   },
 }
 `;
@@ -522,7 +611,14 @@ exports[`properties: general transform: skew 1`] = `
 exports[`properties: general transform: translate 1`] = `
 {
   "style": {
-    "transform": "translate(10px, 20px) translateX(11px) translateY(12px) translateZ(13px) translate3d(20px, 30px, 40px)",
+    "transform": [
+      {
+        "translateX": 11,
+      },
+      {
+        "translateY": 12,
+      },
+    ],
   },
 }
 `;

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -1236,7 +1236,14 @@ exports[`<html.*> style polyfills "transition" properties : transition property 
   style={
     {
       "position": "static",
-      "transform": "translateY(50px) rotateX(90deg)",
+      "transform": [
+        {
+          "translateY": 50,
+        },
+        {
+          "rotateX": "90deg",
+        },
+      ],
     }
   }
 />

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -160,28 +160,28 @@ describe('<html.*>', () => {
     test('"transition" properties ', () => {
       const { Easing } = require('react-native');
 
-      const styles = {
-        backgroundColor: {
-          backgroundColor: 'rgba(0,0,0,0.1)',
+      const styles = css.create({
+        backgroundColor: (backgroundColor) => ({
+          backgroundColor: backgroundColor ?? 'rgba(0,0,0,0.1)',
           transitionDelay: 200,
           transitionDuration: 2000,
           transitionProperty: 'backgroundColor',
           transitionTimingFunction: 'ease-in-out'
-        },
-        opacity: {
-          opacity: 1.0,
+        }),
+        opacity: (opacity, timingFunction) => ({
+          opacity: opacity ?? 1.0,
           transitionDelay: 50,
           transitionDuration: 1000,
           transitionProperty: 'opacity',
-          transitionTimingFunction: 'ease-in'
-        },
-        transform: {
-          transform: 'translateY(0px) rotateX(0deg)',
+          transitionTimingFunction: timingFunction ?? 'ease-in'
+        }),
+        transform: (transform) => ({
+          transform: transform ?? 'translateY(0px) rotateX(0deg)',
           transitionDelay: 0,
           transitionDuration: 1000,
           transitionProperty: 'transform',
           transitionTimingFunction: 'ease-out'
-        },
+        }),
         transitionAll: {
           opacity: 1.0,
           transform: 'translateY(0px) rotateX(0deg)',
@@ -205,14 +205,14 @@ describe('<html.*>', () => {
           transitionProperty: 'transform',
           transitionTimingFunction: 'ease-out'
         },
-        width: {
-          width: 100,
+        width: (width) => ({
+          width: width ?? 100,
           transitionDelay: 0,
           transitionDuration: 500,
           transitionProperty: 'width',
           transitionTimingFunction: 'ease'
-        }
-      };
+        })
+      });
 
       let root;
 
@@ -226,46 +226,38 @@ describe('<html.*>', () => {
 
       // backgroundColor transition
       act(() => {
-        root = create(<html.div style={styles.backgroundColor} />);
+        root = create(<html.div style={styles.backgroundColor()} />);
       });
       expect(root.toJSON()).toMatchSnapshot('backgroundColor transition start');
       expect(Easing.inOut).toHaveBeenCalled();
       act(() => {
         root.update(
-          <html.div
-            style={[
-              styles.backgroundColor,
-              { backgroundColor: 'rgba(255,255,255,0.9)' }
-            ]}
-          />
+          <html.div style={[styles.backgroundColor('rgba(255,255,255,0.9)')]} />
         );
       });
       expect(root.toJSON()).toMatchSnapshot('backgroundColor transition end');
 
       // opacity transition
       act(() => {
-        root = create(<html.div style={styles.opacity} />);
+        root = create(<html.div style={styles.opacity()} />);
       });
       expect(root.toJSON()).toMatchSnapshot('opacity transition start');
       expect(Easing.in).toHaveBeenCalled();
       act(() => {
-        root.update(<html.div style={[styles.opacity, { opacity: 0 }]} />);
+        root.update(<html.div style={[styles.opacity(0)]} />);
       });
       expect(root.toJSON()).toMatchSnapshot('opacity transition end');
 
       // transform transition
       act(() => {
-        root = create(<html.div style={styles.transform} />);
+        root = create(<html.div style={styles.transform()} />);
       });
       expect(root.toJSON()).toMatchSnapshot('transform transition start');
       expect(Easing.out).toHaveBeenCalled();
       act(() => {
         root.update(
           <html.div
-            style={[
-              styles.transform,
-              { transform: 'translateY(50px) rotateX(90deg)' }
-            ]}
+            style={[styles.transform('translateY(50px) rotateX(90deg)')]}
           />
         );
       });
@@ -273,12 +265,12 @@ describe('<html.*>', () => {
 
       // width transition
       act(() => {
-        root = create(<html.div style={styles.width} />);
+        root = create(<html.div style={styles.width()} />);
       });
       expect(root.toJSON()).toMatchSnapshot('width transition start');
       expect(Easing.out).toHaveBeenCalled();
       act(() => {
-        root.update(<html.div style={[styles.width, { width: 200 }]} />);
+        root.update(<html.div style={[styles.width(200)]} />);
       });
       expect(root.toJSON()).toMatchSnapshot('width transition end');
 
@@ -286,10 +278,7 @@ describe('<html.*>', () => {
       act(() => {
         root = create(
           <html.div
-            style={[
-              styles.opacity,
-              { transitionTimingFunction: 'cubic-bezier( 0.1,  0.2,0.3  ,0.4)' }
-            ]}
+            style={styles.opacity(1, 'cubic-bezier( 0.1,  0.2,0.3  ,0.4)')}
           />
         );
       });


### PR DESCRIPTION
For simplicity (and to fix an internal edge case), we now translate all 'transform' values to the React Native object syntax. If a string 'transform' is ever passed to an Animated component, the animation will now work as expected.

Close #123