### PR TITLE
Fix style inheritance logic in component creator

### DIFF
--- a/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
+++ b/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
@@ -7,18 +7,15 @@
  * @flow strict-local
  */
 
-import type { CustomProperties, Style } from '../../types/styles';
+import type { Style } from '../../types/styles';
 
 import * as React from 'react';
 import { flattenStyle } from './flattenStyle';
-import { useStyleProps } from './useStyleProps';
 
 type Value = Style;
 
 type ProviderProps = $ReadOnly<{
   children: React$MixedElement,
-  customProperties: ?CustomProperties,
-  hover: boolean,
   value: Value
 }>;
 
@@ -35,29 +32,9 @@ if (__DEV__) {
 export function InheritedStylesProvider(
   props: ProviderProps
 ): React$MixedElement {
-  const { children, customProperties, hover, value } = props;
-  const valueFontSize = value?.fontSize;
-
+  const { children, value } = props;
   const inheritedStyles = useInheritedStyles();
-  const inheritedFontSize = inheritedStyles?.fontSize;
-
-  const computedFontSize = useStyleProps(
-    { fontSize: valueFontSize } as $FlowFixMe,
-    {
-      customProperties,
-      hover,
-      // $FlowFixMe
-      inheritedFontSize
-    }
-  ).style?.fontSize;
-
-  const fontStyle = computedFontSize != null && { fontSize: computedFontSize };
-
-  const flatStyle = flattenStyle([
-    inheritedStyles as ?Style,
-    value as ?Style,
-    fontStyle as $FlowFixMe
-  ]);
+  const flatStyle = flattenStyle([inheritedStyles as ?Style, value as ?Style]);
 
   return (
     <ContextInheritedStyles.Provider children={children} value={flatStyle} />

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -8,7 +8,6 @@
  */
 
 import type { StrictProps } from '../../types/StrictProps';
-import type { Style } from '../../types/styles';
 import type {
   ChangeEvent,
   EditingEvent,
@@ -423,69 +422,6 @@ export function createStrictDOMComponent<T, P: StrictProps>(
 
       const flatStyle = flattenStyle(extractedStyles);
 
-      const {
-        color,
-        cursor,
-        fontFamily,
-        fontSize,
-        fontStyle,
-        fontVariant,
-        fontWeight,
-        letterSpacing,
-        lineHeight,
-        textAlign,
-        textIndent,
-        textTransform,
-        whiteSpace,
-        ...nonTextStyle
-      } = flatStyle;
-
-      const nextInheritedStyles: { ...Style } = {};
-      if (color != null) {
-        nextInheritedStyles.color = color;
-      }
-      if (cursor != null) {
-        nextInheritedStyles.cursor = cursor;
-      }
-      if (fontFamily != null) {
-        nextInheritedStyles.fontFamily = fontFamily;
-      }
-      if (fontSize != null) {
-        nextInheritedStyles.fontSize = fontSize;
-      }
-      if (fontStyle != null) {
-        nextInheritedStyles.fontStyle = fontStyle;
-      }
-      if (fontVariant != null) {
-        nextInheritedStyles.fontVariant = fontVariant;
-      }
-      if (fontWeight != null) {
-        nextInheritedStyles.fontWeight = fontWeight;
-      }
-      if (letterSpacing != null) {
-        nextInheritedStyles.letterSpacing = letterSpacing;
-      }
-      if (lineHeight != null) {
-        nextInheritedStyles.lineHeight = lineHeight;
-      }
-      if (textAlign != null) {
-        nextInheritedStyles.textAlign = textAlign;
-      }
-      if (textIndent != null) {
-        nextInheritedStyles.textIndent = textIndent;
-      }
-      if (textTransform != null) {
-        nextInheritedStyles.textTransform = textTransform;
-      }
-      if (whiteSpace != null) {
-        nextInheritedStyles.whiteSpace = whiteSpace;
-      }
-
-      const hasNextInheritedStyles =
-        nextInheritedStyles != null &&
-        typeof nextInheritedStyles === 'object' &&
-        Object.keys(nextInheritedStyles).length > 0;
-
       const renderStyles = [
         defaultProps?.style ?? null,
         // Use 'static' position by default where allowed
@@ -502,26 +438,13 @@ export function createStrictDOMComponent<T, P: StrictProps>(
             ]
           : null,
         // Styles for Text
-        nativeComponent === Text && [
-          styles.userSelectAuto,
-          inheritedStyles,
+        [
+          nativeComponent === Text && [styles.userSelectAuto, inheritedStyles],
           flatStyle
-        ],
-        // Styles for TextInput
-        nativeComponent === TextInput && [flatStyle],
-        // Styles for everything else
-        (nativeComponent !== Text || nativeComponent !== TextInput) && [
-          nonTextStyle
         ]
       ];
 
-      const { hover, handlers } = useHoverHandlers(
-        // we include the next inherited styles for non-text
-        // so that any related hover handlers get attached.
-        nativeComponent === Text || nativeComponent === TextInput
-          ? renderStyles
-          : [renderStyles, nextInheritedStyles as $FlowFixMe]
-      );
+      const { hover, handlers } = useHoverHandlers(renderStyles);
 
       if (handlers.type === 'HOVERABLE') {
         for (const handler of [
@@ -635,11 +558,77 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       // This is where we hack in a shim for `transitionProperty`,
       // `transitionDuration`, `transitionDelay`, `transitionTimingFunction`.
       const {
+        color,
+        cursor,
+        fontFamily,
+        fontSize,
+        fontStyle,
+        fontVariant,
+        fontWeight,
+        letterSpacing,
+        lineHeight, // eslint-disable-line no-unused-vars
+        textAlign,
+        textIndent,
+        textTransform,
+        whiteSpace,
         transitionDelay,
         transitionDuration,
         transitionProperty,
-        transitionTimingFunction
+        transitionTimingFunction,
+        ...nonTextStyle
       } = styleProps.style;
+
+      const nextInheritedStyles = {} as $FlowFixMe;
+      if (color != null) {
+        nextInheritedStyles.color = color;
+      }
+      if (cursor != null) {
+        nextInheritedStyles.cursor = cursor;
+      }
+      if (fontFamily != null) {
+        nextInheritedStyles.fontFamily = fontFamily;
+      }
+      if (fontSize != null) {
+        nextInheritedStyles.fontSize = fontSize;
+      }
+      if (fontStyle != null) {
+        nextInheritedStyles.fontStyle = fontStyle;
+      }
+      if (fontVariant != null) {
+        nextInheritedStyles.fontVariant = fontVariant;
+      }
+      if (fontWeight != null) {
+        nextInheritedStyles.fontWeight = fontWeight;
+      }
+      if (letterSpacing != null) {
+        nextInheritedStyles.letterSpacing = letterSpacing;
+      }
+      if (flatStyle.lineHeight != null) {
+        // Intentionally use the unresolved value to account for unitless
+        // lineHeight, which needs to be preserved when inherited.
+        nextInheritedStyles.lineHeight = flatStyle.lineHeight;
+      }
+      if (textAlign != null) {
+        nextInheritedStyles.textAlign = textAlign;
+      }
+      if (textIndent != null) {
+        nextInheritedStyles.textIndent = textIndent;
+      }
+      if (textTransform != null) {
+        nextInheritedStyles.textTransform = textTransform;
+      }
+      if (whiteSpace != null) {
+        nextInheritedStyles.whiteSpace = whiteSpace;
+      }
+
+      const hasNextInheritedStyles =
+        nextInheritedStyles != null &&
+        typeof nextInheritedStyles === 'object' &&
+        Object.keys(nextInheritedStyles).length > 0;
+
+      if (nativeComponent !== Text && nativeComponent !== TextInput) {
+        styleProps.style = nonTextStyle;
+      }
 
       const resolvedTransitionProperty =
         resolveTransitionProperty(transitionProperty);
@@ -701,8 +690,6 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         element = (
           <InheritedStylesProvider
             children={element}
-            customProperties={customProperties}
-            hover={hover}
             value={nextInheritedStyles}
           />
         );

--- a/packages/react-strict-dom/src/native/modules/useStyleTransition.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleTransition.js
@@ -188,6 +188,13 @@ export function useStyleTransition(
             (transforms[i].translateY != null &&
               refTransforms[i].translateY == null)
           ) {
+            if (__DEV__) {
+              warnMsg(
+                'The types of transforms must be the same before and after the transition. The transition will not animate.\n' +
+                  `Before: ${JSON.stringify(transforms)}\n` +
+                  `After: ${JSON.stringify(refTransforms)}`
+              );
+            }
             return transforms;
           }
         }

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -308,6 +308,19 @@ describe('<html.*>', () => {
       expect(root.toJSON()).toMatchSnapshot();
     });
 
+    test('fontSize to resolve em units', () => {
+      const styles = css.create({
+        root: {
+          fontSize: '2em',
+          maxHeight: '2em'
+        }
+      });
+      const root = create(<html.div style={styles.root} />);
+      const rootElement = root.toJSON();
+      expect(rootElement.props.style.fontSize).toBeUndefined();
+      expect(rootElement.props.style.maxHeight).toBe(2 * 2 * 16);
+    });
+
     test.skip('"inherit" keyword', () => {});
     test.skip('"initial" keyword', () => {});
     test.skip('"unset" keyword', () => {});


### PR DESCRIPTION
This patch fixes an issue where 'em' units weren't correctly resolved on non-text elements with a 'fontSize'. The component creator was not forwarding 'fontSize' to the style resolver, which mean 'em' units were falling back to using the default 'fontSize' of 16px.

Now the non-text elements only strip text styles after the styles have been fully resolved. This also simplifies the logic for the inherited styles context.