### PR TITLE
Add missing elements to DOM -> Native mapping

### DIFF
--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -92,15 +92,15 @@ function Shell(): React.MixedElement {
     <ScrollView>
       <html.div style={egStyles.div}>
         <ExampleBlock title="HTML elements">
+          <html.div>Text inside div (kind of) works</html.div>
+          <html.hr />
           <html.div data-testid="testid" role="none">
             div
           </html.div>
           <html.span suppressHydrationWarning={true}>span</html.span>
           <html.p>paragraph</html.p>
           <html.blockquote>blockquote</html.blockquote>
-
           <html.div />
-
           <html.span>
             <html.a href="https://google.com">anchor</html.a>,<html.b>b</html.b>
             ,<html.code>code</html.code>,<html.del>del</html.del>,
@@ -115,34 +115,31 @@ function Shell(): React.MixedElement {
             </html.span>
             ,<html.u>u</html.u>
           </html.span>
-
           <html.div />
-
+          <html.div />
           <html.pre>pre</html.pre>
-
           <html.div />
-
           <html.h1>h1</html.h1>
           <html.h2>h2</html.h2>
           <html.h3>h3</html.h3>
           <html.h4>h4</html.h4>
           <html.h5>h5</html.h5>
           <html.h6>h6</html.h6>
-
           <html.span>
             line <html.br /> break
           </html.span>
-          <html.hr />
-
-          {/* text inheritance and text children */}
-          <html.div>Text inside div (kind of) works</html.div>
-          <html.div style={styles.inheritedText}>
-            <html.div>Text style inheritance works</html.div>
-            <html.div>
-              <html.span>Text style inheritance works</html.span>
-            </html.div>
-          </html.div>
-
+          <html.ol>
+            <html.li>ordered list item: one</html.li>
+            <html.li>ordered list item: two</html.li>
+            <html.li>ordered list item: three</html.li>
+          </html.ol>
+          <html.ul>
+            <html.li>
+              <html.div>unordered list item: one</html.div>
+            </html.li>
+            <html.li>unordered list item: one</html.li>
+            <html.li>unordered list item: one</html.li>
+          </html.ul>
           <html.img
             onLoad={(e) => {
               console.log(e.type, e);
@@ -152,7 +149,6 @@ function Shell(): React.MixedElement {
             src="http://placehold.jp/150x150.png"
             style={styles.objContain}
           />
-
           <html.div />
           <html.label for="id">label</html.label>
           <html.div />
@@ -199,6 +195,16 @@ function Shell(): React.MixedElement {
           <html.button onClick={() => setAnimate(!animate)}>
             {animate ? 'Reset' : 'Start'}
           </html.button>
+        </ExampleBlock>
+
+        <ExampleBlock title="CSS Inheritance">
+          {/* text inheritance and text children */}
+          <html.div style={styles.inheritedText}>
+            <html.div>Text style inheritance works</html.div>
+            <html.div>
+              <html.span>Text style inheritance works</html.span>
+            </html.div>
+          </html.div>
         </ExampleBlock>
 
         {/* block layout emulation */}

--- a/packages/react-strict-dom/src/dom/runtime.js
+++ b/packages/react-strict-dom/src/dom/runtime.js
@@ -19,9 +19,6 @@ import * as stylex from '@stylexjs/stylex';
 const styles = stylex.create({
   // reset all 'block' elements
   block: {
-    // boxSizing: 'border-box',
-    // borderStyle: 'solid',
-    listStyle: 'none',
     margin: 0,
     padding: 0
   },
@@ -70,6 +67,9 @@ const styles = stylex.create({
     borderWidth: 1,
     borderStyle: 'solid'
   },
+  list: {
+    listStyle: 'none'
+  },
   strong: {
     fontWeight: 'bold'
   },
@@ -108,7 +108,7 @@ const label: StrictReactDOMPropsStyle = styles.inline;
 const li: StrictReactDOMPropsStyle = styles.block;
 const main: StrictReactDOMPropsStyle = styles.block;
 const nav: StrictReactDOMPropsStyle = styles.block;
-const ol: StrictReactDOMPropsStyle = styles.block;
+const ol: StrictReactDOMPropsStyle = [styles.list, styles.block];
 const optgroup: StrictReactDOMPropsStyle = null;
 const option: StrictReactDOMPropsStyle = null;
 const p: StrictReactDOMPropsStyle = styles.block;
@@ -125,7 +125,7 @@ const textarea: StrictReactDOMPropsStyle = [
   styles.textarea
 ];
 const u: StrictReactDOMPropsStyle = null;
-const ul: StrictReactDOMPropsStyle = styles.block;
+const ul: StrictReactDOMPropsStyle = [styles.list, styles.block];
 
 export const defaultStyles = {
   a: a as typeof a,

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -52,15 +52,24 @@ function getComponentFromElement(tagName: string) {
     case 'footer':
     case 'form':
     case 'header':
+    case 'hr':
+    case 'li':
     case 'main':
     case 'nav':
     case 'ol':
+    case 'optgroup':
     case 'section':
+    case 'select':
     case 'ul': {
       return View;
     }
+    case 'a':
+    case 'b':
+    case 'bdi':
+    case 'bdo':
     case 'br':
     case 'code':
+    case 'del':
     case 'em':
     case 'h1':
     case 'h2':
@@ -68,11 +77,19 @@ function getComponentFromElement(tagName: string) {
     case 'h4':
     case 'h5':
     case 'h6':
+    case 'i':
+    case 'ins':
+    case 'kbd':
+    case 'label':
+    case 'option':
     case 'p':
     case 'pre':
+    case 's':
+    case 'span':
     case 'strong':
     case 'sub':
-    case 'sup': {
+    case 'sup':
+    case 'u': {
       return Text;
     }
     case 'button': {
@@ -177,6 +194,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         href,
         id,
         inputMode,
+        label,
         maxLength,
         onBlur,
         onChange,
@@ -565,6 +583,8 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         if (width != null) {
           nativeProps.width = width;
         }
+      } else if (tagName === 'option') {
+        nativeProps.children = label;
       } else if (tagName === 'textarea') {
         nativeProps.multiline = true;
         if (rows != null) {

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-dom
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-dom
@@ -141,7 +141,7 @@ exports[`html "a" supports inline event handlers 1`] = `
 
 exports[`html "article" ignores and warns about unsupported attributes 1`] = `
 <article
-  className="html-article xe8uvvx x1ghz6dp x1717udv"
+  className="html-article x1ghz6dp x1717udv"
 />
 `;
 
@@ -196,7 +196,7 @@ exports[`html "article" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-article xe8uvvx x1ghz6dp x1717udv"
+  className="html-article x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -220,7 +220,7 @@ exports[`html "article" supports global attributes 1`] = `
 
 exports[`html "article" supports inline event handlers 1`] = `
 <article
-  className="html-article xe8uvvx x1ghz6dp x1717udv"
+  className="html-article x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -269,7 +269,7 @@ exports[`html "article" supports inline event handlers 1`] = `
 
 exports[`html "aside" ignores and warns about unsupported attributes 1`] = `
 <aside
-  className="html-aside xe8uvvx x1ghz6dp x1717udv"
+  className="html-aside x1ghz6dp x1717udv"
 />
 `;
 
@@ -324,7 +324,7 @@ exports[`html "aside" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-aside xe8uvvx x1ghz6dp x1717udv"
+  className="html-aside x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -348,7 +348,7 @@ exports[`html "aside" supports global attributes 1`] = `
 
 exports[`html "aside" supports inline event handlers 1`] = `
 <aside
-  className="html-aside xe8uvvx x1ghz6dp x1717udv"
+  className="html-aside x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -781,7 +781,7 @@ exports[`html "bdo" supports inline event handlers 1`] = `
 
 exports[`html "blockquote" ignores and warns about unsupported attributes 1`] = `
 <blockquote
-  className="html-blockquote xe8uvvx x1ghz6dp x1717udv"
+  className="html-blockquote x1ghz6dp x1717udv"
 />
 `;
 
@@ -836,7 +836,7 @@ exports[`html "blockquote" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-blockquote xe8uvvx x1ghz6dp x1717udv"
+  className="html-blockquote x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -860,7 +860,7 @@ exports[`html "blockquote" supports global attributes 1`] = `
 
 exports[`html "blockquote" supports inline event handlers 1`] = `
 <blockquote
-  className="html-blockquote xe8uvvx x1ghz6dp x1717udv"
+  className="html-blockquote x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -1432,7 +1432,7 @@ exports[`html "del" supports inline event handlers 1`] = `
 
 exports[`html "div" ignores and warns about unsupported attributes 1`] = `
 <div
-  className="html-div xe8uvvx x1ghz6dp x1717udv"
+  className="html-div x1ghz6dp x1717udv"
 />
 `;
 
@@ -1487,7 +1487,7 @@ exports[`html "div" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-div xe8uvvx x1ghz6dp x1717udv"
+  className="html-div x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -1511,7 +1511,7 @@ exports[`html "div" supports global attributes 1`] = `
 
 exports[`html "div" supports inline event handlers 1`] = `
 <div
-  className="html-div xe8uvvx x1ghz6dp x1717udv"
+  className="html-div x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -1688,7 +1688,7 @@ exports[`html "em" supports inline event handlers 1`] = `
 
 exports[`html "fieldset" ignores and warns about unsupported attributes 1`] = `
 <fieldset
-  className="html-fieldset xe8uvvx x1ghz6dp x1717udv"
+  className="html-fieldset x1ghz6dp x1717udv"
 />
 `;
 
@@ -1743,7 +1743,7 @@ exports[`html "fieldset" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-fieldset xe8uvvx x1ghz6dp x1717udv"
+  className="html-fieldset x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -1767,7 +1767,7 @@ exports[`html "fieldset" supports global attributes 1`] = `
 
 exports[`html "fieldset" supports inline event handlers 1`] = `
 <fieldset
-  className="html-fieldset xe8uvvx x1ghz6dp x1717udv"
+  className="html-fieldset x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -1816,7 +1816,7 @@ exports[`html "fieldset" supports inline event handlers 1`] = `
 
 exports[`html "footer" ignores and warns about unsupported attributes 1`] = `
 <footer
-  className="html-footer xe8uvvx x1ghz6dp x1717udv"
+  className="html-footer x1ghz6dp x1717udv"
 />
 `;
 
@@ -1871,7 +1871,7 @@ exports[`html "footer" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-footer xe8uvvx x1ghz6dp x1717udv"
+  className="html-footer x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -1895,7 +1895,7 @@ exports[`html "footer" supports global attributes 1`] = `
 
 exports[`html "footer" supports inline event handlers 1`] = `
 <footer
-  className="html-footer xe8uvvx x1ghz6dp x1717udv"
+  className="html-footer x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -1944,7 +1944,7 @@ exports[`html "footer" supports inline event handlers 1`] = `
 
 exports[`html "form" ignores and warns about unsupported attributes 1`] = `
 <form
-  className="html-form xe8uvvx x1ghz6dp x1717udv"
+  className="html-form x1ghz6dp x1717udv"
 />
 `;
 
@@ -1999,7 +1999,7 @@ exports[`html "form" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-form xe8uvvx x1ghz6dp x1717udv"
+  className="html-form x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -2023,7 +2023,7 @@ exports[`html "form" supports global attributes 1`] = `
 
 exports[`html "form" supports inline event handlers 1`] = `
 <form
-  className="html-form xe8uvvx x1ghz6dp x1717udv"
+  className="html-form x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -2072,7 +2072,7 @@ exports[`html "form" supports inline event handlers 1`] = `
 
 exports[`html "h1" ignores and warns about unsupported attributes 1`] = `
 <h1
-  className="html-h1 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h1 x1ghz6dp x1717udv xngnso2 x1vvkbs"
 />
 `;
 
@@ -2127,7 +2127,7 @@ exports[`html "h1" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-h1 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h1 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -2151,7 +2151,7 @@ exports[`html "h1" supports global attributes 1`] = `
 
 exports[`html "h1" supports inline event handlers 1`] = `
 <h1
-  className="html-h1 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h1 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -2200,7 +2200,7 @@ exports[`html "h1" supports inline event handlers 1`] = `
 
 exports[`html "h2" ignores and warns about unsupported attributes 1`] = `
 <h2
-  className="html-h2 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h2 x1ghz6dp x1717udv xngnso2 x1vvkbs"
 />
 `;
 
@@ -2255,7 +2255,7 @@ exports[`html "h2" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-h2 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h2 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -2279,7 +2279,7 @@ exports[`html "h2" supports global attributes 1`] = `
 
 exports[`html "h2" supports inline event handlers 1`] = `
 <h2
-  className="html-h2 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h2 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -2328,7 +2328,7 @@ exports[`html "h2" supports inline event handlers 1`] = `
 
 exports[`html "h3" ignores and warns about unsupported attributes 1`] = `
 <h3
-  className="html-h3 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h3 x1ghz6dp x1717udv xngnso2 x1vvkbs"
 />
 `;
 
@@ -2383,7 +2383,7 @@ exports[`html "h3" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-h3 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h3 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -2407,7 +2407,7 @@ exports[`html "h3" supports global attributes 1`] = `
 
 exports[`html "h3" supports inline event handlers 1`] = `
 <h3
-  className="html-h3 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h3 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -2456,7 +2456,7 @@ exports[`html "h3" supports inline event handlers 1`] = `
 
 exports[`html "h4" ignores and warns about unsupported attributes 1`] = `
 <h4
-  className="html-h4 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h4 x1ghz6dp x1717udv xngnso2 x1vvkbs"
 />
 `;
 
@@ -2511,7 +2511,7 @@ exports[`html "h4" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-h4 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h4 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -2535,7 +2535,7 @@ exports[`html "h4" supports global attributes 1`] = `
 
 exports[`html "h4" supports inline event handlers 1`] = `
 <h4
-  className="html-h4 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h4 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -2584,7 +2584,7 @@ exports[`html "h4" supports inline event handlers 1`] = `
 
 exports[`html "h5" ignores and warns about unsupported attributes 1`] = `
 <h5
-  className="html-h5 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h5 x1ghz6dp x1717udv xngnso2 x1vvkbs"
 />
 `;
 
@@ -2639,7 +2639,7 @@ exports[`html "h5" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-h5 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h5 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -2663,7 +2663,7 @@ exports[`html "h5" supports global attributes 1`] = `
 
 exports[`html "h5" supports inline event handlers 1`] = `
 <h5
-  className="html-h5 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h5 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -2712,7 +2712,7 @@ exports[`html "h5" supports inline event handlers 1`] = `
 
 exports[`html "h6" ignores and warns about unsupported attributes 1`] = `
 <h6
-  className="html-h6 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h6 x1ghz6dp x1717udv xngnso2 x1vvkbs"
 />
 `;
 
@@ -2767,7 +2767,7 @@ exports[`html "h6" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-h6 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h6 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -2791,7 +2791,7 @@ exports[`html "h6" supports global attributes 1`] = `
 
 exports[`html "h6" supports inline event handlers 1`] = `
 <h6
-  className="html-h6 xe8uvvx x1ghz6dp x1717udv xngnso2 x1vvkbs"
+  className="html-h6 x1ghz6dp x1717udv xngnso2 x1vvkbs"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -2840,7 +2840,7 @@ exports[`html "h6" supports inline event handlers 1`] = `
 
 exports[`html "header" ignores and warns about unsupported attributes 1`] = `
 <header
-  className="html-header xe8uvvx x1ghz6dp x1717udv"
+  className="html-header x1ghz6dp x1717udv"
 />
 `;
 
@@ -2895,7 +2895,7 @@ exports[`html "header" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-header xe8uvvx x1ghz6dp x1717udv"
+  className="html-header x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -2919,7 +2919,7 @@ exports[`html "header" supports global attributes 1`] = `
 
 exports[`html "header" supports inline event handlers 1`] = `
 <header
-  className="html-header xe8uvvx x1ghz6dp x1717udv"
+  className="html-header x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -2968,7 +2968,7 @@ exports[`html "header" supports inline event handlers 1`] = `
 
 exports[`html "hr" ignores and warns about unsupported attributes 1`] = `
 <hr
-  className="html-hr xe8uvvx x1ghz6dp x1717udv x42x0ya xng3xce xc342km x9f619 xjm9jq1"
+  className="html-hr x1ghz6dp x1717udv x42x0ya xng3xce xc342km x9f619 xjm9jq1"
 />
 `;
 
@@ -3023,7 +3023,7 @@ exports[`html "hr" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-hr xe8uvvx x1ghz6dp x1717udv x42x0ya xng3xce xc342km x9f619 xjm9jq1"
+  className="html-hr x1ghz6dp x1717udv x42x0ya xng3xce xc342km x9f619 xjm9jq1"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -3047,7 +3047,7 @@ exports[`html "hr" supports global attributes 1`] = `
 
 exports[`html "hr" supports inline event handlers 1`] = `
 <hr
-  className="html-hr xe8uvvx x1ghz6dp x1717udv x42x0ya xng3xce xc342km x9f619 xjm9jq1"
+  className="html-hr x1ghz6dp x1717udv x42x0ya xng3xce xc342km x9f619 xjm9jq1"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -3919,7 +3919,7 @@ exports[`html "label" supports inline event handlers 1`] = `
 
 exports[`html "main" ignores and warns about unsupported attributes 1`] = `
 <main
-  className="html-main xe8uvvx x1ghz6dp x1717udv"
+  className="html-main x1ghz6dp x1717udv"
 />
 `;
 
@@ -3974,7 +3974,7 @@ exports[`html "main" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-main xe8uvvx x1ghz6dp x1717udv"
+  className="html-main x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -3998,7 +3998,7 @@ exports[`html "main" supports global attributes 1`] = `
 
 exports[`html "main" supports inline event handlers 1`] = `
 <main
-  className="html-main xe8uvvx x1ghz6dp x1717udv"
+  className="html-main x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -4047,7 +4047,7 @@ exports[`html "main" supports inline event handlers 1`] = `
 
 exports[`html "nav" ignores and warns about unsupported attributes 1`] = `
 <nav
-  className="html-nav xe8uvvx x1ghz6dp x1717udv"
+  className="html-nav x1ghz6dp x1717udv"
 />
 `;
 
@@ -4102,7 +4102,7 @@ exports[`html "nav" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-nav xe8uvvx x1ghz6dp x1717udv"
+  className="html-nav x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -4126,7 +4126,7 @@ exports[`html "nav" supports global attributes 1`] = `
 
 exports[`html "nav" supports inline event handlers 1`] = `
 <nav
-  className="html-nav xe8uvvx x1ghz6dp x1717udv"
+  className="html-nav x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -4569,7 +4569,7 @@ exports[`html "option" supports input attributes 1`] = `
 
 exports[`html "p" ignores and warns about unsupported attributes 1`] = `
 <p
-  className="html-p xe8uvvx x1ghz6dp x1717udv"
+  className="html-p x1ghz6dp x1717udv"
 />
 `;
 
@@ -4624,7 +4624,7 @@ exports[`html "p" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-p xe8uvvx x1ghz6dp x1717udv"
+  className="html-p x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -4648,7 +4648,7 @@ exports[`html "p" supports global attributes 1`] = `
 
 exports[`html "p" supports inline event handlers 1`] = `
 <p
-  className="html-p xe8uvvx x1ghz6dp x1717udv"
+  className="html-p x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -4697,7 +4697,7 @@ exports[`html "p" supports inline event handlers 1`] = `
 
 exports[`html "pre" ignores and warns about unsupported attributes 1`] = `
 <pre
-  className="html-pre xe8uvvx x1ghz6dp x1717udv xelszwe xrv4cvt xysyzu8"
+  className="html-pre x1ghz6dp x1717udv xelszwe xrv4cvt xysyzu8"
 />
 `;
 
@@ -4752,7 +4752,7 @@ exports[`html "pre" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-pre xe8uvvx x1ghz6dp x1717udv xelszwe xrv4cvt xysyzu8"
+  className="html-pre x1ghz6dp x1717udv xelszwe xrv4cvt xysyzu8"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -4776,7 +4776,7 @@ exports[`html "pre" supports global attributes 1`] = `
 
 exports[`html "pre" supports inline event handlers 1`] = `
 <pre
-  className="html-pre xe8uvvx x1ghz6dp x1717udv xelszwe xrv4cvt xysyzu8"
+  className="html-pre x1ghz6dp x1717udv xelszwe xrv4cvt xysyzu8"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -4953,7 +4953,7 @@ exports[`html "s" supports inline event handlers 1`] = `
 
 exports[`html "section" ignores and warns about unsupported attributes 1`] = `
 <section
-  className="html-section xe8uvvx x1ghz6dp x1717udv"
+  className="html-section x1ghz6dp x1717udv"
 />
 `;
 
@@ -5008,7 +5008,7 @@ exports[`html "section" supports global attributes 1`] = `
   aria-valuetext="Five"
   autoCapitalize={true}
   autoFocus={true}
-  className="html-section xe8uvvx x1ghz6dp x1717udv"
+  className="html-section x1ghz6dp x1717udv"
   data-testid="some-test-id"
   dir="ltr"
   enterKeyHint="go"
@@ -5032,7 +5032,7 @@ exports[`html "section" supports global attributes 1`] = `
 
 exports[`html "section" supports inline event handlers 1`] = `
 <section
-  className="html-section xe8uvvx x1ghz6dp x1717udv"
+  className="html-section x1ghz6dp x1717udv"
   onAuxClick={[Function]}
   onBeforeInput={[Function]}
   onBlur={[Function]}
@@ -6144,7 +6144,7 @@ exports[`html "ul" supports inline event handlers 1`] = `
 
 exports[`html temporary data-* props support 1`] = `
 <div
-  className="html-div xe8uvvx x1ghz6dp x1717udv"
+  className="html-div x1ghz6dp x1717udv"
   data-imgperflogname="imgperflogname"
   data-visualcompletion="visualcompletion"
 />

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
@@ -2312,20 +2312,20 @@ exports[`html "header" supports inline event handlers 1`] = `
 `;
 
 exports[`html "hr" ignores and warns about unsupported attributes 1`] = `
-<Text
+<View
+  experimental_layoutConformance="strict"
   style={
     {
       "backgroundColor": "black",
       "height": 1,
       "position": "static",
-      "userSelect": "auto",
     }
   }
 />
 `;
 
 exports[`html "hr" supports global attributes 1`] = `
-<Text
+<View
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -2354,6 +2354,7 @@ exports[`html "hr" supports global attributes 1`] = `
     }
   }
   accessibilityViewIsModal={true}
+  experimental_layoutConformance="strict"
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
@@ -2366,18 +2367,19 @@ exports[`html "hr" supports global attributes 1`] = `
       "display": "none",
       "height": 1,
       "position": "static",
-      "userSelect": "auto",
       "writingDirection": "ltr",
     }
   }
   testID="some-test-id"
 >
-  children
-</Text>
+  <Text>
+    children
+  </Text>
+</View>
 `;
 
 exports[`html "hr" supports inline event handlers 1`] = `
-<Text
+<Pressable
   onBlur={[Function]}
   onFocus={[Function]}
   onGotPointerCapture={[Function]}
@@ -2407,7 +2409,6 @@ exports[`html "hr" supports inline event handlers 1`] = `
       "backgroundColor": "black",
       "height": 1,
       "position": "static",
-      "userSelect": "auto",
     }
   }
 />
@@ -3349,18 +3350,18 @@ exports[`html "ol" supports inline event handlers 1`] = `
 `;
 
 exports[`html "optgroup" ignores and warns about unsupported attributes 1`] = `
-<Text
+<View
+  experimental_layoutConformance="strict"
   style={
     {
       "position": "static",
-      "userSelect": "auto",
     }
   }
 />
 `;
 
 exports[`html "optgroup" supports global attributes 1`] = `
-<Text
+<View
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -3389,6 +3390,7 @@ exports[`html "optgroup" supports global attributes 1`] = `
     }
   }
   accessibilityViewIsModal={true}
+  experimental_layoutConformance="strict"
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
@@ -3399,18 +3401,19 @@ exports[`html "optgroup" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "position": "static",
-      "userSelect": "auto",
       "writingDirection": "ltr",
     }
   }
   testID="some-test-id"
 >
-  children
-</Text>
+  <Text>
+    children
+  </Text>
+</View>
 `;
 
 exports[`html "optgroup" supports inline event handlers 1`] = `
-<Text
+<Pressable
   onBlur={[Function]}
   onFocus={[Function]}
   onGotPointerCapture={[Function]}
@@ -3438,7 +3441,6 @@ exports[`html "optgroup" supports inline event handlers 1`] = `
   style={
     {
       "position": "static",
-      "userSelect": "auto",
     }
   }
 />
@@ -3500,9 +3502,7 @@ exports[`html "option" supports global attributes 1`] = `
     }
   }
   testID="some-test-id"
->
-  children
-</Text>
+/>
 `;
 
 exports[`html "option" supports inline event handlers 1`] = `
@@ -3548,7 +3548,9 @@ exports[`html "option" supports input attributes 1`] = `
       "userSelect": "auto",
     }
   }
-/>
+>
+  label
+</Text>
 `;
 
 exports[`html "p" ignores and warns about unsupported attributes 1`] = `
@@ -3943,29 +3945,29 @@ exports[`html "section" supports inline event handlers 1`] = `
 `;
 
 exports[`html "select" ignores and warns about unsupported attributes 1`] = `
-<Text
+<View
+  experimental_layoutConformance="strict"
   style={
     {
       "position": "static",
-      "userSelect": "auto",
     }
   }
 />
 `;
 
 exports[`html "select" supports additional select attributes 1`] = `
-<Text
+<View
+  experimental_layoutConformance="strict"
   style={
     {
       "position": "static",
-      "userSelect": "auto",
     }
   }
 />
 `;
 
 exports[`html "select" supports global attributes 1`] = `
-<Text
+<View
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -3994,6 +3996,7 @@ exports[`html "select" supports global attributes 1`] = `
     }
   }
   accessibilityViewIsModal={true}
+  experimental_layoutConformance="strict"
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
@@ -4004,18 +4007,19 @@ exports[`html "select" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "position": "static",
-      "userSelect": "auto",
       "writingDirection": "ltr",
     }
   }
   testID="some-test-id"
 >
-  children
-</Text>
+  <Text>
+    children
+  </Text>
+</View>
 `;
 
 exports[`html "select" supports inline event handlers 1`] = `
-<Text
+<Pressable
   onBlur={[Function]}
   onFocus={[Function]}
   onGotPointerCapture={[Function]}
@@ -4043,7 +4047,6 @@ exports[`html "select" supports inline event handlers 1`] = `
   style={
     {
       "position": "static",
-      "userSelect": "auto",
     }
   }
 />


### PR DESCRIPTION
Certain elements should be rendering as View but were defaulting to Text.

And on web the list-style reset is applied only to 'ol' and 'ul' elements, to fix an issue where 'li' was no longering inheriting list-style from its ancestor.