### PR TITLE
Avoid duplicate console messages

### DIFF
--- a/packages/react-strict-dom/src/shared/logUtils.js
+++ b/packages/react-strict-dom/src/shared/logUtils.js
@@ -7,14 +7,28 @@
  * @flow strict
  */
 
+const loggedMessages: { [string]: boolean, ... } = {};
+
 export function errorMsg(msg: string) {
+  if (process.env.NODE_ENV !== 'test' && loggedMessages[msg]) {
+    return;
+  }
+  loggedMessages[msg] = true;
   console.error(`[error] React Strict DOM: ${msg}`);
 }
 
 export function logMsg(msg: string) {
+  if (process.env.NODE_ENV !== 'test' && loggedMessages[msg]) {
+    return;
+  }
+  loggedMessages[msg] = true;
   console.log(`[log] React Strict DOM: ${msg}`);
 }
 
 export function warnMsg(msg: string) {
+  if (process.env.NODE_ENV !== 'test' && loggedMessages[msg]) {
+    return;
+  }
+  loggedMessages[msg] = true;
   console.warn(`[warn] React Strict DOM: ${msg}`);
 }


### PR DESCRIPTION
Reduce repeated messages in the logs so there is only one warning or error for each type of issue. In the test environment, every instance is still logged.