### PR TITLE
Switches native View to ViewNativeComponent

### DIFF
--- a/packages/benchmarks/perf/mocks/ViewNativeComponent.js
+++ b/packages/benchmarks/perf/mocks/ViewNativeComponent.js
@@ -5,4 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = 'ViewNativeComponent';
+const ViewNativeComponent = 'ViewNativeComponent';
+
+export default ViewNativeComponent;

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -16,9 +16,9 @@ import {
   TextInput,
   Platform,
   Pressable,
-  Text,
-  View
+  Text
 } from 'react-native';
+import { View } from '../react-native';
 
 import { ProvideCustomProperties } from './ContextCustomProperties';
 import { ProvideDisplayInside, useDisplayInside } from './ContextDisplayInside';
@@ -103,7 +103,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
 ): React.AbstractComponent<P, T> {
   const component: React.AbstractComponent<P, T> = React.forwardRef(
     function (props, forwardedRef) {
-      let nativeComponent = getComponentFromElement(tagName);
+      let NativeComponent = getComponentFromElement(tagName);
       const elementRef = useStrictDOMElement<T>({ tagName });
 
       /**
@@ -150,7 +150,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
           defaultProps?.style,
           height != null && width != null && styles.aspectRatio(width, height)
         ];
-      } else if (nativeComponent === Text) {
+      } else if (NativeComponent === Text) {
         defaultProps.style = [defaultProps?.style, styles.userSelectAuto];
       }
 
@@ -161,14 +161,14 @@ export function createStrictDOMComponent<T, P: StrictProps>(
             tagName !== 'hr' ||
             tagName !== 'img' ||
             tagName !== 'option' ||
-            nativeComponent !== TextInput,
-          withInheritedStyle: nativeComponent === Text,
+            NativeComponent !== TextInput,
+          withInheritedStyle: NativeComponent === Text,
           withTextStyle:
-            nativeComponent === Text || nativeComponent === TextInput
+            NativeComponent === Text || NativeComponent === TextInput
         });
 
-      if (nativeProps.onPress != null && nativeComponent === View) {
-        nativeComponent = Pressable;
+      if (nativeProps.onPress != null && NativeComponent === View) {
+        NativeComponent = Pressable;
       }
 
       // Tag-specific props
@@ -270,12 +270,12 @@ export function createStrictDOMComponent<T, P: StrictProps>(
 
       // Component-specific props
 
-      if (nativeComponent === Pressable) {
+      if (NativeComponent === Pressable) {
         if (disabled === true) {
           nativeProps.disabled = true;
           nativeProps.focusable = false;
         }
-      } else if (nativeComponent === TextInput) {
+      } else if (NativeComponent === TextInput) {
         if (autoComplete != null) {
           nativeProps.autoComplete = autoComplete;
         }
@@ -360,9 +360,9 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       // Sometimes we can auto-fix this
       if (
         typeof nativeProps.children === 'string' &&
-        nativeComponent !== Text &&
-        nativeComponent !== TextInput &&
-        nativeComponent !== Image
+        NativeComponent !== Text &&
+        NativeComponent !== TextInput &&
+        NativeComponent !== Image
       ) {
         nativeProps.children = <TextString children={nativeProps.children} />;
       }
@@ -415,7 +415,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         nativeProps.style.flexShrink ??= 1;
       }
 
-      if (nativeComponent === Text) {
+      if (NativeComponent === Text) {
         // Workaround: Android doesn't support ellipsis truncation if Text is selectable
         // See #136
         const disableUserSelect =
@@ -431,14 +431,14 @@ export function createStrictDOMComponent<T, P: StrictProps>(
 
       // Use Animated components if necessary
       if (nativeProps.animated === true) {
-        if (nativeComponent === View) {
-          nativeComponent = Animated.View;
+        if (NativeComponent === View) {
+          NativeComponent = Animated.View;
         }
-        if (nativeComponent === Text) {
-          nativeComponent = Animated.Text;
+        if (NativeComponent === Text) {
+          NativeComponent = Animated.Text;
         }
-        if (nativeComponent === Pressable) {
-          nativeComponent = AnimatedPressable;
+        if (NativeComponent === Pressable) {
+          NativeComponent = AnimatedPressable;
         }
       }
 
@@ -446,13 +446,13 @@ export function createStrictDOMComponent<T, P: StrictProps>(
        * Construct tree
        */
 
-      if (nativeComponent === View) {
+      if (NativeComponent === View) {
         // enable W3C flexbox layout
         nativeProps.experimental_layoutConformance = 'strict';
       }
 
-      // $FlowFixMe (we don't care about the internal React Native prop types)
-      let element = React.createElement(nativeComponent, nativeProps);
+      // $FlowFixMe
+      let element = <NativeComponent {...nativeProps} />;
 
       if (
         nativeProps.children != null &&

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
@@ -120,7 +120,7 @@ exports[`html "a" supports inline event handlers 1`] = `
 `;
 
 exports[`html "article" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -131,7 +131,7 @@ exports[`html "article" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "article" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -184,7 +184,7 @@ exports[`html "article" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "article" supports inline event handlers 1`] = `
@@ -222,7 +222,7 @@ exports[`html "article" supports inline event handlers 1`] = `
 `;
 
 exports[`html "aside" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -233,7 +233,7 @@ exports[`html "aside" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "aside" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -286,7 +286,7 @@ exports[`html "aside" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "aside" supports inline event handlers 1`] = `
@@ -615,7 +615,7 @@ exports[`html "bdo" supports inline event handlers 1`] = `
 `;
 
 exports[`html "blockquote" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -626,7 +626,7 @@ exports[`html "blockquote" ignores and warns about unsupported attributes 1`] = 
 `;
 
 exports[`html "blockquote" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -679,7 +679,7 @@ exports[`html "blockquote" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "blockquote" supports inline event handlers 1`] = `
@@ -1134,7 +1134,7 @@ exports[`html "del" supports inline event handlers 1`] = `
 `;
 
 exports[`html "div" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -1145,7 +1145,7 @@ exports[`html "div" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "div" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -1198,7 +1198,7 @@ exports[`html "div" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "div" supports inline event handlers 1`] = `
@@ -1335,7 +1335,7 @@ exports[`html "em" supports inline event handlers 1`] = `
 `;
 
 exports[`html "fieldset" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -1346,7 +1346,7 @@ exports[`html "fieldset" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "fieldset" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -1399,7 +1399,7 @@ exports[`html "fieldset" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "fieldset" supports inline event handlers 1`] = `
@@ -1437,7 +1437,7 @@ exports[`html "fieldset" supports inline event handlers 1`] = `
 `;
 
 exports[`html "footer" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -1448,7 +1448,7 @@ exports[`html "footer" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "footer" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -1501,7 +1501,7 @@ exports[`html "footer" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "footer" supports inline event handlers 1`] = `
@@ -1539,7 +1539,7 @@ exports[`html "footer" supports inline event handlers 1`] = `
 `;
 
 exports[`html "form" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -1550,7 +1550,7 @@ exports[`html "form" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "form" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -1603,7 +1603,7 @@ exports[`html "form" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "form" supports inline event handlers 1`] = `
@@ -2253,7 +2253,7 @@ exports[`html "h6" supports inline event handlers 1`] = `
 `;
 
 exports[`html "header" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   role="header"
   style={
@@ -2265,7 +2265,7 @@ exports[`html "header" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "header" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -2318,7 +2318,7 @@ exports[`html "header" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "header" supports inline event handlers 1`] = `
@@ -2357,7 +2357,7 @@ exports[`html "header" supports inline event handlers 1`] = `
 `;
 
 exports[`html "hr" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -2371,7 +2371,7 @@ exports[`html "hr" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "hr" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -2427,7 +2427,7 @@ exports[`html "hr" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "hr" supports inline event handlers 1`] = `
@@ -3111,7 +3111,7 @@ exports[`html "label" supports inline event handlers 1`] = `
 `;
 
 exports[`html "main" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -3122,7 +3122,7 @@ exports[`html "main" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "main" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -3175,7 +3175,7 @@ exports[`html "main" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "main" supports inline event handlers 1`] = `
@@ -3213,7 +3213,7 @@ exports[`html "main" supports inline event handlers 1`] = `
 `;
 
 exports[`html "nav" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -3224,7 +3224,7 @@ exports[`html "nav" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "nav" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -3277,7 +3277,7 @@ exports[`html "nav" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "nav" supports inline event handlers 1`] = `
@@ -3315,7 +3315,7 @@ exports[`html "nav" supports inline event handlers 1`] = `
 `;
 
 exports[`html "ol" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -3326,7 +3326,7 @@ exports[`html "ol" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "ol" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -3379,7 +3379,7 @@ exports[`html "ol" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "ol" supports inline event handlers 1`] = `
@@ -3417,7 +3417,7 @@ exports[`html "ol" supports inline event handlers 1`] = `
 `;
 
 exports[`html "optgroup" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -3428,7 +3428,7 @@ exports[`html "optgroup" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "optgroup" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -3481,7 +3481,7 @@ exports[`html "optgroup" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "optgroup" supports inline event handlers 1`] = `
@@ -3920,7 +3920,7 @@ exports[`html "s" supports inline event handlers 1`] = `
 `;
 
 exports[`html "section" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -3931,7 +3931,7 @@ exports[`html "section" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "section" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -3984,7 +3984,7 @@ exports[`html "section" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "section" supports inline event handlers 1`] = `
@@ -4022,7 +4022,7 @@ exports[`html "section" supports inline event handlers 1`] = `
 `;
 
 exports[`html "select" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -4033,7 +4033,7 @@ exports[`html "select" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "select" supports additional select attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -4044,7 +4044,7 @@ exports[`html "select" supports additional select attributes 1`] = `
 `;
 
 exports[`html "select" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -4097,7 +4097,7 @@ exports[`html "select" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "select" supports inline event handlers 1`] = `
@@ -4750,7 +4750,7 @@ exports[`html "u" supports inline event handlers 1`] = `
 `;
 
 exports[`html "ul" ignores and warns about unsupported attributes 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -4761,7 +4761,7 @@ exports[`html "ul" ignores and warns about unsupported attributes 1`] = `
 `;
 
 exports[`html "ul" supports global attributes 1`] = `
-<View
+<ViewNativeComponent
   accessibilityElementsHidden={true}
   accessibilityLabel="Label"
   accessibilityLabelledBy={
@@ -4814,7 +4814,7 @@ exports[`html "ul" supports global attributes 1`] = `
   >
     children
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`html "ul" supports inline event handlers 1`] = `
@@ -4852,7 +4852,7 @@ exports[`html "ul" supports inline event handlers 1`] = `
 `;
 
 exports[`html temporary data-* props support 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<html.*> auto-wraps raw strings: auto-wrap raw strings 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -18,11 +18,11 @@ exports[`<html.*> auto-wraps raw strings: auto-wrap raw strings 1`] = `
   >
     text
   </Text>
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`<html.*> block layout override of flex layout: block layout override of flex 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -37,7 +37,7 @@ exports[`<html.*> block layout override of flex layout: block layout override of
     }
   }
 >
-  <View
+  <ViewNativeComponent
     experimental_layoutConformance="strict"
     style={
       {
@@ -45,11 +45,11 @@ exports[`<html.*> block layout override of flex layout: block layout override of
       }
     }
   />
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`<html.*> default block layout: block layout 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -60,7 +60,7 @@ exports[`<html.*> default block layout: block layout 1`] = `
 `;
 
 exports[`<html.*> default flex layout: flex layout 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -75,7 +75,7 @@ exports[`<html.*> default flex layout: flex layout 1`] = `
     }
   }
 >
-  <View
+  <ViewNativeComponent
     experimental_layoutConformance="strict"
     style={
       {
@@ -84,7 +84,7 @@ exports[`<html.*> default flex layout: flex layout 1`] = `
       }
     }
   />
-  <View
+  <ViewNativeComponent
     experimental_layoutConformance="strict"
     style={
       {
@@ -93,7 +93,7 @@ exports[`<html.*> default flex layout: flex layout 1`] = `
       }
     }
   />
-</View>
+</ViewNativeComponent>
 `;
 
 exports[`<html.*> prop polyfills <img> "src" prop with loading props 1`] = `
@@ -675,7 +675,7 @@ exports[`<html.*> prop polyfills <textarea> "rows" prop 1`] = `
 `;
 
 exports[`<html.*> prop polyfills global "dir" prop: "auto" block 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -698,7 +698,7 @@ exports[`<html.*> prop polyfills global "dir" prop: "auto" text 1`] = `
 `;
 
 exports[`<html.*> prop polyfills global "dir" prop: "ltr" block 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -723,7 +723,7 @@ exports[`<html.*> prop polyfills global "dir" prop: "ltr" text 1`] = `
 `;
 
 exports[`<html.*> prop polyfills global "dir" prop: "rtl" block 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -748,7 +748,7 @@ exports[`<html.*> prop polyfills global "dir" prop: "rtl" text 1`] = `
 `;
 
 exports[`<html.*> prop polyfills global "hidden" prop 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -830,7 +830,7 @@ exports[`<html.*> prop polyfills global "hidden" prop: "until-found" 1`] = `
 `;
 
 exports[`<html.*> prop polyfills global "hidden" prop: display set 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -1517,7 +1517,7 @@ exports[`<html.*> style polyfills "transition" properties  width transition: sta
 `;
 
 exports[`<html.*> style polyfills inherited styles 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -1526,7 +1526,7 @@ exports[`<html.*> style polyfills inherited styles 1`] = `
     }
   }
 >
-  <View
+  <ViewNativeComponent
     experimental_layoutConformance="strict"
     style={
       {
@@ -1564,12 +1564,12 @@ exports[`<html.*> style polyfills inherited styles 1`] = `
         }
       }
     />
-  </View>
-</View>
+  </ViewNativeComponent>
+</ViewNativeComponent>
 `;
 
 exports[`<html.*> style polyfills inherited styles for auto-fix of raw strings 1`] = `
-<View
+<ViewNativeComponent
   experimental_layoutConformance="strict"
   style={
     {
@@ -1577,7 +1577,7 @@ exports[`<html.*> style polyfills inherited styles for auto-fix of raw strings 1
     }
   }
 >
-  <View
+  <ViewNativeComponent
     experimental_layoutConformance="strict"
     style={
       {
@@ -1596,8 +1596,8 @@ exports[`<html.*> style polyfills inherited styles for auto-fix of raw strings 1
     >
       text
     </Text>
-  </View>
-</View>
+  </ViewNativeComponent>
+</ViewNativeComponent>
 `;
 
 exports[`<html.*> style polyfills inherited themes 1`] = `
@@ -1636,7 +1636,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
       }
     }
   />,
-  <View
+  <ViewNativeComponent
     experimental_layoutConformance="strict"
     style={
       {
@@ -1666,7 +1666,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
         }
       }
     />
-    <View
+    <ViewNativeComponent
       experimental_layoutConformance="strict"
       style={
         {
@@ -1696,8 +1696,8 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
           }
         }
       />
-    </View>
-  </View>,
+    </ViewNativeComponent>
+  </ViewNativeComponent>,
   <Text
     style={
       {


### PR DESCRIPTION
Bypass the React Native "View" component for "ViewNativeComponent". RSD currently does all the intermediate transforms that View otherwise does in React Native.