### PR TITLE
Add support for experimental React Native style implementations

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -569,7 +569,17 @@ export function props(
     else if (styleProp === 'placeContent') {
       nextStyle.alignContent = nextStyle.alignContent ?? styleValue;
       nextStyle.justifyContent = nextStyle.justifyContent ?? styleValue;
-    } else {
+    }
+    // experimental styles
+    else if (styleProp === 'boxShadow') {
+      nextStyle.experimental_boxShadow = styleValue;
+    } else if (styleProp === 'filter') {
+      nextStyle.experimental_filter = styleValue;
+    } else if (styleProp === 'mixBlendMode') {
+      nextStyle.experimental_mixBlendMode = styleValue;
+    }
+    // Everything else
+    else {
       nextStyle[styleProp] = styleValue;
     }
   }

--- a/packages/react-strict-dom/src/native/stylex/isAllowedStyleKey.js
+++ b/packages/react-strict-dom/src/native/stylex/isAllowedStyleKey.js
@@ -7,6 +7,18 @@
  * @flow strict
  */
 
+// $FlowFixMe(nonstrict-import)
+import { Platform } from 'react-native';
+
+const version = Platform.constants.reactNativeVersion;
+const { major, minor, patch } = version;
+// Main branch OSS build, or internal build
+const isMain = major === 1000 && minor === 0 && patch === 0;
+// Nightly NPM package
+// $FlowFixMe (pre-release is number type)
+const isNightly = version?.prerelease?.startsWith('nightly-');
+const isExperimental = isMain || isNightly;
+
 const allowedStyleKeySet = new Set<string>([
   'alignContent',
   'alignItems',
@@ -156,6 +168,12 @@ const allowedStyleKeySet = new Set<string>([
   // Pseudo-element keys
   '::placeholder'
 ]);
+
+if (isExperimental) {
+  allowedStyleKeySet.add('boxShadow');
+  allowedStyleKeySet.add('filter');
+  allowedStyleKeySet.add('mixBlendMode');
+}
 
 export function isAllowedStyleKey(key: string): boolean {
   return (

--- a/packages/react-strict-dom/tests/__mocks__/react-native.js
+++ b/packages/react-strict-dom/tests/__mocks__/react-native.js
@@ -46,6 +46,16 @@ export const Linking = {
 };
 
 export const Platform = {
+  get constants() {
+    return {
+      reactNativeVersion: {
+        major: 1000,
+        minor: 0,
+        patch: 0,
+        prerelease: undefined
+      }
+    };
+  },
   OS: 'android',
   select(obj) {
     return obj.android || obj.ios || obj.native || obj.default;

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -86,6 +86,30 @@ exports[`properties: general borderStyle 2`] = `
 }
 `;
 
+exports[`properties: general boxShadow 1`] = `
+{
+  "style": {
+    "experimental_boxShadow": "1px 2px 3px 4px red",
+  },
+}
+`;
+
+exports[`properties: general boxShadow 2`] = `
+{
+  "style": {
+    "experimental_boxShadow": "1px 2px 3px 4px red, 2px 3px 4px 5px blue",
+  },
+}
+`;
+
+exports[`properties: general boxShadow 3`] = `
+{
+  "style": {
+    "experimental_boxShadow": "inset 1px 2px 3px 4px red",
+  },
+}
+`;
+
 exports[`properties: general boxSizing: content-box: allDifferent 1`] = `
 {
   "style": {
@@ -216,7 +240,13 @@ exports[`properties: general direction: rtl 1`] = `
 }
 `;
 
-exports[`properties: general filter 1`] = `{}`;
+exports[`properties: general filter 1`] = `
+{
+  "style": {
+    "experimental_filter": "blur(1px)",
+  },
+}
+`;
 
 exports[`properties: general fontSize: default 1`] = `
 {
@@ -307,6 +337,14 @@ exports[`properties: general marginHorizontal 1`] = `{}`;
 exports[`properties: general marginStart 1`] = `{}`;
 
 exports[`properties: general marginVertical 1`] = `{}`;
+
+exports[`properties: general mixBlendMode 1`] = `
+{
+  "style": {
+    "experimental_mixBlendMode": "multiply",
+  },
+}
+`;
 
 exports[`properties: general objectFit: contain 1`] = `
 {

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -157,28 +157,21 @@ describe('properties: general', () => {
 
   test('boxShadow', () => {
     const styles = css.create({
-      root: {
+      single: {
         boxShadow: '1px 2px 3px 4px red'
-      }
-    });
-    css.props.call(mockOptions, styles.root);
-    expect(console.warn).toHaveBeenCalledTimes(1);
-
-    const styles2 = css.create({
-      root: {
+      },
+      multi: {
         boxShadow: '1px 2px 3px 4px red, 2px 3px 4px 5px blue'
-      }
-    });
-    css.props.call(mockOptions, styles2.root);
-    expect(console.warn).toHaveBeenCalledTimes(2);
-
-    const styles3 = css.create({
-      root: {
+      },
+      inset: {
         boxShadow: 'inset 1px 2px 3px 4px red'
       }
     });
-    css.props.call(mockOptions, styles3.root);
-    expect(console.warn).toHaveBeenCalledTimes(3);
+    expect(css.props.call(mockOptions, styles.single)).toMatchSnapshot();
+
+    expect(css.props.call(mockOptions, styles.multi)).toMatchSnapshot();
+
+    expect(css.props.call(mockOptions, styles.inset)).toMatchSnapshot();
   });
 
   test('boxSizing: content-box', () => {
@@ -311,7 +304,6 @@ describe('properties: general', () => {
     expect(css.props.call(mockOptions, styles.rtl)).toMatchSnapshot('rtl');
   });
 
-  // unsupported
   test('filter', () => {
     const { underTest } = css.create({
       underTest: {
@@ -319,7 +311,6 @@ describe('properties: general', () => {
       }
     });
     expect(css.props.call(mockOptions, underTest)).toMatchSnapshot();
-    expect(console.warn).toHaveBeenCalled();
   });
 
   test('fontSize', () => {
@@ -451,6 +442,15 @@ describe('properties: general', () => {
     });
     expect(css.props.call(mockOptions, underTest)).toMatchSnapshot();
     expect(console.warn).toHaveBeenCalled();
+  });
+
+  test('mixBlendMode', () => {
+    const { underTest } = css.create({
+      underTest: {
+        mixBlendMode: 'multiply'
+      }
+    });
+    expect(css.props.call(mockOptions, underTest)).toMatchSnapshot();
   });
 
   test('objectFit', () => {

--- a/packages/react-strict-dom/tools/rollup/mock-react-native-for-benchmarks.js
+++ b/packages/react-strict-dom/tools/rollup/mock-react-native-for-benchmarks.js
@@ -50,6 +50,17 @@ const Linking = {
 };
 
 const Platform = {
+  get constants() {
+    return {
+      reactNativeVersion: {
+        major: 1000,
+        minor: 0,
+        patch: 0,
+        prerelease: undefined
+      }
+    };
+  },
+  OS: 'android',
   select(obj) {
     return obj.android || obj.ios || obj.native || obj.default;
   }


### PR DESCRIPTION
Include experimental boxShadow, filter, and mixBlendMode features. This requires React Native version detection.