### PR TITLE
Avoid creating copies of customProperties in native polyfill

### DIFF
--- a/packages/react-strict-dom/package.json
+++ b/packages/react-strict-dom/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "benchmark": "node tests/benchmarks/benchmarks.node.js",
     "build": "rollup --config ../../configs/rollup.config.js",
-    "clean": "del-cli \"./dist/*\"",
+    "clean": "del-cli \"./build/*\" \"./dist/*\"",
     "dev": "npm run build -- --watch",
     "prebuild": "npm run clean && gen-types -i src/ -o dist"
   },

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -403,6 +403,8 @@ export function createStrictDOMComponent<T, P: StrictProps>(
        * Resolve the style props
        */
       const inheritedStyles: ?Style = React.useContext(InheritableStyleContext);
+      const inheritedCustomProperties = React.useContext(ThemeContext);
+
       const [extractedStyles, customPropertiesFromThemes] = extractStyleThemes(
         props.style
       );
@@ -509,6 +511,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       }
       const _styleProps = useStyleProps(renderStyles, {
         customProperties: customPropertiesFromThemes,
+        inheritedCustomProperties,
         hover
       });
 
@@ -676,14 +679,16 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         );
       }
 
-      const inheritedCustomProperties = React.useContext(ThemeContext);
-
       return (
         <ThemeContext.Provider
-          value={{
-            ...inheritedCustomProperties,
-            ...customPropertiesFromThemes
-          }}
+          value={
+            customPropertiesFromThemes != null
+              ? {
+                  ...inheritedCustomProperties,
+                  ...customPropertiesFromThemes
+                }
+              : inheritedCustomProperties
+          }
         >
           <DisplayModeInsideContext.Provider value={nextDisplayModeInside}>
             <InheritableStyleContext.Provider

--- a/packages/react-strict-dom/src/native/modules/extractStyleThemes.js
+++ b/packages/react-strict-dom/src/native/modules/extractStyleThemes.js
@@ -37,5 +37,8 @@ export function extractStyleThemes(
       }
     }
   }
-  return [styles, theme];
+
+  const themeValue = Object.keys(theme).length > 0 ? theme : null;
+
+  return [styles, themeValue];
 }

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -12,12 +12,12 @@ import type { Styles } from '../../types/styles';
 import * as React from 'react';
 import { typeof Animated, PixelRatio, useWindowDimensions } from 'react-native';
 import { FontSizeContext } from './FontSizeContext';
