### PR TITLE
Fix text truncation ellipsis on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ React Native compatibility is a work in progress. Please see [COMPATIBILITY.md](
 * `apps`
   * Example applications.
   * [examples](https://github.com/facebook/react-strict-dom/blob/main/apps/examples)
-* `configs`
-  * Contains configuration files used by the monorepo tooling (compiling, linting, testing, etc.)
 * `packages`
   * Contains the individual packages managed in the monorepo.
   * [eslint-plugin](https://github.com/facebook/react-strict-dom/blob/main/packages/eslint-plugin)
   * [react-strict-dom](https://github.com/facebook/react-strict-dom/blob/main/packages/react-strict-dom) ([docs](https://github.com/facebook/react-strict-dom/blob/main/packages/react-strict-dom/README.md))
+* `tools`
+  * Tools used by the monorepo (pre-commit tasks, etc.)
 
 ## Tasks
 
@@ -34,7 +34,7 @@ React Native compatibility is a work in progress. Please see [COMPATIBILITY.md](
   * Use `npm run dev` to run the dev script in every workspace.
   * Use `npm run dev -w <package-name>` to run the dev script for a specific workspace.
 * `test`
-  * Use `npm run test` to run tests for every workspace.
+  * Use `npm test` to run tests for every workspace.
 
 More details and setup instructions can be found in the [CONTRIBUTING][contributing] guide.
 

--- a/packages/react-strict-dom/COMPATIBILITY.md
+++ b/packages/react-strict-dom/COMPATIBILITY.md
@@ -553,7 +553,7 @@ Note these APIs can only be accessed using `Node.getRootNode().defaultView`, in 
 | justifySelf | ❌ | ❌ | |
 | left | ✅ | ✅ | |
 | letterSpacing | ✅ | ✅ | |
-| lineClamp | 🟡 | 🟡 | |
+| lineClamp | 🟡 | 🟡 | Disables text-selection on Android ([#136](https://github.com/facebook/react-strict-dom/issues/136)) |
 | lineHeight (unitless) | 🟡 | 🟡 | |
 | margin | ✅ | ✅ | |
 | marginBlock | 🟡 | 🟡 | |

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -48,6 +48,7 @@ import {
   TextInput,
   Text,
   View,
+  Platform,
   Pressable
 } from 'react-native';
 import * as stylex from '../stylex';
@@ -544,6 +545,16 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         ..._styleProps,
         style: { ..._styleProps.style }
       };
+
+      // Workaround: Android doesn't support ellipsis truncation if text is selectable
+      // See #136
+      if (
+        Platform.OS === 'android' &&
+        styleProps.numberOfLines != null &&
+        styleProps.style.userSelect !== 'none'
+      ) {
+        styleProps.style.userSelect = 'none';
+      }
 
       if (
         isString(children) &&

--- a/packages/react-strict-dom/tests/__mocks__/react-native.js
+++ b/packages/react-strict-dom/tests/__mocks__/react-native.js
@@ -46,6 +46,7 @@ export const Linking = {
 };
 
 export const Platform = {
+  OS: 'android',
   select(obj) {
     return obj.android || obj.ios || obj.native || obj.default;
   }

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -1658,3 +1658,18 @@ exports[`<html.*> style polyfills legacy: ThemeProvider 1`] = `
   Expect color:red
 </Text>
 `;
+
+exports[`<html.*> style polyfills lineClamp workaround for Android 1`] = `
+<Text
+  dir="auto"
+  numberOfLines={3}
+  style={
+    {
+      "position": "static",
+      "userSelect": "none",
+    }
+  }
+>
+  text
+</Text>
+`;

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -93,6 +93,18 @@ describe('<html.*>', () => {
       expect(root.toJSON()).toMatchSnapshot();
     });
 
+    // See #136
+    test('lineClamp workaround for Android', () => {
+      const styles = css.create({
+        root: {
+          lineClamp: 3
+        }
+      });
+      const root = create(<html.span style={styles.root}>text</html.span>);
+      // expect userSelect:none
+      expect(root.toJSON()).toMatchSnapshot();
+    });
+
     test('inherited themes', () => {
       const tokens = css.defineVars({
         rootColor: 'red',


### PR DESCRIPTION
Android does not support ellipsis overflows for text that is selectable. This patch trades off user-selection of text for the correct visual of rendering an ellipsis when text overflows the specified number of lines.