### PR TITLE
Simplify resolving of custom property values

### DIFF
--- a/packages/react-strict-dom/src/native/modules/ContextCustomProperties.js
+++ b/packages/react-strict-dom/src/native/modules/ContextCustomProperties.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 import { __customProperties } from '../stylex';
 
-type Value = $ReadOnly<{ [string]: string | number }>;
+type Value = $ReadOnly<{ [key: string]: string | number }>;
 
 const defaultContext = __customProperties;
 const ContextCustomProperties: React$Context<Value> =
@@ -22,7 +22,16 @@ if (__DEV__) {
 
 export const CustomPropertiesProvider = ContextCustomProperties.Provider;
 
-export function useCustomProperties(): Value {
-  const context = React.useContext(ContextCustomProperties);
-  return context;
+export function useCustomProperties(customPropertiesFromThemes: ?Value): Value {
+  const inheritedCustomProperties = React.useContext(ContextCustomProperties);
+  if (customPropertiesFromThemes == null) {
+    return inheritedCustomProperties;
+  }
+  // TODO: optimize
+  const customProperties = Object.assign(
+    {},
+    inheritedCustomProperties,
+    customPropertiesFromThemes
+  );
+  return customProperties;
 }

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -409,12 +409,11 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       /**
        * Resolve the style props
        */
-      const inheritedCustomProperties = useCustomProperties();
-      const inheritedStyles = useInheritedStyles();
-
       const [extractedStyles, customPropertiesFromThemes] = extractStyleThemes(
         props.style
       );
+      const customProperties = useCustomProperties(customPropertiesFromThemes);
+      const inheritedStyles = useInheritedStyles();
 
       const {
         color,
@@ -531,7 +530,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       }
 
       const _styleProps = useStyleProps(renderStyles, {
-        customProperties: customPropertiesFromThemes,
+        customProperties,
         hover,
         // $FlowFixMe
         inheritedFontSize: inheritedStyles?.fontSize
@@ -687,7 +686,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         element = (
           <InheritedStylesProvider
             children={element}
-            customProperties={customPropertiesFromThemes}
+            customProperties={customProperties}
             hover={hover}
             value={nextInheritedStyles}
           />
@@ -707,10 +706,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         element = (
           <CustomPropertiesProvider
             children={element}
-            value={{
-              ...inheritedCustomProperties,
-              ...customPropertiesFromThemes
-            }}
+            value={customProperties}
           />
         );
       }

--- a/packages/react-strict-dom/src/native/modules/extractStyleThemes.js
+++ b/packages/react-strict-dom/src/native/modules/extractStyleThemes.js
@@ -10,6 +10,7 @@
 import type { Style, Styles } from '../../types/styles';
 
 type CustomProperties = { [string]: string | number };
+
 // TODO: optimize
 export function extractStyleThemes(
   mixOfStyleAndTheme: ?Styles | Style | Array<Styles | Style>

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -12,7 +12,6 @@ import type { Styles } from '../../types/styles';
 
 import { PixelRatio, useWindowDimensions } from 'react-native';
 import * as stylex from '../stylex';
-import { useCustomProperties } from './ContextCustomProperties';
 
 type StyleOptions = {
   customProperties: ?$ReadOnly<{ [string]: string | number }>,
@@ -42,7 +41,6 @@ export function useStyleProps(
 
   const { height, width } = useWindowDimensions();
   const fontScale = PixelRatio.getFontScale();
-  const inheritedCustomProperties = useCustomProperties();
 
   // Marking it as `any` as Flow slows to a crawl when trying to type this.
   // But we already know that `style` is the correct type so this is still safe.
@@ -51,7 +49,6 @@ export function useStyleProps(
       customProperties: customProperties ?? emptyObject,
       fontScale,
       hover,
-      inheritedCustomProperties: inheritedCustomProperties ?? emptyObject,
       // $FlowFixMe
       inheritedFontSize,
       passthroughProperties,

--- a/packages/react-strict-dom/src/native/stylex/customProperties.js
+++ b/packages/react-strict-dom/src/native/stylex/customProperties.js
@@ -32,14 +32,12 @@ export function stringContainsVariables(input: string): boolean {
 function resolveVariableReferenceValue(
   propName: string,
   variable: CSSVariableReferenceValue,
-  propertyRegistry: CustomProperties,
-  inheritedPropertyRegistry: CustomProperties
+  propertyRegistry: CustomProperties
 ) {
   const variableName = normalizeVariableName(variable.variable);
   const fallbackValue = variable.fallback;
 
-  let variableValue: string | number | null =
-    propertyRegistry[variableName] || inheritedPropertyRegistry[variableName];
+  let variableValue: string | number | null = propertyRegistry[variableName];
 
   // Perform variable resolution on the variable's resolved value if it itself
   // contains variables
@@ -50,8 +48,7 @@ function resolveVariableReferenceValue(
     variableValue = resolveVariableReferences(
       propName,
       CSSUnparsedValue.parse(propName, variableValue),
-      propertyRegistry,
-      inheritedPropertyRegistry
+      propertyRegistry
     );
   }
 
@@ -66,8 +63,7 @@ function resolveVariableReferenceValue(
     const resolvedFallback = resolveVariableReferences(
       propName,
       fallbackValue,
-      propertyRegistry,
-      inheritedPropertyRegistry
+      propertyRegistry
     );
     if (resolvedFallback != null) {
       return resolvedFallback;
@@ -85,8 +81,7 @@ function resolveVariableReferenceValue(
 export function resolveVariableReferences(
   propName: string,
   propValue: CSSUnparsedValue,
-  propertyRegistry: CustomProperties,
-  inheritedPropertyRegistry: CustomProperties
+  propertyRegistry: CustomProperties
 ): string | number | null {
   const result: Array<string | number> = [];
   for (const value of propValue.values()) {
@@ -94,8 +89,7 @@ export function resolveVariableReferences(
       const resolvedValue = resolveVariableReferenceValue(
         propName,
         value,
-        propertyRegistry,
-        inheritedPropertyRegistry
+        propertyRegistry
       );
       if (resolvedValue == null) {
         // Failure to resolve a css variable in a value means the entire value is unparsable so we bail out and

--- a/packages/react-strict-dom/src/native/stylex/flattenStyleXStyles.js
+++ b/packages/react-strict-dom/src/native/stylex/flattenStyleXStyles.js
@@ -15,6 +15,7 @@ type StylesArray<+T> = T | $ReadOnlyArray<StylesArray<T>>;
 
 type Styles = StylesArray<InlineStyle | false | void | null>;
 
+// TODO: optimize
 export function flattenStyle(...styles: $ReadOnlyArray<Styles>): {
   [key: string]: $FlowFixMe
 } {

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -30,7 +30,6 @@ type ResolveStyleOptions = $ReadOnly<{
   customProperties: $ReadOnly<{ [string]: string | number }>,
   fontScale: number | void,
   hover?: ?boolean,
-  inheritedCustomProperties: $ReadOnly<{ [string]: string | number }>,
   inheritedFontSize: ?number,
   passthroughProperties: $ReadOnlyArray<string>,
   viewportHeight: number,
@@ -332,7 +331,6 @@ function resolveStyle<S: { +[string]: mixed }>(
   options: ResolveStyleOptions
 ): S {
   const customProperties = options.customProperties || {};
-  const inheritedCustomProperties = options.inheritedCustomProperties || {};
   const inheritedFontSize = options.inheritedFontSize;
 
   const result: { [string]: mixed } = {};
@@ -364,8 +362,7 @@ function resolveStyle<S: { +[string]: mixed }>(
       const resolvedValue = resolveVariableReferences(
         propName,
         styleValue,
-        customProperties,
-        inheritedCustomProperties
+        customProperties
       );
       if (resolvedValue != null) {
         stylesToReprocess[propName] = resolvedValue;


### PR DESCRIPTION
Simplifies the resolving logic so the concept of "inherited" custom properties isn't exposed beyond the React code. Any time there are custom properties from themes, we have to create a new object for that component during render - this object can be passed to the style resolving functions too.