### PR TITLE
RSD benchmarks with --jitless

### DIFF
--- a/packages/react-strict-dom/package.json
+++ b/packages/react-strict-dom/package.json
@@ -11,7 +11,7 @@
     "!**/__tests__"
   ],
   "scripts": {
-    "benchmarks": "npm run build:benchmarks && node benchmarks/benchmarks.node.js",
+    "benchmarks": "npm run build:benchmarks && node --jitless benchmarks/benchmarks.node.js",
     "build:benchmarks": "rollup --config ./tools/rollup-benchmarks.config.js",
     "build": "rollup --config ./tools/rollup.config.js",
     "clean": "del-cli \"./build/*\" \"./dist/*\"",


### PR DESCRIPTION
This change was suggested by the React Native team to better approximate Hermes (no JIT).