### PR TITLE
fix: Define global types for TypeScript

### DIFF
--- a/packages/react-strict-dom/src/types/TypeShims.d.ts
+++ b/packages/react-strict-dom/src/types/TypeShims.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+declare global {
+  declare type ReactStrictDOMDataProps = {};
+  declare type Stringish = string;
+}

--- a/packages/scripts/generate-types.js
+++ b/packages/scripts/generate-types.js
@@ -86,12 +86,21 @@ async function generateTypes(inputDir, outputDir, rootDir) {
             continue;
           }
 
-          const outputTSContents = await translate.translateFlowDefToTSDef(
+          let outputTSContents = await translate.translateFlowDefToTSDef(
             outputFlowContents
               .replace(/\$ReadOnlyMap/g, 'ReadonlyMap')
               .replace(/\$ReadOnlySet/g, 'ReadonlySet'),
             monorepoPackage.prettier
           );
+
+          if (
+            path.dirname(outputFullPath).endsWith('react-strict-dom/dist/types')
+          ) {
+            outputTSContents = outputTSContents.replace(
+              'import ',
+              "import './TypeShims';\nimport "
+            );
+          }
 
           await fsPromises.writeFile(
             outputFullPath.replace(/\.js$/, '.d.ts'),


### PR DESCRIPTION
Fixes #113

This fixes the issue with missing types in Typescript. This does not not change the setup for Flow which still require the types be defined by the consumer.