### PR TITLE
Don't render Context Providers unless needed

### DIFF
--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -63,7 +63,7 @@ type ClickEventData = {
   shiftKey: boolean
 };
 
-export default function App(): React.MixedElement {
+function Shell(): React.MixedElement {
   const [clickData, setClickData] = React.useState({ color: 'red', text: '' });
   const [clickEventData, setClickEventData] = React.useState<ClickEventData>({
     altKey: false,
@@ -524,6 +524,14 @@ export default function App(): React.MixedElement {
         </ExampleBlock>
       </html.div>
     </ScrollView>
+  );
+}
+
+export default function App(): React.MixedElement {
+  return (
+    <React.StrictMode>
+      <Shell />
+    </React.StrictMode>
   );
 }
 

--- a/packages/react-strict-dom/src/native/index.js
+++ b/packages/react-strict-dom/src/native/index.js
@@ -8,14 +8,17 @@
  */
 
 import typeof * as TStyleX from '@stylexjs/stylex';
+import { typeof CSSCustomPropertiesProvider as TCSSCustomPropertiesProvider } from './modules/CSSCustomPropertiesContext';
+
 export * from '../types/StrictTypes';
 
 import * as html from './html';
 import * as cssRaw from './stylex';
-import { ThemeProvider } from './modules/ThemeContext';
-import { typeof ThemeProvider as TThemeProvider } from './modules/ThemeContext';
+import { CSSCustomPropertiesProvider } from './modules/CSSCustomPropertiesContext';
 
-const contexts = { ThemeProvider: ThemeProvider as TThemeProvider };
+const contexts = {
+  ThemeProvider: CSSCustomPropertiesProvider as TCSSCustomPropertiesProvider
+};
 
 // Export using StyleX types as the shim has divergent types internally.
 const css: TStyleX = cssRaw as $FlowFixMe;

--- a/packages/react-strict-dom/src/native/modules/CSSCustomPropertiesContext.js
+++ b/packages/react-strict-dom/src/native/modules/CSSCustomPropertiesContext.js
@@ -17,18 +17,28 @@ type ProviderProps = $ReadOnly<{
   customProperties: ProviderValue
 }>;
 
-type TThemeContext = React$Context<ProviderValue>;
+type TCSSCustomPropertiesContext = React$Context<ProviderValue>;
 
 const defaultContext = __customProperties;
 
-export const ThemeContext: TThemeContext = React.createContext(defaultContext);
+export const CSSCustomPropertiesContext: TCSSCustomPropertiesContext =
+  React.createContext(defaultContext);
 
-export function ThemeProvider(props: ProviderProps): React$MixedElement {
+export function CSSCustomPropertiesProvider(
+  props: ProviderProps
+): React$MixedElement {
   const { children, customProperties } = props;
 
   return customProperties ? (
-    <ThemeContext.Provider children={children} value={customProperties} />
+    <CSSCustomPropertiesContext.Provider
+      children={children}
+      value={customProperties}
+    />
   ) : (
     children
   );
+}
+
+if (__DEV__) {
+  CSSCustomPropertiesContext.displayName = 'CSSCustomProperties';
 }

--- a/packages/react-strict-dom/src/native/modules/CSSDisplayModeInsideContext.js
+++ b/packages/react-strict-dom/src/native/modules/CSSDisplayModeInsideContext.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import * as React from 'react';
+
+type Value = 'flow' | 'flex';
+
+const defaultContext = 'flow';
+
+export const CSSDisplayModeInsideContext: React$Context<Value> =
+  React.createContext(defaultContext);
+
+if (__DEV__) {
+  CSSDisplayModeInsideContext.displayName = 'CSSDisplayModeInside';
+}

--- a/packages/react-strict-dom/src/native/modules/CSSFontSizeContext.js
+++ b/packages/react-strict-dom/src/native/modules/CSSFontSizeContext.js
@@ -7,13 +7,15 @@
  * @flow strict
  */
 
-import type { Style } from '../../types/styles';
-
 import * as React from 'react';
 
-type ProviderValue = ?Style;
+type Value = ?number;
 
-const defaultContext: ProviderValue = {};
+const defaultContext = null;
 
-export const InheritableStyleContext: React$Context<ProviderValue> =
+export const CSSFontSizeContext: React$Context<Value> =
   React.createContext(defaultContext);
+
+if (__DEV__) {
+  CSSFontSizeContext.displayName = 'CSSFontSize';
+}

--- a/packages/react-strict-dom/src/native/modules/CSSStyleContext.js
+++ b/packages/react-strict-dom/src/native/modules/CSSStyleContext.js
@@ -7,11 +7,17 @@
  * @flow strict
  */
 
+import type { Style } from '../../types/styles';
+
 import * as React from 'react';
 
-type FontSizeValue = ?number;
+type ProviderValue = ?Style;
 
-const defaultContext = null;
+const defaultContext: ProviderValue = {};
 
-export const FontSizeContext: React$Context<FontSizeValue> =
+export const CSSStyleContext: React$Context<ProviderValue> =
   React.createContext(defaultContext);
+
+if (__DEV__) {
+  CSSStyleContext.displayName = 'CSSStyle';
+}

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -11,7 +11,7 @@ import type { Styles } from '../../types/styles';
 
 import * as React from 'react';
 import { typeof Animated, PixelRatio, useWindowDimensions } from 'react-native';
-import { FontSizeContext } from './FontSizeContext';
+import { CSSFontSizeContext } from './CSSFontSizeContext';
 import * as stylex from '../stylex';
 
 type StyleOptions = {
@@ -39,7 +39,7 @@ export function useStyleProps(
   ...
 }> {
   const { height, width } = useWindowDimensions();
-  const inheritedFontSize = React.useContext(FontSizeContext);
+  const inheritedFontSize = React.useContext(CSSFontSizeContext);
   const fontScale = PixelRatio.getFontScale();
   const { customProperties, inheritedCustomProperties, hover } = options;
 


### PR DESCRIPTION
Skip rendering the existing Context Providers where possible. This patch significantly reduces how many providers are rendered by default, and provides dev-time debugging names for the providers that do get rendered.

**Before**

<img width="697" alt="image" src="https://github.com/facebook/react-strict-dom/assets/239676/66eac926-b4e9-4264-ba07-d2f1a4a09eb4">

**After**

<img width="697" alt="image" src="https://github.com/facebook/react-strict-dom/assets/239676/23702935-94be-4a67-8aea-ec92e1c27101">

