### PR TITLE
Fix string auto-wrap hack with style inheritance of themes

### DIFF
--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -398,21 +398,44 @@ function Shell(): React.MixedElement {
         <ExampleBlock title="CSS Variables & Theming">
           <html.p style={styles.inheritedText}>Global variables</html.p>
           <html.div style={styles.square} />
+          <html.input
+            placeholder="input type:text"
+            // $FlowFixMe
+            style={styles.input}
+            type="text"
+          />
 
           <html.p style={[themedTokens, styles.inheritedText]}>
             Direct theming
           </html.p>
           <html.div style={[themedTokens, styles.square]} />
+          <html.input
+            placeholder="input type:text"
+            style={[themedTokens, [styles.input]]}
+            type="text"
+          />
 
           <html.div style={themedTokens}>
             <html.p style={styles.inheritedText}>Inherit theming</html.p>
             <html.div style={styles.square} />
+            <html.input
+              placeholder="input type:text"
+              // $FlowFixMe
+              style={styles.input}
+              type="text"
+            />
           </html.div>
 
           <html.div style={themedTokens}>
             <html.div style={themedTokensAlt}>
               <html.p style={styles.inheritedText}>Nested theming</html.p>
               <html.div style={styles.square} />
+              <html.input
+                placeholder="input type:text"
+                // $FlowFixMe
+                style={styles.input}
+                type="text"
+              />
             </html.div>
           </html.div>
         </ExampleBlock>
@@ -550,12 +573,16 @@ const animateSequence = css.keyframes({
 
 const themedTokens = css.createTheme(tokens, {
   squareColor: 'purple',
-  textColor: 'purple'
+  textColor: 'purple',
+  inputColor: 'purple',
+  inputPlaceholderColor: 'mediumpurple'
 });
 
 const themedTokensAlt = css.createTheme(tokens, {
-  squareColor: 'orange',
-  textColor: 'darkorange'
+  squareColor: 'darkorange',
+  textColor: 'darkorange',
+  inputColor: 'orangered',
+  inputPlaceholderColor: 'orange'
 });
 
 const styles = css.create({
@@ -711,5 +738,12 @@ const styles = css.create({
   text: {
     fontSize: '2em',
     backgroundColor: 'rgba(255,0,0,0.25)'
+  },
+  input: {
+    color: tokens.inputColor,
+    fontWeight: 'bold',
+    '::placeholder': {
+      color: tokens.inputPlaceholderColor
+    }
   }
 });

--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -135,6 +135,7 @@ function Shell(): React.MixedElement {
           {/* text inheritance and text children */}
           <html.div>Text inside div (kind of) works</html.div>
           <html.div style={styles.inheritedText}>
+            <html.div>Text style inheritance works</html.div>
             <html.div>
               <html.span>Text style inheritance works</html.span>
             </html.div>

--- a/apps/examples/src/tokens.stylex.js
+++ b/apps/examples/src/tokens.stylex.js
@@ -14,12 +14,16 @@ import { css } from 'react-strict-dom';
 export const tokens: VarGroup<
   $ReadOnly<{
     squareColor: string,
-    textColor: string
+    textColor: string,
+    inputColor: string,
+    inputPlaceholderColor: string
   }>
 > = css.defineVars({
   squareColor: 'red',
   textColor: {
     default: 'darkred',
     '@media (prefers-color-scheme: dark)': 'lightred'
-  }
+  },
+  inputColor: 'red',
+  inputPlaceholderColor: 'pink'
 });

--- a/packages/react-strict-dom/src/native/modules/ContextCustomProperties.js
+++ b/packages/react-strict-dom/src/native/modules/ContextCustomProperties.js
@@ -7,13 +7,13 @@
  * @flow strict
  */
 
+import type { CustomProperties } from '../../types/styles';
+
 import * as React from 'react';
 import { __customProperties } from '../stylex';
 
-type Value = $ReadOnly<{ [key: string]: string | number }>;
-
 const defaultContext = __customProperties;
-const ContextCustomProperties: React$Context<Value> =
+const ContextCustomProperties: React$Context<CustomProperties> =
   React.createContext(defaultContext);
 
 if (__DEV__) {
@@ -22,7 +22,9 @@ if (__DEV__) {
 
 export const CustomPropertiesProvider = ContextCustomProperties.Provider;
 
-export function useCustomProperties(customPropertiesFromThemes: ?Value): Value {
+export function useCustomProperties(
+  customPropertiesFromThemes: ?CustomProperties
+): CustomProperties {
   const inheritedCustomProperties = React.useContext(ContextCustomProperties);
   if (customPropertiesFromThemes == null) {
     return inheritedCustomProperties;

--- a/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
+++ b/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
@@ -7,7 +7,7 @@
  * @flow strict-local
  */
 
-import type { Style } from '../../types/styles';
+import type { CustomProperties, Style } from '../../types/styles';
 
 import * as React from 'react';
 import { flattenStyle } from './flattenStyle';
@@ -17,7 +17,7 @@ type Value = Style;
 
 type ProviderProps = $ReadOnly<{
   children: React$MixedElement,
-  customProperties: ?$ReadOnly<{ [string]: string | number }>,
+  customProperties: ?CustomProperties,
   hover: boolean,
   value: Value
 }>;

--- a/packages/react-strict-dom/src/native/modules/TextString.js
+++ b/packages/react-strict-dom/src/native/modules/TextString.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import * as React from 'react';
+import { Text } from 'react-native';
+import { useCustomProperties } from './ContextCustomProperties';
+import { useInheritedStyles } from './ContextInheritedStyles';
+import { useStyleProps } from './useStyleProps';
+
+type Props = $ReadOnly<{|
+  children: string,
+  hover: boolean
+|}>;
+
+export function TextString(props: Props): React$MixedElement {
+  const { children, hover } = props;
+
+  const customProperties = useCustomProperties();
+  const inheritedStyles: $FlowFixMe = useInheritedStyles();
+  const inheritedFontSize =
+    typeof inheritedStyles?.fontSize === 'number'
+      ? inheritedStyles?.fontSize
+      : undefined;
+
+  const styleProps = useStyleProps(inheritedStyles, {
+    customProperties,
+    hover,
+    inheritedFontSize: inheritedFontSize
+  });
+
+  return (
+    // $FlowFixMe
+    <Text {...styleProps} children={children} />
+  );
+}

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -421,6 +421,8 @@ export function createStrictDOMComponent<T, P: StrictProps>(
           ? inheritedStyles?.fontSize
           : undefined;
 
+      const flatStyle = flattenStyle(extractedStyles);
+
       const {
         color,
         cursor,
@@ -435,8 +437,8 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         textIndent,
         textTransform,
         whiteSpace,
-        ...nonTextStyles
-      } = flattenStyle(extractedStyles);
+        ...nonTextStyle
+      } = flatStyle;
 
       const nextInheritedStyles: { ...Style } = {};
       if (color != null) {
@@ -499,18 +501,24 @@ export function createStrictDOMComponent<T, P: StrictProps>(
                 styles.aspectRatio(width, height)
             ]
           : null,
-        // Add default text styles
-        nativeComponent === Text && styles.userSelectAuto,
-        // Provided styles
-        nativeComponent === Text
-          ? [inheritedStyles, extractedStyles]
-          : [nonTextStyles]
+        // Styles for Text
+        nativeComponent === Text && [
+          styles.userSelectAuto,
+          inheritedStyles,
+          flatStyle
+        ],
+        // Styles for TextInput
+        nativeComponent === TextInput && [flatStyle],
+        // Styles for everything else
+        (nativeComponent !== Text || nativeComponent !== TextInput) && [
+          nonTextStyle
+        ]
       ];
 
       const { hover, handlers } = useHoverHandlers(
         // we include the next inherited styles for non-text
         // so that any related hover handlers get attached.
-        nativeComponent === Text
+        nativeComponent === Text || nativeComponent === TextInput
           ? renderStyles
           : [renderStyles, nextInheritedStyles as $FlowFixMe]
       );

--- a/packages/react-strict-dom/src/native/modules/extractStyleThemes.js
+++ b/packages/react-strict-dom/src/native/modules/extractStyleThemes.js
@@ -7,9 +7,7 @@
  * @flow strict
  */
 
-import type { Style, Styles } from '../../types/styles';
-
-type CustomProperties = { [key: string]: string | number };
+import type { CustomProperties, Style, Styles } from '../../types/styles';
 
 const emptyValue = [undefined, undefined];
 
@@ -29,7 +27,7 @@ export function extractStyleThemes(
     if (item !== null && typeof item === 'object') {
       if (item.$$theme != null) {
         for (const key in item) {
-          if (typeof item[key] === 'string') {
+          if (item[key] !== undefined) {
             theme[key] = item[key];
           }
         }

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -8,13 +8,13 @@
  */
 
 import { typeof Animated } from 'react-native';
-import type { Styles } from '../../types/styles';
+import type { CustomProperties, Styles } from '../../types/styles';
 
 import { PixelRatio, useColorScheme, useWindowDimensions } from 'react-native';
 import * as stylex from '../stylex';
 
 type StyleOptions = {
-  customProperties: ?$ReadOnly<{ [string]: string | number }>,
+  customProperties: ?CustomProperties,
   hover: boolean,
   inheritedFontSize: ?number
 };
@@ -25,8 +25,8 @@ export function useStyleProps(
   style: Styles,
   options: StyleOptions
 ): $ReadOnly<{
-  style?: $ReadOnly<{
-    [key: string]: string | number | Animated['Value']
+  style?: ?$ReadOnly<{
+    [key: string]: ?(string | number | Animated['Value'])
   }>,
   ...
 }> {
@@ -44,7 +44,6 @@ export function useStyleProps(
       customProperties: customProperties ?? emptyObject,
       fontScale,
       hover,
-      // $FlowFixMe
       inheritedFontSize,
       viewportHeight: height,
       viewportWidth: width

--- a/packages/react-strict-dom/src/native/stylex/customProperties.js
+++ b/packages/react-strict-dom/src/native/stylex/customProperties.js
@@ -7,12 +7,11 @@
  * @flow strict
  */
 
+import type { CustomProperties } from '../../types/styles';
+
 import { CSSUnparsedValue } from './typed-om/CSSUnparsedValue';
 import { CSSVariableReferenceValue } from './typed-om/CSSVariableReferenceValue';
 import { warnMsg } from '../../shared/logUtils';
-
-export type MutableCustomProperties = { [key: string]: string | number };
-export type CustomProperties = $ReadOnly<MutableCustomProperties>;
 
 const memoizedValues = new Map<string, string>();
 
@@ -50,7 +49,7 @@ function resolveVariableReferenceValue(
   const variableName = normalizeVariableName(variable.variable);
   const fallbackValue = variable.fallback;
 
-  let variableValue: string | number | null = propertyRegistry[variableName];
+  let variableValue: mixed = propertyRegistry[variableName];
 
   // Perform variable resolution on the variable's resolved value if it itself
   // contains variables
@@ -101,7 +100,7 @@ export function resolveVariableReferences(
   propertyRegistry: CustomProperties,
   colorScheme: 'light' | 'dark' = 'light'
 ): string | number | null {
-  const result: Array<string | number> = [];
+  const result: Array<mixed> = [];
   for (const value of propValue.values()) {
     if (value instanceof CSSVariableReferenceValue) {
       const resolvedValue = resolveVariableReferenceValue(

--- a/packages/react-strict-dom/src/native/stylex/fixContentBox.js
+++ b/packages/react-strict-dom/src/native/stylex/fixContentBox.js
@@ -7,9 +7,10 @@
  * @flow strict
  */
 
+import type { ReactNativeStyle } from '../../types/styles';
+
 import { warnMsg } from '../../shared/logUtils';
 
-type FlatStyle = { [key: string]: mixed };
 type Direction = 0 | 1 | 2 | 3;
 
 const TOP: Direction = 0;
@@ -43,7 +44,7 @@ const paddingMapping: [string, Direction[]][] = [
   ['paddingEnd', [END]]
 ];
 
-export function fixContentBox(flatStyle: FlatStyle): FlatStyle {
+export function fixContentBox(flatStyle: ReactNativeStyle): ReactNativeStyle {
   const border: [number, number, number, number] = [0, 0, 0, 0];
   const padding: [number, number, number, number] = [0, 0, 0, 0];
 
@@ -77,7 +78,7 @@ export function fixContentBox(flatStyle: FlatStyle): FlatStyle {
     ['maxHeight', correctionVertical]
   ]);
 
-  const nextStyle: FlatStyle = {};
+  const nextStyle: ReactNativeStyle = {};
   for (const styleProp of Object.keys(flatStyle)) {
     const correction = correctionMapping.get(styleProp);
     const styleValue = flatStyle[styleProp];

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -76,14 +76,14 @@ function processStyle(
       if (propName === '::placeholder') {
         const placeholderStyleProps = Object.keys(styleValue);
         for (let i = 0; i < placeholderStyleProps.length; i++) {
-          const propName = placeholderStyleProps[i];
-          if (propName === 'color') {
-            result['placeholderTextColor'] = styleValue[propName];
+          const prop = placeholderStyleProps[i];
+          if (prop === 'color') {
+            result['placeholderTextColor'] = processStyle({
+              color: styleValue.color
+            }).color;
           } else {
             if (__DEV__) {
-              warnMsg(
-                `unsupported "::placeholder" style property "${propName}"`
-              );
+              warnMsg(`unsupported "::placeholder" style property "${prop}"`);
             }
           }
         }
@@ -550,7 +550,9 @@ export function props(
       nextStyle.paddingStart = styleValue;
     } else if (styleProp === 'paddingInlineEnd') {
       nextStyle.paddingEnd = styleValue;
-    } else if (styleProp === 'placeholderTextColor') {
+    }
+    // '::placeholder' polyfill
+    else if (styleProp === 'placeholderTextColor') {
       nativeProps.placeholderTextColor = styleValue;
     }
     // visibility polyfill

--- a/packages/react-strict-dom/src/types/styles.js
+++ b/packages/react-strict-dom/src/types/styles.js
@@ -48,3 +48,8 @@ export type IStyleX = $ReadOnly<{
   createTheme: TStyleX['createTheme'],
   ...
 }>;
+
+export type MutableCustomProperties = { [string]: mixed };
+export type CustomProperties = $ReadOnly<MutableCustomProperties>;
+
+export type ReactNativeStyle = { [key: string]: ?(string | number) };

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -1554,6 +1554,38 @@ exports[`<html.*> style polyfills inherited styles 1`] = `
 </View>
 `;
 
+exports[`<html.*> style polyfills inherited styles for auto-fix of raw strings 1`] = `
+<View
+  experimental_layoutConformance="strict"
+  style={
+    {
+      "position": "static",
+    }
+  }
+>
+  <View
+    experimental_layoutConformance="strict"
+    style={
+      {
+        "position": "static",
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "green",
+          "fontSize": 64,
+          "lineHeight": 192,
+        }
+      }
+    >
+      text
+    </Text>
+  </View>
+</View>
+`;
+
 exports[`<html.*> style polyfills inherited themes 1`] = `
 [
   <Text

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -617,6 +617,20 @@ exports[`<html.*> prop polyfills <input> "disabled" prop 1`] = `
 />
 `;
 
+exports[`<html.*> prop polyfills <input> "style" prop 1`] = `
+<TextInput
+  placeholderTextColor="pink"
+  style={
+    {
+      "borderWidth": 1,
+      "color": "red",
+      "fontWeight": "bold",
+      "position": "static",
+    }
+  }
+/>
+`;
+
 exports[`<html.*> prop polyfills <input> "type" prop: "email" 1`] = `
 <TextInput
   inputMode="email"
@@ -1612,6 +1626,16 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
   >
     Expect color:green
   </Text>,
+  <TextInput
+    placeholder="Expect placeholderTextColor:green"
+    placeholderTextColor="green"
+    style={
+      {
+        "borderWidth": 1,
+        "position": "static",
+      }
+    }
+  />,
   <View
     experimental_layoutConformance="strict"
     style={
@@ -1632,6 +1656,16 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
     >
       Expect color:green (inherited)
     </Text>
+    <TextInput
+      placeholder="Expect placeholderTextColor:green"
+      placeholderTextColor="green"
+      style={
+        {
+          "borderWidth": 1,
+          "position": "static",
+        }
+      }
+    />
     <View
       experimental_layoutConformance="strict"
       style={
@@ -1652,6 +1686,16 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
       >
         Expect color:blue (nested)
       </Text>
+      <TextInput
+        placeholder="Expect placeholderTextColor:blue"
+        placeholderTextColor="blue"
+        style={
+          {
+            "borderWidth": 1,
+            "position": "static",
+          }
+        }
+      />
     </View>
   </View>,
   <Text

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -114,7 +114,10 @@ describe('<html.*>', () => {
         rootColor: 'green'
       });
       const nestedTheme = css.createTheme(tokens, {
-        rootColor: 'blue'
+        rootColor: {
+          default: 'blue',
+          '@media (prefers-color-scheme: dark)': 'purple'
+        }
       });
 
       const styles = css.create({
@@ -254,6 +257,37 @@ describe('<html.*>', () => {
       expect(secondSpan.props.style.lineHeight).toBe(1.5 * 20);
       const secondSpanInner = secondSpan.children[0];
       expect(secondSpanInner.props.style.lineHeight).toBe(2 * 20);
+    });
+
+    test('inherited styles for auto-fix of raw strings', () => {
+      const tokens = css.defineVars({
+        color: 'red',
+        fontSize: '1em',
+        lineHeight: 1
+      });
+      const theme = css.createTheme(tokens, {
+        color: 'green',
+        fontSize: '2em',
+        lineHeight: 3
+      });
+
+      const styles = css.create({
+        root: {
+          color: tokens.color,
+          fontSize: tokens.fontSize,
+          lineHeight: tokens.lineHeight
+        },
+        text: {
+          fontSize: tokens.fontSize
+        }
+      });
+
+      const root = create(
+        <html.div style={[theme, styles.root]}>
+          <html.div style={styles.text}>text</html.div>
+        </html.div>
+      );
+      expect(root.toJSON()).toMatchSnapshot();
     });
 
     test.skip('"inherit" keyword', () => {});

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -124,6 +124,11 @@ describe('<html.*>', () => {
         root: {
           backgroundColor: tokens.otherColor,
           color: tokens.rootColor
+        },
+        input: {
+          '::placeholder': {
+            color: tokens.rootColor
+          }
         }
       });
 
@@ -131,14 +136,26 @@ describe('<html.*>', () => {
         <>
           <html.span style={styles.root}>Expect color:red</html.span>
           <html.span style={[theme, styles.root]}>Expect color:green</html.span>
+          <html.input
+            placeholder="Expect placeholderTextColor:green"
+            style={[theme, styles.input]}
+          />
           <html.div style={theme}>
             <html.span style={styles.root}>
               Expect color:green (inherited)
             </html.span>
+            <html.input
+              placeholder="Expect placeholderTextColor:green"
+              style={styles.input}
+            />
             <html.div style={nestedTheme}>
               <html.span style={styles.root}>
                 Expect color:blue (nested)
               </html.span>
+              <html.input
+                placeholder="Expect placeholderTextColor:blue"
+                style={styles.input}
+              />
             </html.div>
           </html.div>
           <html.span style={styles.root}>Expect color:red</html.span>
@@ -756,6 +773,20 @@ describe('<html.*>', () => {
           create(<html.input type={type} />);
           expect(console.error).toHaveBeenCalledTimes(i + 1);
         });
+      });
+
+      test('"style" prop', () => {
+        const styles = css.create({
+          input: {
+            color: 'red',
+            fontWeight: 'bold',
+            '::placeholder': {
+              color: 'pink'
+            }
+          }
+        });
+        const root = create(<html.input style={styles.input} />);
+        expect(root.toJSON()).toMatchSnapshot();
       });
     });
 


### PR DESCRIPTION
This patch fixes a source of crashes in React Native and other bugs in the style resolving logic.

1. Previously, the automatic wrapping of raw text strings with `<Text>` didn't fully resolve inherited styles containing StyleX theme variables. Passing objects as style values to React Native  was responsible for the crash.

2. `customProperties` should have values typed `mixed`, since the value can be an object returned from `css.defineVars` when a dark theme Media Query is used in the variable definition.

3. `extractStyleThemes` was only extracting variable values of string type, which excluded numeric and object value theme overrides.

4. `lineHeight` was incorrectly resolved when wrapping raw text strings in a `<Text>`, because the computed `fontSize` could end up being excluded from the `lineHeight` calculation. This may also have occurred in the general case where a numeric fontSize were used.