### PR TITLE
Remove console messages from prod builds

### DIFF
--- a/configs/rollup.config.js
+++ b/configs/rollup.config.js
@@ -12,8 +12,6 @@ import replace from '@rollup/plugin-replace';
 import resolve from '@rollup/plugin-node-resolve';
 import path from 'path';
 
-const isProduction = false;
-
 const babelPlugin = babel({
   babelHelpers: 'bundled',
   configFile: require.resolve('./babel.config.js')
@@ -37,17 +35,8 @@ function ossLicensePlugin() {
   };
 }
 
-const replacePlugin = replace({
-  preventAssignment: true,
-  values: {
-    __DEV__: isProduction ? 'false' : 'true',
-    'process.env.NODE_ENV': isProduction ? "'production'" : "'development'"
-  }
-});
-
 const sharedPlugins = [
   babelPlugin,
-  replacePlugin,
   resolve(),
   // commonjs packages: styleq and css-mediaquery
   commonjs()
@@ -118,6 +107,12 @@ const nativeConfigs = [
       format: 'commonjs'
     },
     plugins: [
+      replace({
+        preventAssignment: true,
+        values: {
+          __DEV__: 'false'
+        }
+      }),
       // alias react-native to mock
       alias({
         entries: [

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -195,7 +195,9 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         props
       );
       delete nativeProps.suppressHydrationWarning;
-      validateStrictProps(nativeProps);
+      if (__DEV__) {
+        validateStrictProps(nativeProps);
+      }
 
       if (ariaPosInSet != null) {
         nativeProps.accessibilityPosInSet = ariaPosInSet;
@@ -222,7 +224,9 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       }
       if (href != null && tagName === 'a') {
         nativeProps.onPress = function (e) {
-          errorMsg('<a> "href" handling is not implemented in React Native.');
+          if (__DEV__) {
+            errorMsg('<a> "href" handling is not implemented in React Native.');
+          }
         };
       }
       if (tagName === 'br') {
@@ -252,9 +256,11 @@ export function createStrictDOMComponent<T, P: StrictProps>(
           nativeProps.secureTextEntry = true;
         }
         if (type === 'checkbox' || type === 'date' || type === 'radio') {
-          errorMsg(
-            `<input type="${type}" /> is not implemented in React Native.`
-          );
+          if (__DEV__) {
+            errorMsg(
+              `<input type="${type}" /> is not implemented in React Native.`
+            );
+          }
         }
       }
       if (tagName === 'textarea') {
@@ -555,7 +561,11 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         displayValue !== 'none' &&
         displayValue !== 'block'
       ) {
-        warnMsg(`unsupported style value in "display:${String(displayValue)}"`);
+        if (__DEV__) {
+          warnMsg(
+            `unsupported style value in "display:${String(displayValue)}"`
+          );
+        }
       }
 
       if (displayValue === 'flex') {

--- a/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
+++ b/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
@@ -14,7 +14,9 @@ import { useElementCallback } from '../../shared/useElementCallback';
 import { errorMsg } from '../../shared/logUtils';
 
 function errorUnimplemented(name: string) {
-  errorMsg(`unsupported method node.${name}()`);
+  if (__DEV__) {
+    errorMsg(`unsupported method node.${name}()`);
+  }
 }
 
 /*

--- a/packages/react-strict-dom/src/native/modules/useStyleTransition.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleTransition.js
@@ -113,9 +113,11 @@ export function useStyleTransition(
   }
 
   if (valueRef.current?.length !== transitionProperties.length) {
-    errorMsg(
-      'invalid style transition. The number of transition properties must be the same before and after the transition.'
-    );
+    if (__DEV__) {
+      errorMsg(
+        'invalid style transition. The number of transition properties must be the same before and after the transition.'
+      );
+    }
     return [];
   }
 
@@ -142,18 +144,22 @@ export function useStyleTransition(
           !Array.isArray(refTransforms) ||
           transforms.length !== refTransforms.length
         ) {
-          warnMsg(
-            'The number or types of transforms must be the same before and after the transition. The transition will not animate.'
-          );
+          if (__DEV__) {
+            warnMsg(
+              'The number or types of transforms must be the same before and after the transition. The transition will not animate.'
+            );
+          }
           return transforms;
         }
 
         // TODO: Figure out how to animate matrix transforms
         for (const transform of transforms) {
           if (transform.matrix != null) {
-            warnMsg(
-              'Matrix transforms cannot be animated. The transition will not animate.'
-            );
+            if (__DEV__) {
+              warnMsg(
+                'Matrix transforms cannot be animated. The transition will not animate.'
+              );
+            }
             return transforms;
           }
         }

--- a/packages/react-strict-dom/src/native/stylex/CSSLengthUnitValue.js
+++ b/packages/react-strict-dom/src/native/stylex/CSSLengthUnitValue.js
@@ -9,6 +9,8 @@
 
 import type { SpreadOptions } from './SpreadOptions';
 
+import { warnMsg } from '../../shared/logUtils';
+
 const LENGTH_REGEX = /^(-?[0-9]*[.]?[0-9]+)(em|px|rem|vh|vmax|vmin|vw)$/;
 
 type CSSLengthUnitType = 'em' | 'px' | 'rem' | 'vh' | 'vmax' | 'vmin' | 'vw';
@@ -73,7 +75,9 @@ export class CSSLengthUnitValue {
         return viewportWidth * valuePercent;
       }
       default: {
-        console.error(`[stylex]: Unsupported unit of "${unit}"`);
+        if (__DEV__) {
+          warnMsg(`unsupported unit of "${unit}"`);
+        }
         return 0;
       }
     }

--- a/packages/react-strict-dom/src/native/stylex/CSSTextShadow.js
+++ b/packages/react-strict-dom/src/native/stylex/CSSTextShadow.js
@@ -31,7 +31,9 @@ export class CSSTextShadow {
   constructor(value: string) {
     const parsedShadow = CSSTextShadow.parse(value);
     if (parsedShadow.length > 1) {
-      warnMsg('unsupported multiple values for style property "textShadow".');
+      if (__DEV__) {
+        warnMsg('unsupported multiple values for style property "textShadow".');
+      }
     }
     this.parsedShadow = parsedShadow[0];
   }

--- a/packages/react-strict-dom/src/native/stylex/customProperties.js
+++ b/packages/react-strict-dom/src/native/stylex/customProperties.js
@@ -65,7 +65,9 @@ function resolveVariableReferenceValue(
     }
   }
 
-  warnMsg(`unrecognized custom property "${variable.variable}"`);
+  if (__DEV__) {
+    warnMsg(`unrecognized custom property "${variable.variable}"`);
+  }
 
   return null;
 }

--- a/packages/react-strict-dom/src/native/stylex/fixContentBox.js
+++ b/packages/react-strict-dom/src/native/stylex/fixContentBox.js
@@ -91,11 +91,13 @@ export function fixContentBox(flatStyle: FlatStyle): FlatStyle {
         continue;
       }
       if (typeof styleValue !== 'number') {
-        warnMsg(
-          `unsupported style value in "${styleProp}:${String(
-            styleValue
-          )}" when used with "boxSizing:'content-box'". Expected a value that resolves to a number. Percentage values can only be used with "boxSizing:'border-box'".`
-        );
+        if (__DEV__) {
+          warnMsg(
+            `unsupported style value in "${styleProp}:${String(
+              styleValue
+            )}" when used with "boxSizing:'content-box'". Expected a value that resolves to a number. Percentage values can only be used with "boxSizing:'border-box'".`
+          );
+        }
         return flatStyle;
       }
       nextStyle[styleProp] = styleValue + correction;

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -265,7 +265,9 @@ function processStyle<S: { +[string]: mixed }>(style: S): S {
 
       // React Native shadows on iOS cannot polyfill box-shadow
       if (propName === 'boxShadow') {
-        warnMsg('unsupported style property "boxShadow".');
+        if (__DEV__) {
+          warnMsg('unsupported style property "boxShadow".');
+        }
         delete result.boxShadow;
         continue;
       }
@@ -300,7 +302,11 @@ function processStyle<S: { +[string]: mixed }>(style: S): S {
           if (propName === 'color') {
             result['placeholderTextColor'] = styleValue[propName];
           } else {
-            warnMsg(`unsupported "::placeholder" style property "${propName}"`);
+            if (__DEV__) {
+              warnMsg(
+                `unsupported "::placeholder" style property "${propName}"`
+              );
+            }
           }
         }
         delete result['::placeholder'];
@@ -451,7 +457,9 @@ type Keyframes = {
 };
 
 function _keyframes(k: Keyframes): Keyframes {
-  errorMsg('css.keyframes() is not supported.');
+  if (__DEV__) {
+    errorMsg('css.keyframes() is not supported.');
+  }
   return k;
 }
 export const keyframes: (Keyframes) => string = _keyframes as $FlowFixMe;
@@ -588,9 +596,11 @@ export function props(
           styleValue === 'currentcolor' ||
           styleValue === 'unset'
         ) {
-          warnMsg(
-            `unsupported style value in "${styleProp}:${String(styleValue)}"`
-          );
+          if (__DEV__) {
+            warnMsg(
+              `unsupported style value in "${styleProp}:${String(styleValue)}"`
+            );
+          }
         } else {
           nativeProps.cursorColor = styleValue;
         }
@@ -693,20 +703,26 @@ export function props(
           styleValue === 'safe center' ||
           styleValue === 'unsafe center'
         ) {
-          warnMsg(
-            `unsupported style value in "${styleProp}:${String(styleValue)}"`
-          );
+          if (__DEV__) {
+            warnMsg(
+              `unsupported style value in "${styleProp}:${String(styleValue)}"`
+            );
+          }
         }
         // Multiple, different values are invalid.
         else {
-          errorMsg(
-            `invalid style value in "${styleProp}:${String(styleValue)}"`
-          );
+          if (__DEV__) {
+            errorMsg(
+              `invalid style value in "${styleProp}:${String(styleValue)}"`
+            );
+          }
         }
       }
       // everything else
       else {
-        warnMsg(`unsupported style property "${styleProp}"`);
+        if (__DEV__) {
+          warnMsg(`unsupported style property "${styleProp}"`);
+        }
       }
 
       delete flatStyle[styleProp];
@@ -718,17 +734,21 @@ export function props(
     // filter.
     // We check this at resolve time to ensure the render-time styles are safe.
     if (!isReactNativeStyleValue(styleValue)) {
-      warnMsg(
-        `unsupported style value in "${styleProp}:${String(styleValue)}"`
-      );
+      if (__DEV__) {
+        warnMsg(
+          `unsupported style value in "${styleProp}:${String(styleValue)}"`
+        );
+      }
       delete flatStyle[styleProp];
       continue;
     }
 
     if (!isReactNativeShortFormValid(styleProp, styleValue)) {
-      errorMsg(
-        `invalid style value in "${styleProp}:${String(styleValue)}". Shortform properties cannot contain multiple values. Please use longform properties.`
-      );
+      if (__DEV__) {
+        errorMsg(
+          `invalid style value in "${styleProp}:${String(styleValue)}". Shortform properties cannot contain multiple values. Please use longform properties.`
+        );
+      }
       delete flatStyle[styleProp];
       continue;
     }
@@ -764,14 +784,18 @@ export function props(
     const positionValue = flatStyle.position;
     if (positionValue === 'fixed') {
       flatStyle.position = 'absolute';
-      warnMsg(
-        'unsupported style value in "position:fixed". Falling back to "position:absolute".'
-      );
+      if (__DEV__) {
+        warnMsg(
+          'unsupported style value in "position:fixed". Falling back to "position:absolute".'
+        );
+      }
     } else if (positionValue === 'sticky') {
       flatStyle.position = 'relative';
-      warnMsg(
-        'unsupported style value in "position:sticky". Falling back to "position:relative".'
-      );
+      if (__DEV__) {
+        warnMsg(
+          'unsupported style value in "position:sticky". Falling back to "position:relative".'
+        );
+      }
     }
 
     for (const timeValuedProperty of timeValuedProperties) {

--- a/packages/react-strict-dom/src/native/stylex/typed-om/CSSUnparsedValue.js
+++ b/packages/react-strict-dom/src/native/stylex/typed-om/CSSUnparsedValue.js
@@ -54,9 +54,11 @@ export class CSSUnparsedValue extends CSSStyleValue {
     depth: number = 0
   ): CSSUnparsedValue {
     if (depth > MAX_RESOLVE_DEPTH) {
-      errorMsg(
-        `reached maximum recursion limit (${MAX_RESOLVE_DEPTH}) while resolving custom properties — please ensure you don't have a custom property reference cycle.`
-      );
+      if (__DEV__) {
+        errorMsg(
+          `reached maximum recursion limit (${MAX_RESOLVE_DEPTH}) while resolving custom properties — please ensure you don't have a custom property reference cycle.`
+        );
+      }
       return new CSSUnparsedValue([]);
     }
 
@@ -79,11 +81,13 @@ export class CSSUnparsedValue extends CSSStyleValue {
           const args = splitComponentValueListByComma(currentValue.nodes);
           const variableName = CSSUnparsedValue.#resolveVariableName(args[0]);
           if (variableName == null) {
-            warnMsg(
-              `Failed to resolve variable name from '${valueParser.stringify(
-                args[0]
-              )}'`
-            );
+            if (__DEV__) {
+              warnMsg(
+                `Failed to resolve variable name from '${valueParser.stringify(
+                  args[0]
+                )}'`
+              );
+            }
             return new CSSUnparsedValue([]);
           }
 
@@ -97,9 +101,11 @@ export class CSSUnparsedValue extends CSSStyleValue {
               new CSSVariableReferenceValue(variableName, fallbackValue)
             );
           } catch (err) {
-            warnMsg(
-              `Error creating CSSVariableReferenceValue: ${err.toString()}`
-            );
+            if (__DEV__) {
+              warnMsg(
+                `Error creating CSSVariableReferenceValue: ${err.toString()}`
+              );
+            }
             return new CSSUnparsedValue([]);
           }
         } else {


### PR DESCRIPTION
Wraps the log utils in `__DEV__` on native, so React Native can DCE the log messages in prod builds.

Makes sure that the benchmark build strips code wrapped in `__DEV__`, so we can see the impact of removing logs when processing unsupported props or styles that would otherwise log messages in dev.