### PR TITLE
Fix TypeError: _version$prerelease.startsWith is not a function (it is undefined)

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/isAllowedStyleKey.js
+++ b/packages/react-strict-dom/src/native/stylex/isAllowedStyleKey.js
@@ -16,7 +16,7 @@ const { major, minor, patch } = version;
 const isMain = major === 1000 && minor === 0 && patch === 0;
 // Nightly NPM package
 // $FlowFixMe (pre-release is number type)
-const isNightly = version?.prerelease?.startsWith('nightly-');
+const isNightly = version?.prerelease?.toString()?.startsWith('nightly-');
 const isExperimental = isMain || isNightly;
 
 const allowedStyleKeySet = new Set<string>([


### PR DESCRIPTION
This PR fixes the following error that happens with `react-native@0.75.0-rc.4` and `react-strict-dom@0.0.18`.

```
TypeError: _version$prerelease.startsWith is not a function (it is undefined), js engine: hermes
```

```ts
console.log(version); // {"major": 0, "minor": 75, "patch": 0, "prerelease": 0}
```

<img width="484" alt="Screenshot 2024-07-11 at 09 00 36" src="https://github.com/facebook/react-strict-dom/assets/20516055/0e901975-5820-467c-8d38-77f98b9b8f49">

