### PR TITLE
Skip animation setup if no style transitions

### DIFF
--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -8,7 +8,7 @@
  */
 
 import type { StrictProps } from '../../types/StrictProps';
-import type { Style, Transform } from '../../types/styles';
+import type { Style } from '../../types/styles';
 import type {
   ChangeEvent,
   EditingEvent,
@@ -151,14 +151,14 @@ function isNumber(num: mixed): boolean %checks {
   return typeof num === 'number';
 }
 
-function resolveTransitionProperty(property: mixed): string[] {
+function resolveTransitionProperty(property: mixed): ?(string[]) {
   if (property === 'all') {
     return ['opacity', 'transform'];
   }
   if (typeof property === 'string') {
     return property.split(',').map((p) => p.trim());
   }
-  return [];
+  return null;
 }
 
 export function createStrictDOMComponent<T, P: StrictProps>(
@@ -643,16 +643,13 @@ export function createStrictDOMComponent<T, P: StrictProps>(
 
       const resolvedTransitionProperty =
         resolveTransitionProperty(transitionProperty);
-      const transitionProperties = resolvedTransitionProperty.flatMap(
+      const transitionProperties = resolvedTransitionProperty?.flatMap(
         (property) => {
           const value = styleProps.style[property];
           if (isString(value) || isNumber(value) || Array.isArray(value)) {
             return [{ property, value }];
           }
-          return [] as Array<{
-            property: string,
-            value: string | number | Transform[]
-          }>;
+          return [] as [];
         }
       );
       const animatedPropertyValues = useStyleTransition({

--- a/packages/react-strict-dom/src/native/modules/useStyleTransition.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleTransition.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 import type { AnimatedNode } from '../../types/react-native';
@@ -88,19 +88,20 @@ export function useStyleTransition(
   const animatedRef = useRef(new Animated.Value(0));
 
   useEffect(() => {
-    Animated.sequence([
-      Animated.delay(transitionDelay ?? 0),
-
-      Animated.timing(animatedRef.current, {
-        toValue: 1,
-        duration: transitionDuration ?? 16,
-        easing: getEasingFunction(transitionTimingFunction),
-        useNativeDriver: canUseNativeDriver(transitionProperties)
-      })
-    ]).start(() => {
-      valueRef.current = transitionProperties;
-      animatedRef.current = new Animated.Value(0);
-    });
+    if (transitionProperties != null) {
+      Animated.sequence([
+        Animated.delay(transitionDelay ?? 0),
+        Animated.timing(animatedRef.current, {
+          toValue: 1,
+          duration: transitionDuration ?? 16,
+          easing: getEasingFunction(transitionTimingFunction),
+          useNativeDriver: canUseNativeDriver(transitionProperties)
+        })
+      ]).start(() => {
+        valueRef.current = transitionProperties;
+        animatedRef.current = new Animated.Value(0);
+      });
+    }
   }, [
     transitionDelay,
     transitionDuration,

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -312,9 +312,12 @@ describe('<html.*>', () => {
     test.skip('"unset" keyword', () => {});
 
     test('"transition" properties ', () => {
-      const { Easing } = require('react-native');
+      const { Animated, Easing } = require('react-native');
 
       const styles = css.create({
+        none: {
+          backgroundColor: 'red'
+        },
         backgroundColor: (backgroundColor) => ({
           backgroundColor: backgroundColor ?? 'rgba(0,0,0,0.1)',
           transitionDelay: 200,
@@ -373,10 +376,11 @@ describe('<html.*>', () => {
       // default
       act(() => {
         root = create(<html.div />);
-        root.update(<html.div style={{}} />);
+        root.update(<html.div style={styles.none} />);
       });
       // assert no warning if no transition property is specified
       expect(console.warn).not.toHaveBeenCalled();
+      expect(Animated.sequence).not.toHaveBeenCalled();
 
       // backgroundColor transition
       act(() => {


### PR DESCRIPTION
The native polyfill for CSS transitions should not setup Animated calls unless transitions are defined.