### PR TITLE
CSS transition polyfill initial state improvement

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -97,6 +97,6 @@ jobs:
         body: |
           <!-- workflow-benchmarks-perf-data -->
           ### workflow: benchmarks/perf (native)
-          Comparison of performance test results, measured in operations per second. Higher is faster.
+          Comparison of performance test results, measured in operations per second. Larger is better.
           ${{ steps.collect.outputs.table }}
         edit-mode: replace

--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -86,6 +86,7 @@ function Shell(): React.MixedElement {
   const [skew, setSkew] = React.useState(SKEW_INACTIVE);
   const [fadeUpActive, setFadeUpActive] = React.useState(true);
   const [animate, setAnimate] = React.useState(false);
+  const [shouldAnimate, setShouldAnimate] = React.useState(false);
 
   return (
     <ScrollView>
@@ -274,18 +275,19 @@ function Shell(): React.MixedElement {
           <html.div
             style={[
               styles.square,
-              styles.transitionBackgroundColor,
+              shouldAnimate && styles.transitionBackgroundColor,
               styles.dynamicBg(backgroundColor)
             ]}
           />
           <html.button
-            onClick={() =>
-              setBackgroundColor(
-                backgroundColor === BGCOLOR_INACTIVE
+            onClick={() => {
+              setShouldAnimate(true);
+              setBackgroundColor((bg) => {
+                return bg === BGCOLOR_INACTIVE
                   ? BGCOLOR_ACTIVE
-                  : BGCOLOR_INACTIVE
-              )
-            }
+                  : BGCOLOR_INACTIVE;
+              });
+            }}
           >
             Toggle
           </html.button>

--- a/packages/benchmarks/compare.js
+++ b/packages/benchmarks/compare.js
@@ -55,12 +55,10 @@ function generateComparisonData(results) {
   if (isValidBase && isValidPatch) {
     const ratio = patchResult / baseResult;
     ratioFixed = ratio.toFixed(2);
-    if (ratio < 0.95) {
-      icon = '🔴';
+    if (ratio < 0.95 || ratio > 1.05) {
+      icon = '**!!**';
     } else if (ratio < 1) {
       icon = '-';
-    } else if (ratio > 1.05) {
-      icon = '🟢';
     } else if (ratio > 1) {
       icon = '+';
     }

--- a/packages/benchmarks/perf/mocks/react-native.js
+++ b/packages/benchmarks/perf/mocks/react-native.js
@@ -29,7 +29,10 @@ export const Animated = {
   delay: () => {},
   sequence: () => {
     return {
-      start: () => {}
+      start: (callback) => {
+        callback();
+      },
+      stop: () => {}
     };
   }
 };

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -13,6 +13,7 @@ import type { Props as ReactNativeProps } from '../../types/react-native';
 import { PixelRatio, useColorScheme, useWindowDimensions } from 'react-native';
 import * as stylex from '../stylex';
 import { useHoverHandlers } from './useHoverHandlers';
+import { useStyleTransition } from './useStyleTransition';
 
 type StyleOptions = {
   customProperties: ?CustomProperties,
@@ -57,6 +58,13 @@ export function useStyleProps(
     ]) {
       styleProps[handler] = handlers[handler];
     }
+  }
+
+  const styleWithAnimations = useStyleTransition(styleProps.style);
+  if (styleProps.style !== styleWithAnimations) {
+    // This is an internal prop used to track components that need Animated renderers
+    styleProps.animated = true;
+    styleProps.style = styleWithAnimations;
   }
 
   return styleProps;

--- a/packages/react-strict-dom/src/types/react-native.js
+++ b/packages/react-strict-dom/src/types/react-native.js
@@ -52,6 +52,7 @@ type Props = {
   accessibilityViewIsModal?: ?boolean,
   autoComplete?: ?string,
   alt?: ?Stringish,
+  animated?: ?boolean, // non-standard
   caretHidden?: TextInputProps['caretHidden'],
   cursorColor?: TextInputProps['cursorColor'],
   children?: ?React$Node,

--- a/packages/react-strict-dom/tests/__mocks__/react-native/index.js
+++ b/packages/react-strict-dom/tests/__mocks__/react-native/index.js
@@ -25,7 +25,10 @@ export const Animated = {
   delay: jest.fn(),
   sequence: jest.fn(() => {
     return {
-      start: jest.fn()
+      start: jest.fn((callback) => {
+        callback();
+      }),
+      stop: jest.fn()
     };
   })
 };

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -998,10 +998,9 @@ exports[`<html.*> prop polyfills global "tabIndex" prop 1`] = `
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : Animated.Pressable 1`] = `"Animated.Pressable"`;
-
-exports[`<html.*> style polyfills "transition" properties : backgroundColor transition end 1`] = `
+exports[`<html.*> style polyfills "transition" properties  backgroundColor transition: end 1`] = `
 <Animated.View
+  animated={true}
   style={
     {
       "backgroundColor": {
@@ -1020,8 +1019,9 @@ exports[`<html.*> style polyfills "transition" properties : backgroundColor tran
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : backgroundColor transition start 1`] = `
+exports[`<html.*> style polyfills "transition" properties  backgroundColor transition: start 1`] = `
 <Animated.View
+  animated={true}
   style={
     {
       "backgroundColor": {
@@ -1040,8 +1040,9 @@ exports[`<html.*> style polyfills "transition" properties : backgroundColor tran
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : cubic-bezier timing function 1`] = `
+exports[`<html.*> style polyfills "transition" properties  cubic-bezier easing 1`] = `
 <Animated.View
+  animated={true}
   style={
     {
       "opacity": {
@@ -1060,8 +1061,9 @@ exports[`<html.*> style polyfills "transition" properties : cubic-bezier timing 
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : opacity transition end 1`] = `
+exports[`<html.*> style polyfills "transition" properties  opacity transition: end 1`] = `
 <Animated.View
+  animated={true}
   style={
     {
       "opacity": {
@@ -1080,8 +1082,9 @@ exports[`<html.*> style polyfills "transition" properties : opacity transition e
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : opacity transition start 1`] = `
+exports[`<html.*> style polyfills "transition" properties  opacity transition: start 1`] = `
 <Animated.View
+  animated={true}
   style={
     {
       "opacity": {
@@ -1100,8 +1103,11 @@ exports[`<html.*> style polyfills "transition" properties : opacity transition s
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : rotate 1`] = `
+exports[`<html.*> style polyfills "transition" properties  other element types 1`] = `"Animated.Pressable"`;
+
+exports[`<html.*> style polyfills "transition" properties  other transforms: rotate 1`] = `
 <Animated.View
+  animated={true}
   style={
     {
       "position": "static",
@@ -1160,8 +1166,9 @@ exports[`<html.*> style polyfills "transition" properties : rotate 1`] = `
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : scale 1`] = `
+exports[`<html.*> style polyfills "transition" properties  other transforms: scale 1`] = `
 <Animated.View
+  animated={true}
   style={
     {
       "position": "static",
@@ -1220,8 +1227,9 @@ exports[`<html.*> style polyfills "transition" properties : scale 1`] = `
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : skew 1`] = `
+exports[`<html.*> style polyfills "transition" properties  other transforms: skew 1`] = `
 <Animated.View
+  animated={true}
   style={
     {
       "position": "static",
@@ -1256,191 +1264,9 @@ exports[`<html.*> style polyfills "transition" properties : skew 1`] = `
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : transform transition end 1`] = `
+exports[`<html.*> style polyfills "transition" properties  other transforms: translate 1`] = `
 <Animated.View
-  style={
-    {
-      "position": "static",
-      "transform": [
-        {
-          "translateY": {
-            "inputRange": [
-              0,
-              1,
-            ],
-            "outputRange": [
-              0,
-              50,
-            ],
-          },
-        },
-        {
-          "rotateX": {
-            "inputRange": [
-              0,
-              1,
-            ],
-            "outputRange": [
-              "0deg",
-              "90deg",
-            ],
-          },
-        },
-      ],
-    }
-  }
-/>
-`;
-
-exports[`<html.*> style polyfills "transition" properties : transform transition start 1`] = `
-<Animated.View
-  style={
-    {
-      "position": "static",
-      "transform": [
-        {
-          "translateY": {
-            "inputRange": [
-              0,
-              1,
-            ],
-            "outputRange": [
-              0,
-              0,
-            ],
-          },
-        },
-        {
-          "rotateX": {
-            "inputRange": [
-              0,
-              1,
-            ],
-            "outputRange": [
-              "0deg",
-              "0deg",
-            ],
-          },
-        },
-      ],
-    }
-  }
-/>
-`;
-
-exports[`<html.*> style polyfills "transition" properties : transition all properties 1`] = `
-<Animated.View
-  style={
-    {
-      "opacity": {
-        "inputRange": [
-          0,
-          1,
-        ],
-        "outputRange": [
-          1,
-          1,
-        ],
-      },
-      "position": "static",
-      "transform": [
-        {
-          "translateY": {
-            "inputRange": [
-              0,
-              1,
-            ],
-            "outputRange": [
-              0,
-              0,
-            ],
-          },
-        },
-        {
-          "rotateX": {
-            "inputRange": [
-              0,
-              1,
-            ],
-            "outputRange": [
-              "0deg",
-              "0deg",
-            ],
-          },
-        },
-      ],
-    }
-  }
-/>
-`;
-
-exports[`<html.*> style polyfills "transition" properties : transition multiple properties 1`] = `
-<Animated.View
-  style={
-    {
-      "opacity": {
-        "inputRange": [
-          0,
-          1,
-        ],
-        "outputRange": [
-          1,
-          1,
-        ],
-      },
-      "position": "static",
-      "transform": [
-        {
-          "translateY": {
-            "inputRange": [
-              0,
-              1,
-            ],
-            "outputRange": [
-              0,
-              0,
-            ],
-          },
-        },
-        {
-          "rotateX": {
-            "inputRange": [
-              0,
-              1,
-            ],
-            "outputRange": [
-              "0deg",
-              "0deg",
-            ],
-          },
-        },
-      ],
-    }
-  }
-/>
-`;
-
-exports[`<html.*> style polyfills "transition" properties : transition property end 1`] = `
-<View
-  experimental_layoutConformance="strict"
-  style={
-    {
-      "position": "static",
-      "transform": [
-        {
-          "translateY": 50,
-        },
-        {
-          "rotateX": "90deg",
-        },
-      ],
-    }
-  }
-/>
-`;
-
-exports[`<html.*> style polyfills "transition" properties : translate 1`] = `
-<Animated.View
+  animated={true}
   style={
     {
       "position": "static",
@@ -1475,8 +1301,249 @@ exports[`<html.*> style polyfills "transition" properties : translate 1`] = `
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : width transition end 1`] = `
+exports[`<html.*> style polyfills "transition" properties  transform transition: end 1`] = `
 <Animated.View
+  animated={true}
+  style={
+    {
+      "position": "static",
+      "transform": [
+        {
+          "translateY": {
+            "inputRange": [
+              0,
+              1,
+            ],
+            "outputRange": [
+              0,
+              50,
+            ],
+          },
+        },
+        {
+          "rotateX": {
+            "inputRange": [
+              0,
+              1,
+            ],
+            "outputRange": [
+              "0deg",
+              "90deg",
+            ],
+          },
+        },
+      ],
+    }
+  }
+/>
+`;
+
+exports[`<html.*> style polyfills "transition" properties  transform transition: start 1`] = `
+<Animated.View
+  animated={true}
+  style={
+    {
+      "position": "static",
+      "transform": [
+        {
+          "translateY": {
+            "inputRange": [
+              0,
+              1,
+            ],
+            "outputRange": [
+              0,
+              0,
+            ],
+          },
+        },
+        {
+          "rotateX": {
+            "inputRange": [
+              0,
+              1,
+            ],
+            "outputRange": [
+              "0deg",
+              "0deg",
+            ],
+          },
+        },
+      ],
+    }
+  }
+/>
+`;
+
+exports[`<html.*> style polyfills "transition" properties  transition all properties (opacity and transform) 1`] = `
+<Animated.View
+  animated={true}
+  style={
+    {
+      "opacity": {
+        "inputRange": [
+          0,
+          1,
+        ],
+        "outputRange": [
+          1,
+          1,
+        ],
+      },
+      "position": "static",
+      "transform": [
+        {
+          "translateY": {
+            "inputRange": [
+              0,
+              1,
+            ],
+            "outputRange": [
+              0,
+              0,
+            ],
+          },
+        },
+        {
+          "rotateX": {
+            "inputRange": [
+              0,
+              1,
+            ],
+            "outputRange": [
+              "0deg",
+              "0deg",
+            ],
+          },
+        },
+      ],
+    }
+  }
+/>
+`;
+
+exports[`<html.*> style polyfills "transition" properties  transition multiple properties 1`] = `
+<Animated.View
+  animated={true}
+  style={
+    {
+      "opacity": {
+        "inputRange": [
+          0,
+          1,
+        ],
+        "outputRange": [
+          1,
+          1,
+        ],
+      },
+      "position": "static",
+      "transform": [
+        {
+          "translateY": {
+            "inputRange": [
+              0,
+              1,
+            ],
+            "outputRange": [
+              0,
+              0,
+            ],
+          },
+        },
+        {
+          "rotateX": {
+            "inputRange": [
+              0,
+              1,
+            ],
+            "outputRange": [
+              "0deg",
+              "0deg",
+            ],
+          },
+        },
+      ],
+    }
+  }
+/>
+`;
+
+exports[`<html.*> style polyfills "transition" properties  transition with missing properties 1`] = `
+<Animated.View
+  animated={true}
+  style={
+    {
+      "position": "static",
+    }
+  }
+/>
+`;
+
+exports[`<html.*> style polyfills "transition" properties  transition with missing properties 2`] = `
+<Animated.View
+  animated={true}
+  style={
+    {
+      "position": "static",
+      "transform": [
+        {
+          "translateY": 50,
+        },
+        {
+          "rotateX": "90deg",
+        },
+      ],
+    }
+  }
+/>
+`;
+
+exports[`<html.*> style polyfills "transition" properties  update triggers transition: green to blue 1`] = `
+<Animated.View
+  animated={true}
+  style={
+    {
+      "backgroundColor": {
+        "inputRange": [
+          0,
+          1,
+        ],
+        "outputRange": [
+          "green",
+          "blue",
+        ],
+      },
+      "position": "static",
+    }
+  }
+/>
+`;
+
+exports[`<html.*> style polyfills "transition" properties  update triggers transition: red to green 1`] = `
+<Animated.View
+  animated={true}
+  style={
+    {
+      "backgroundColor": {
+        "inputRange": [
+          0,
+          1,
+        ],
+        "outputRange": [
+          "red",
+          "green",
+        ],
+      },
+      "position": "static",
+    }
+  }
+/>
+`;
+
+exports[`<html.*> style polyfills "transition" properties  width transition: end 1`] = `
+<Animated.View
+  animated={true}
   style={
     {
       "position": "static",
@@ -1495,8 +1562,9 @@ exports[`<html.*> style polyfills "transition" properties : width transition end
 />
 `;
 
-exports[`<html.*> style polyfills "transition" properties : width transition start 1`] = `
+exports[`<html.*> style polyfills "transition" properties  width transition: start 1`] = `
 <Animated.View
+  animated={true}
   style={
     {
       "position": "static",

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -348,7 +348,7 @@ describe('<html.*>', () => {
     test.skip('"initial" keyword', () => {});
     test.skip('"unset" keyword', () => {});
 
-    test('"transition" properties ', () => {
+    describe('"transition" properties ', () => {
       const { Animated, Easing } = require('react-native');
 
       const styles = css.create({
@@ -408,158 +408,209 @@ describe('<html.*>', () => {
         })
       });
 
-      let root;
+      test('default', () => {
+        let root;
+        // default
+        act(() => {
+          root = create(<html.div />);
+        });
+        act(() => {
+          root.update(<html.div style={styles.none} />);
+        });
+        // assert no warning if no transition property is specified
+        expect(console.error).not.toHaveBeenCalled();
+        expect(console.warn).not.toHaveBeenCalled();
+        expect(Animated.sequence).not.toHaveBeenCalled();
+      });
 
-      // default
-      act(() => {
-        root = create(<html.div />);
-        root.update(<html.div style={styles.none} />);
+      test('update triggers transition', () => {
+        let root;
+        // update triggers transition
+        act(() => {
+          root = create(<html.div style={styles.none} />);
+        });
+        act(() => {
+          root.update(<html.div style={styles.backgroundColor('green')} />);
+        });
+        expect(console.error).not.toHaveBeenCalled();
+        expect(Animated.sequence).toHaveBeenCalled();
+        expect(root.toJSON()).toMatchSnapshot('red to green');
+        act(() => {
+          root.update(<html.div style={styles.backgroundColor('blue')} />);
+        });
+        expect(root.toJSON()).toMatchSnapshot('green to blue');
       });
-      // assert no warning if no transition property is specified
-      expect(console.warn).not.toHaveBeenCalled();
-      expect(Animated.sequence).not.toHaveBeenCalled();
 
-      // backgroundColor transition
-      act(() => {
-        root = create(<html.div style={styles.backgroundColor()} />);
+      test('backgroundColor transition', () => {
+        let root;
+        // backgroundColor transition
+        act(() => {
+          root = create(<html.div style={styles.backgroundColor()} />);
+        });
+        expect(root.toJSON()).toMatchSnapshot('start');
+        expect(Easing.inOut).toHaveBeenCalled();
+        act(() => {
+          root.update(
+            <html.div style={styles.backgroundColor('rgba(255,255,255,0.9)')} />
+          );
+        });
+        expect(root.toJSON()).toMatchSnapshot('end');
       });
-      expect(root.toJSON()).toMatchSnapshot('backgroundColor transition start');
-      expect(Easing.inOut).toHaveBeenCalled();
-      act(() => {
-        root.update(
-          <html.div style={styles.backgroundColor('rgba(255,255,255,0.9)')} />
-        );
-      });
-      expect(root.toJSON()).toMatchSnapshot('backgroundColor transition end');
 
-      // opacity transition
-      act(() => {
-        root = create(<html.div style={styles.opacity()} />);
+      test('opacity transition', () => {
+        let root;
+        // opacity transition
+        act(() => {
+          root = create(<html.div style={styles.opacity()} />);
+        });
+        expect(root.toJSON()).toMatchSnapshot('start');
+        expect(Easing.in).toHaveBeenCalled();
+        act(() => {
+          root.update(<html.div style={styles.opacity(0)} />);
+        });
+        expect(root.toJSON()).toMatchSnapshot('end');
       });
-      expect(root.toJSON()).toMatchSnapshot('opacity transition start');
-      expect(Easing.in).toHaveBeenCalled();
-      act(() => {
-        root.update(<html.div style={styles.opacity(0)} />);
-      });
-      expect(root.toJSON()).toMatchSnapshot('opacity transition end');
 
-      // transform transition
-      act(() => {
-        root = create(<html.div style={styles.transform()} />);
+      test('transform transition', () => {
+        let root;
+        // transform transition
+        act(() => {
+          root = create(<html.div style={styles.transform()} />);
+        });
+        expect(root.toJSON()).toMatchSnapshot('start');
+        expect(Easing.out).toHaveBeenCalled();
+        act(() => {
+          root.update(
+            <html.div
+              style={styles.transform('translateY(50px) rotateX(90deg)')}
+            />
+          );
+        });
+        expect(root.toJSON()).toMatchSnapshot('end');
       });
-      expect(root.toJSON()).toMatchSnapshot('transform transition start');
-      expect(Easing.out).toHaveBeenCalled();
-      act(() => {
-        root.update(
-          <html.div
-            style={styles.transform('translateY(50px) rotateX(90deg)')}
-          />
-        );
-      });
-      expect(root.toJSON()).toMatchSnapshot('transform transition end');
 
-      // width transition
-      act(() => {
-        root = create(<html.div style={styles.width()} />);
+      test('width transition', () => {
+        let root;
+        // width transition
+        act(() => {
+          root = create(<html.div style={styles.width()} />);
+        });
+        expect(root.toJSON()).toMatchSnapshot('start');
+        expect(Easing.out).toHaveBeenCalled();
+        act(() => {
+          root.update(<html.div style={[styles.width(200)]} />);
+        });
+        expect(root.toJSON()).toMatchSnapshot('end');
       });
-      expect(root.toJSON()).toMatchSnapshot('width transition start');
-      expect(Easing.out).toHaveBeenCalled();
-      act(() => {
-        root.update(<html.div style={[styles.width(200)]} />);
-      });
-      expect(root.toJSON()).toMatchSnapshot('width transition end');
 
-      // cubic-bezier easing
-      act(() => {
-        root = create(
-          <html.div
-            style={styles.opacity(1, 'cubic-bezier( 0.1,  0.2,0.3  ,0.4)')}
-          />
-        );
+      test('cubic-bezier easing', () => {
+        let root;
+        // cubic-bezier easing
+        act(() => {
+          root = create(
+            <html.div
+              style={styles.opacity(1, 'cubic-bezier( 0.1,  0.2,0.3  ,0.4)')}
+            />
+          );
+        });
+        expect(root.toJSON()).toMatchSnapshot();
+        expect(Easing.bezier).toHaveBeenCalledWith(0.1, 0.2, 0.3, 0.4);
       });
-      expect(root.toJSON()).toMatchSnapshot('cubic-bezier timing function');
-      expect(Easing.bezier).toHaveBeenCalledWith(0.1, 0.2, 0.3, 0.4);
 
-      // transition all properties (opacity and transform)
-      act(() => {
-        root = create(<html.div style={styles.transitionAll} />);
+      test('transition all properties (opacity and transform)', () => {
+        let root;
+        // transition all properties (opacity and transform)
+        act(() => {
+          root = create(<html.div style={styles.transitionAll} />);
+        });
+        expect(Easing.in).toHaveBeenCalled();
+        expect(root.toJSON()).toMatchSnapshot();
       });
-      expect(Easing.in).toHaveBeenCalled();
-      expect(root.toJSON()).toMatchSnapshot('transition all properties');
 
-      // transition multiple properties
-      act(() => {
-        root = create(<html.div style={styles.transitionMultiple} />);
+      test('transition multiple properties', () => {
+        let root;
+        // transition multiple properties
+        act(() => {
+          root = create(<html.div style={styles.transitionMultiple} />);
+        });
+        expect(Easing.in).toHaveBeenCalled();
+        expect(root.toJSON()).toMatchSnapshot();
       });
-      expect(Easing.in).toHaveBeenCalled();
-      expect(root.toJSON()).toMatchSnapshot('transition multiple properties');
 
-      // transition with missing properties
-      act(() => {
-        root = create(<html.div style={styles.transitionWithoutProperty} />);
+      test('transition with missing properties', () => {
+        let root;
+        // transition with missing properties
+        act(() => {
+          root = create(<html.div style={styles.transitionWithoutProperty} />);
+        });
+        act(() => {
+          root.update(<html.div style={[styles.transitionWithoutProperty]} />);
+        });
+        expect(console.error).not.toHaveBeenCalled();
+        expect(root.toJSON()).toMatchSnapshot();
+        act(() => {
+          root.update(
+            <html.div
+              style={
+                // attempt to transition to an end value without a start value
+                styles.transform('translateY(50px) rotateX(90deg)')
+              }
+            />
+          );
+        });
+        expect(console.error).not.toHaveBeenCalled();
+        expect(root.toJSON()).toMatchSnapshot();
       });
-      act(() => {
-        root.update(<html.div style={[styles.transitionWithoutProperty]} />);
-      });
-      // no error as transform start and end value are both missing
-      expect(console.error).not.toHaveBeenCalled();
-      act(() => {
-        root.update(
-          <html.div
-            style={
-              // attempt to transition to an end value without a start value
-              styles.transform('translateY(50px) rotateX(90deg)')
-            }
-          />
-        );
-      });
-      // error as transform start value is missing
-      expect(console.error).toHaveBeenCalled();
-      expect(root.toJSON()).toMatchSnapshot('transition property end');
 
-      // other transforms
-      act(() => {
-        root = create(
-          <html.div
-            style={styles.transform(
-              'rotate(1deg) rotateX(2deg) rotateY(3deg) rotateZ(4deg)'
-            )}
-          />
-        );
+      test('other transforms', () => {
+        let root;
+        // other transforms
+        act(() => {
+          root = create(
+            <html.div
+              style={styles.transform(
+                'rotate(1deg) rotateX(2deg) rotateY(3deg) rotateZ(4deg)'
+              )}
+            />
+          );
+        });
+        expect(root.toJSON()).toMatchSnapshot('rotate');
+        act(() => {
+          root = create(
+            <html.div
+              style={styles.transform('scale(1) scaleX(2) scaleY(4) scaleZ(6)')}
+            />
+          );
+        });
+        expect(root.toJSON()).toMatchSnapshot('scale');
+        act(() => {
+          root = create(
+            <html.div style={styles.transform('skewX(20px) skewY(21px)')} />
+          );
+        });
+        expect(root.toJSON()).toMatchSnapshot('skew');
+        act(() => {
+          root = create(
+            <html.div
+              style={styles.transform('translateX(11px) translateY(21px)')}
+            />
+          );
+        });
+        expect(root.toJSON()).toMatchSnapshot('translate');
       });
-      expect(root.toJSON()).toMatchSnapshot('rotate');
-      act(() => {
-        root = create(
-          <html.div
-            style={styles.transform('scale(1) scaleX(2) scaleY(4) scaleZ(6)')}
-          />
-        );
-      });
-      expect(root.toJSON()).toMatchSnapshot('scale');
-      act(() => {
-        root = create(
-          <html.div style={styles.transform('skewX(20px) skewY(21px)')} />
-        );
-      });
-      expect(root.toJSON()).toMatchSnapshot('skew');
-      act(() => {
-        root = create(
-          <html.div
-            style={styles.transform('translateX(11px) translateY(21px)')}
-          />
-        );
-      });
-      expect(root.toJSON()).toMatchSnapshot('translate');
 
-      // other element types
-      act(() => {
-        root = create(<html.span style={styles.backgroundColor()} />);
+      test('other element types', () => {
+        let root;
+        // other element types
+        act(() => {
+          root = create(<html.span style={styles.backgroundColor()} />);
+        });
+        expect(root.toJSON().type).toBe('Animated.Text');
+        act(() => {
+          root.update(<html.button style={styles.backgroundColor()} />);
+        });
+        expect(root.toJSON().type).toMatchSnapshot();
       });
-      expect(root.toJSON().type).toBe('Animated.Text');
-      act(() => {
-        root.update(<html.button style={styles.backgroundColor()} />);
-      });
-      expect(root.toJSON().type).toMatchSnapshot('Animated.Pressable');
     });
   });
 


### PR DESCRIPTION
Adds support for CSS transitions when an element doesn't include transitions in the initial state. This supports the use case where a mounted component is updated to add CSS transition styles. It should be re-rendered as an Animated component instead of printing an error about not having an initial transition state.

The 'useStyleTransition' hook is also moved out of 'createStrictDOMComponent' and into the 'useStyleProps' hook.