### PR TITLE
Fix inheritance of em-based lineHeight

### DIFF
--- a/packages/react-strict-dom/src/native/modules/TextString.js
+++ b/packages/react-strict-dom/src/native/modules/TextString.js
@@ -9,6 +9,7 @@
 
 import * as React from 'react';
 import { Text } from 'react-native';
+import { resolveUnitlessLineHeight } from './resolveUnitlessLineHeight';
 import { useCustomProperties } from './ContextCustomProperties';
 import { useInheritedStyles } from './ContextInheritedStyles';
 import { useStyleProps } from './useStyleProps';
@@ -42,6 +43,8 @@ export function TextString(props: Props): React$MixedElement {
     // $FlowFixMe (safe to remove style at this point)
     delete styleProps.style;
   }
+
+  resolveUnitlessLineHeight(styleProps.style);
 
   return (
     // $FlowFixMe

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -40,6 +40,7 @@ import { errorMsg, warnMsg } from '../../shared/logUtils';
 import { extractStyleThemes } from './extractStyleThemes';
 import { isPropAllowed } from '../../shared/isPropAllowed';
 import { mergeRefs } from '../../shared/mergeRefs';
+import { resolveUnitlessLineHeight } from './resolveUnitlessLineHeight';
 import { useHoverHandlers } from './useHoverHandlers';
 import { useStrictDOMElement } from './useStrictDOMElement';
 import { useStyleProps } from './useStyleProps';
@@ -795,10 +796,8 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       if (letterSpacing != null) {
         nextInheritedStyles.letterSpacing = letterSpacing;
       }
-      if (flatStyle.lineHeight != null) {
-        // Intentionally use the unresolved value to account for unitless
-        // lineHeight, which needs to be preserved when inherited.
-        nextInheritedStyles.lineHeight = flatStyle.lineHeight;
+      if (lineHeight != null) {
+        nextInheritedStyles.lineHeight = lineHeight;
       }
       if (textAlign != null) {
         nextInheritedStyles.textAlign = textAlign;
@@ -812,6 +811,8 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       if (whiteSpace != null) {
         nextInheritedStyles.whiteSpace = whiteSpace;
       }
+
+      resolveUnitlessLineHeight(styleProps.style);
 
       const hasNextInheritedStyles =
         nextInheritedStyles != null &&

--- a/packages/react-strict-dom/src/native/modules/resolveUnitlessLineHeight.js
+++ b/packages/react-strict-dom/src/native/modules/resolveUnitlessLineHeight.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+import type { Style as ReactNativeStyle } from '../../types/react-native';
+
+/**
+ * Unitless lineHeight acts as a fontSize multiplier. It is only fully resolved
+ * at the point at which an element is being styled, so that inherited values
+ * remain correct rather than being prematurely resolved to pixel values.
+ */
+export function resolveUnitlessLineHeight(
+  style: ReactNativeStyle
+): ReactNativeStyle {
+  if (typeof style?.lineHeight === 'string') {
+    const fontSize = typeof style?.fontSize === 'number' ? style.fontSize : 16;
+    style.lineHeight = parseFloat(style.lineHeight) * fontSize;
+  }
+  return style;
+}

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -325,7 +325,7 @@ exports[`properties: general lineHeight: unitless number 1`] = `
 {
   "style": {
     "fontSize": 16,
-    "lineHeight": 24,
+    "lineHeight": "1.5",
   },
 }
 `;
@@ -334,7 +334,7 @@ exports[`properties: general lineHeight: unitless string 1`] = `
 {
   "style": {
     "fontSize": 16,
-    "lineHeight": 24,
+    "lineHeight": "1.5",
   },
 }
 `;

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -227,54 +227,77 @@ describe('<html.*>', () => {
           <html.span style={styles.nested}>text</html.span>
         </html.div>
       );
+      const getfontSize = (element) => element.props.style.fontSize;
       let rootElement = root.toJSON();
-      let firstSpan = rootElement.children[0];
-      let secondSpan = rootElement.children[1];
-      expect(firstSpan.props.style.fontSize).toBe(2 * 16);
+      let firstChild = rootElement.children[0];
+      let secondSecond = rootElement.children[1];
+      expect(getfontSize(firstChild)).toBe(2 * 16);
       // check that 'em' values are correctly inherited
-      expect(secondSpan.props.style.fontSize).toBe(1.5 * 2 * 16);
+      expect(getfontSize(secondSecond)).toBe(1.5 * 2 * 16);
       // check hover interaction updates inherited value
       act(() => {
         rootElement.props.onMouseEnter();
       });
       rootElement = root.toJSON();
-      firstSpan = rootElement.children[0];
-      secondSpan = rootElement.children[1];
-      expect(firstSpan.props.style.fontSize).toBe(3 * 16);
-      expect(secondSpan.props.style.fontSize).toBe(1.5 * 3 * 16);
+      firstChild = rootElement.children[0];
+      secondSecond = rootElement.children[1];
+      expect(getfontSize(firstChild)).toBe(3 * 16);
+      expect(getfontSize(secondSecond)).toBe(1.5 * 3 * 16);
     });
 
-    test('inherited lineHeight', () => {
+    test('inherited lineHeight (unitless)', () => {
       const styles = css.create({
-        unitlessLineHeight: {
-          lineHeight: 1.5
-        },
-        increaseLineHeight: {
+        root: {
           lineHeight: 2
         },
-        increaseFontSize: {
-          fontSize: 20
+        text: {
+          fontSize: '2em'
+        },
+        nestedText: {
+          lineHeight: '0.5'
         }
       });
       const root = create(
-        <html.div style={styles.unitlessLineHeight}>
-          <html.span>
-            <html.span style={styles.increaseFontSize}>text</html.span>
-          </html.span>
-          <html.span style={styles.increaseFontSize}>
-            <html.span style={styles.increaseLineHeight}>text</html.span>
+        <html.div style={styles.root}>
+          <html.span style={styles.text}>
+            <html.span style={styles.nestedText}>hello</html.span>
           </html.span>
         </html.div>
       );
+      const getLineHeight = (element) => element.props.style.lineHeight;
       const rootElement = root.toJSON();
-      const firstSpan = rootElement.children[0];
-      expect(firstSpan.props.style.lineHeight).toBe(1.5 * 16);
-      const firstSpanInner = firstSpan.children[0];
-      expect(firstSpanInner.props.style.lineHeight).toBe(1.5 * 20);
-      const secondSpan = rootElement.children[1];
-      expect(secondSpan.props.style.lineHeight).toBe(1.5 * 20);
-      const secondSpanInner = secondSpan.children[0];
-      expect(secondSpanInner.props.style.lineHeight).toBe(2 * 20);
+      const firstChild = rootElement.children[0];
+      const firstGrandChild = firstChild.children[0];
+      expect(getLineHeight(firstChild)).toBe(64);
+      expect(getLineHeight(firstGrandChild)).toBe(16);
+    });
+
+    test('inherited lineHeight (em)', () => {
+      const styles = css.create({
+        root: {
+          lineHeight: '2em'
+        },
+        text: {
+          fontSize: '2em'
+        },
+        nestedText: {
+          lineHeight: 2
+        }
+      });
+      const root = create(
+        <html.div style={styles.root}>
+          <html.span style={styles.text}>
+            <html.span style={styles.nestedText}>hello</html.span>
+          </html.span>
+        </html.div>
+      );
+      const getLineHeight = (element) => element.props.style.lineHeight;
+      const rootElement = root.toJSON();
+      const firstChild = rootElement.children[0];
+      const firstGrandChild = firstChild.children[0];
+
+      expect(getLineHeight(firstChild)).toBe(32);
+      expect(getLineHeight(firstGrandChild)).toBe(64);
     });
 
     test('inherited styles for auto-fix of raw strings', () => {


### PR DESCRIPTION
Make sure the computed lineHeight is inherited, unless it's a unitless value which should act as a fontSize multiplier.

### Native (before)

<img width="426" alt="image" src="https://github.com/user-attachments/assets/518f6173-90ba-4f1a-b4bb-2a5362fd80b5">

<img width="286" alt="image" src="https://github.com/user-attachments/assets/17cef6d4-c22d-4611-a429-cc4a100a7d90">

### Native (after)

<img width="424" alt="image" src="https://github.com/user-attachments/assets/8fdb5eca-fc4d-45bf-8482-e6088f0bb806">

<img width="205" alt="image" src="https://github.com/user-attachments/assets/b116721e-2d2d-4fc9-b8cc-e2567d00caf0">

### Web (before and after)

<img width="277" alt="image" src="https://github.com/user-attachments/assets/03d5ce9c-07a8-44d0-a85b-5a1a4d7cc0a6">

<img width="242" alt="image" src="https://github.com/user-attachments/assets/e9bc54d4-a698-435a-bad6-7278377823b5">