-import { ThemeContext } from './ThemeContext';
 import * as stylex from '../stylex';
 
 type StyleOptions = {
-  customProperties?: ?{ [string]: string | number },
-  hover: boolean
+  customProperties: ?$ReadOnly<{ [string]: string | number }>,
+  hover: boolean,
+  inheritedCustomProperties: ?$ReadOnly<{ [string]: string | number }>
 };
 
 const passthroughProperties = [
@@ -26,6 +26,8 @@ const passthroughProperties = [
   'transitionProperty',
   'transitionTimingFunction'
 ];
+
+const emptyObject = {};
 
 export function useStyleProps(
   style: Styles,
@@ -38,21 +40,17 @@ export function useStyleProps(
 }> {
   const { height, width } = useWindowDimensions();
   const inheritedFontSize = React.useContext(FontSizeContext);
-  const inheritedCustomProperties = React.useContext(ThemeContext);
   const fontScale = PixelRatio.getFontScale();
-  const { customProperties: customPropertiesFromThemes, hover } = options;
+  const { customProperties, inheritedCustomProperties, hover } = options;
 
   // Marking it as `any` as Flow slows to a crawl when trying to type this.
   // But we already know that `style` is the correct type so this is still safe.
   const styleProps = stylex.props.call(
     {
-      customProperties: {
-        ...stylex.__customProperties,
-        ...inheritedCustomProperties,
-        ...customPropertiesFromThemes
-      },
+      customProperties: customProperties ?? emptyObject,
       fontScale,
       hover,
+      inheritedCustomProperties: inheritedCustomProperties ?? emptyObject,
       inheritedFontSize,
       passthroughProperties,
       viewportHeight: height,

--- a/packages/react-strict-dom/src/native/stylex/SpreadOptions.js
+++ b/packages/react-strict-dom/src/native/stylex/SpreadOptions.js
@@ -9,9 +9,10 @@
 
 export type SpreadOptions = $ReadOnly<{
   customProperties: $ReadOnly<{ [string]: string | number }>,
-  inheritedFontSize: ?number,
   fontScale: number | void,
   hover?: ?boolean,
+  inheritedCustomProperties: $ReadOnly<{ [string]: string | number }>,
+  inheritedFontSize: ?number,
   passthroughProperties: $ReadOnlyArray<string>,
   viewportHeight: number,
   viewportWidth: number,

--- a/packages/react-strict-dom/src/native/stylex/customProperties.js
+++ b/packages/react-strict-dom/src/native/stylex/customProperties.js
@@ -32,12 +32,14 @@ export function stringContainsVariables(input: string): boolean {
 function resolveVariableReferenceValue(
   propName: string,
   variable: CSSVariableReferenceValue,
-  propertyRegistry: CustomProperties
+  propertyRegistry: CustomProperties,
+  inheritedPropertyRegistry: CustomProperties
 ) {
   const variableName = normalizeVariableName(variable.variable);
   const fallbackValue = variable.fallback;
 
-  let variableValue: string | number | null = propertyRegistry[variableName];
+  let variableValue: string | number | null =
+    propertyRegistry[variableName] || inheritedPropertyRegistry[variableName];
 
   // Perform variable resolution on the variable's resolved value if it itself
   // contains variables
@@ -48,7 +50,8 @@ function resolveVariableReferenceValue(
     variableValue = resolveVariableReferences(
       propName,
       CSSUnparsedValue.parse(propName, variableValue),
-      propertyRegistry
+      propertyRegistry,
+      inheritedPropertyRegistry
     );
   }
 
@@ -58,7 +61,8 @@ function resolveVariableReferenceValue(
     const resolvedFallback = resolveVariableReferences(
       propName,
       fallbackValue,
-      propertyRegistry
+      propertyRegistry,
+      inheritedPropertyRegistry
     );
     if (resolvedFallback != null) {
       return resolvedFallback;
@@ -76,7 +80,8 @@ function resolveVariableReferenceValue(
 export function resolveVariableReferences(
   propName: string,
   propValue: CSSUnparsedValue,
-  propertyRegistry: CustomProperties
+  propertyRegistry: CustomProperties,
+  inheritedPropertyRegistry: CustomProperties
 ): string | number | null {
   const result: Array<string | number> = [];
   for (const value of propValue.values()) {
@@ -84,7 +89,8 @@ export function resolveVariableReferences(
       const resolvedValue = resolveVariableReferenceValue(
         propName,
         value,
-        propertyRegistry
+        propertyRegistry,
+        inheritedPropertyRegistry
       );
       if (resolvedValue == null) {
         // Failure to resolve a css variable in a value means the entire value is unparsable so we bail out and

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -325,6 +325,7 @@ function resolveStyle<S: { +[string]: mixed }>(
   options: SpreadOptions
 ): S {
   const customProperties = options.customProperties || {};
+  const inheritedCustomProperties = options.inheritedCustomProperties || {};
   const result: { [string]: mixed } = {};
   const stylesToReprocess: { [string]: mixed } = {};
   const propNames = Object.keys(style);
@@ -354,7 +355,8 @@ function resolveStyle<S: { +[string]: mixed }>(
       const resolvedValue = resolveVariableReferences(
         propName,
         styleValue,
-        customProperties
+        customProperties,
+        inheritedCustomProperties
       );
       if (resolvedValue != null) {
         stylesToReprocess[propName] = resolvedValue;


### PR DESCRIPTION
The customProperties map can get very large, and creating copies every render can lead to avoidable GC. This diff removes most places where copies are being made.