### PR TITLE
Add support for default color token values from DSP

### DIFF
--- a/apps/examples/src/tokens.stylex.js
+++ b/apps/examples/src/tokens.stylex.js
@@ -18,5 +18,8 @@ export const tokens: VarGroup<
   }>
 > = css.defineVars({
   squareColor: 'red',
-  textColor: 'darkred'
+  textColor: {
+    default: 'darkred',
+    '@media (prefers-color-scheme: dark)': 'lightred'
+  }
 });

--- a/packages/react-strict-dom/src/native/stylex/customProperties.js
+++ b/packages/react-strict-dom/src/native/stylex/customProperties.js
@@ -56,6 +56,11 @@ function resolveVariableReferenceValue(
   }
 
   if (variableValue != null) {
+    if (typeof variableValue === 'object' && variableValue.default != null) {
+      // TODO: Support dark theme through media queries too.
+      const defaultValue = variableValue.default;
+      return defaultValue;
+    }
     return variableValue;
   } else if (fallbackValue != null) {
     const resolvedFallback = resolveVariableReferences(

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -3,26 +3,35 @@
 exports[`properties: custom property css.createTheme: css.__customProperties 1`] = `
 {
   "rootColor__id__1": "red",
-  "rootColor__id__2": "red",
+  "rootColor__id__3": "red",
+  "themeAwareColor__id__2": {
+    "@media (prefers-color-scheme: dark)": "green",
+    "default": "blue",
+  },
 }
 `;
 
 exports[`properties: custom property css.createTheme: theme 1`] = `
 {
   "$$theme": "theme",
-  "rootColor__id__2": "green",
+  "rootColor__id__3": "green",
 }
 `;
 
 exports[`properties: custom property css.defineVars: css.__customProperties 1`] = `
 {
   "rootColor__id__1": "red",
+  "themeAwareColor__id__2": {
+    "@media (prefers-color-scheme: dark)": "green",
+    "default": "blue",
+  },
 }
 `;
 
 exports[`properties: custom property css.defineVars: tokens 1`] = `
 {
   "rootColor": "var(--rootColor__id__1)",
+  "themeAwareColor": "var(--themeAwareColor__id__2)",
 }
 `;
 

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -1135,7 +1135,11 @@ describe('properties: custom property', () => {
 
   test('css.defineVars', () => {
     const tokens = css.defineVars({
-      rootColor: 'red'
+      rootColor: 'red',
+      themeAwareColor: {
+        default: 'blue',
+        '@media (prefers-color-scheme: dark)': 'green'
+      }
     });
     expect(tokens).toMatchSnapshot('tokens');
     expect(css.__customProperties).toMatchSnapshot('css.__customProperties');
@@ -1145,6 +1149,12 @@ describe('properties: custom property', () => {
         tokens.rootColor
       ])
     ).toEqual('red');
+    expect(
+      resolveCustomPropertyValue(css.__customProperties, [
+        'color',
+        tokens.themeAwareColor
+      ])
+    ).toEqual('blue');
   });
 
   test('css.createTheme', () => {


### PR DESCRIPTION
The color token values have the following structure:
```tsx
   "positive": {
      "default": "#31A24C",
      "@media (prefers-color-scheme: dark)": "#31A24C"
   },
```

However, `resolveVariableReferenceValue` function only support `string` type. All other value types falls to the else statement and returned as-it-is. Currently, This leads to the `color` value to be of the type `[Object object]`, which cannot be parsed by CSS.
With this simple change, we handle the case when the `variableValue` is an object, and return the default value.

TODO: Still need to return dark-theme through media queries `@media (prefers-color-scheme: dark)`.