### PR TITLE
Fix native <blockquote> polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ React Native compatibility is a work in progress. Please see [COMPATIBILITY.md](
   * [examples](https://github.com/facebook/react-strict-dom/blob/main/apps/examples)
 * `packages`
   * Contains the individual packages managed in the monorepo.
+  * [benchmarks](https://github.com/facebook/react-strict-dom/blob/main/packages/benchmarks)
   * [react-strict-dom](https://github.com/facebook/react-strict-dom/blob/main/packages/react-strict-dom) ([docs](https://github.com/facebook/react-strict-dom/blob/main/packages/react-strict-dom/README.md))
+  * [scripts](https://github.com/facebook/react-strict-dom/blob/main/packages/scripts)
 * `tools`
   * Tools used by the monorepo (pre-commit tasks, etc.)
 

--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -97,6 +97,7 @@ function Shell(): React.MixedElement {
           </html.div>
           <html.span suppressHydrationWarning={true}>span</html.span>
           <html.p>paragraph</html.p>
+          <html.blockquote>blockquote</html.blockquote>
 
           <html.div />
 

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -46,6 +46,7 @@ function getComponentFromElement(tagName: string) {
   switch (tagName) {
     case 'article':
     case 'aside':
+    case 'blockquote':
     case 'div':
     case 'fieldset':
     case 'footer':
@@ -58,7 +59,6 @@ function getComponentFromElement(tagName: string) {
     case 'ul': {
       return View;
     }
-    case 'blockquote':
     case 'br':
     case 'code':
     case 'em':

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
@@ -605,18 +605,18 @@ exports[`html "bdo" supports inline event handlers 1`] = `
 `;
 
 exports[`html "blockquote" ignores and warns about unsupported attributes 1`] = `
-<Text
+<View
+  experimental_layoutConformance="strict"
   style={
     {
       "position": "static",
-      "userSelect": "auto",
     }
   }
 />
 `;
 
 exports[`html "blockquote" supports global attributes 1`] = `
-<Text
+<View
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -645,6 +645,7 @@ exports[`html "blockquote" supports global attributes 1`] = `
     }
   }
   accessibilityViewIsModal={true}
+  experimental_layoutConformance="strict"
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
@@ -655,18 +656,19 @@ exports[`html "blockquote" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "position": "static",
-      "userSelect": "auto",
       "writingDirection": "ltr",
     }
   }
   testID="some-test-id"
 >
-  children
-</Text>
+  <Text>
+    children
+  </Text>
+</View>
 `;
 
 exports[`html "blockquote" supports inline event handlers 1`] = `
-<Text
+<Pressable
   onBlur={[Function]}
   onFocus={[Function]}
   onGotPointerCapture={[Function]}
@@ -694,7 +696,6 @@ exports[`html "blockquote" supports inline event handlers 1`] = `
   style={
     {
       "position": "static",
-      "userSelect": "auto",
     }
   }
 />


### PR DESCRIPTION
Use `View` instead of `Text` to polyfill `blockquote`. This element can contain block elements like `p` and is better as a `View`. Plus, in React Native on Android you can't set partial borders on `Text`.