### PR TITLE
Add babel sourceMap info to transform

### DIFF
--- a/apps/examples/babel.config.js
+++ b/apps/examples/babel.config.js
@@ -30,7 +30,7 @@ module.exports = function (api) {
   const plugins = [];
 
   if (platform === 'web') {
-    plugins.push(rsdPlugin);
+    plugins.push([rsdPlugin, { debug: true }]);
     plugins.push([
       stylexPlugin,
       {

--- a/packages/react-strict-dom/README.md
+++ b/packages/react-strict-dom/README.md
@@ -71,6 +71,11 @@ module.exports = function () {
 };
 ```
 
+Options for the plugin:
+
+* `debug: boolean` (default: `false`). If set to `true` the plugin adds a `data-react-src` attribute and populates it with sourceMap information about the filename and line-number responsible for rendering the element.
+
+
 **For native**
 
 ```

--- a/packages/react-strict-dom/babel.js
+++ b/packages/react-strict-dom/babel.js
@@ -4,9 +4,21 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+const path = require('path');
 const { addNamed, addNamespace } = require('@babel/helper-module-imports');
 
-module.exports = function ({ types: t }) {
+function createShortFilename(absolutePath, baseDir = process.cwd()) {
+  if (!path.isAbsolute(baseDir)) {
+    throw new Error('Base directory must be an absolute path.');
+  }
+  const relativePath = path.relative(baseDir, absolutePath);
+  // Normalize slashes in the path and truncated
+  const shortPath = relativePath.split(path.sep).slice(-2).join('/');
+  return shortPath;
+}
+
+module.exports = function ({ types: t }, options = {}) {
   const packageName = 'react-strict-dom';
   const packageRuntime = 'react-strict-dom/dist/dom/runtime';
   const findImportDeclaration = (body, sourceValue) =>
@@ -158,6 +170,33 @@ module.exports = function ({ types: t }) {
                   ),
                   [defaultStyles]
                 )
+              )
+            );
+          }
+
+          if (options.debug) {
+            /**
+             * "HTML" sourceMap
+             */
+            const currentFile = path.hub.file;
+            const sourceMap = currentFile.codeMap;
+            const generatedLineNumber = path.node.loc.start.line;
+            let originalLineNumber = generatedLineNumber;
+            if (sourceMap) {
+              const originalPosition = sourceMap.originalPositionFor({
+                line: generatedLineNumber,
+                column: path.node.loc.start.column
+              });
+              originalLineNumber = originalPosition.line;
+            }
+            const shortFilename = createShortFilename(
+              currentFile.opts.filename || ''
+            );
+            // displays filename and line number of the source element
+            path.node.attributes.unshift(
+              t.jsxAttribute(
+                t.jsxIdentifier('data-react-src'),
+                t.stringLiteral(`${shortFilename}:${originalLineNumber}`)
               )
             );
           }

--- a/packages/react-strict-dom/tests/__snapshots__/babel-test.js.snap-dom
+++ b/packages/react-strict-dom/tests/__snapshots__/babel-test.js.snap-dom
@@ -20,6 +20,16 @@ function App() {
 ;"
 `;
 
+exports[`react-strict-dom/babel [transform] <html.*> elements debug mode 1`] = `
+"import * as _stylex from "@stylexjs/stylex";
+import { defaultStyles as _defaultStyles } from "react-strict-dom/dist/dom/runtime";
+import { html as h } from 'react-strict-dom';
+function App() {
+  return <div data-react-src="bar/baz.js:5" {..._stylex.props(_defaultStyles.div)} />;
+}
+;"
+`;
+
 exports[`react-strict-dom/babel [transform] <html.*> elements other props 1`] = `
 "import * as _stylex from "@stylexjs/stylex";
 import { defaultStyles as _defaultStyles } from "react-strict-dom/dist/dom/runtime";

--- a/packages/react-strict-dom/tests/babel-test.js
+++ b/packages/react-strict-dom/tests/babel-test.js
@@ -15,13 +15,13 @@ const { transformSync } = require('@babel/core');
 const rsdPlugin = require('../babel');
 const jsx = require('@babel/plugin-syntax-jsx');
 
-function transform(source, opts = {}) {
+function transform(source, pluginOptions = {}) {
   return transformSync(source, {
-    filename: opts.filename,
+    filename: 'root/foo/bar/baz.js',
     parserOpts: {
       flow: 'all'
     },
-    plugins: [jsx, [rsdPlugin]]
+    plugins: [jsx, [rsdPlugin, { debug: false, ...pluginOptions }]]
   }).code;
 }
 
@@ -138,6 +138,20 @@ describe('react-strict-dom/babel', () => {
         };
         `)
       ).toMatchSnapshot();
+    });
+
+    test('debug mode', () => {
+      const opts = { debug: true };
+      const source = `
+      import {html as h} from 'react-strict-dom'
+      function App() {
+        return (
+          <h.div />
+        );
+      };
+      `;
+      // expect line-number to be 5
+      expect(transform(source, opts)).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
Adding 'debug:true' to the plugin options will display sourceMap info in the DOM about the filename and line number responsible for rendering an RSD element.