### PR TITLE
Separate logic for specific native components

### DIFF
--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -5,7 +5,7 @@
   "description": "Benchmarks for React Strict DOM.",
   "license": "MIT",
   "scripts": {
-    "perf": "rollup --config ./perf/rollup.config.js && node --jitless perf/run.js",
+    "perf": "NODE_ENV=production rollup --config ./perf/rollup.config.js && node --jitless perf/run.js",
     "size": "node size/run.js"
   },
   "dependencies": {

--- a/packages/benchmarks/perf/rollup.config.js
+++ b/packages/benchmarks/perf/rollup.config.js
@@ -15,7 +15,7 @@ import path from 'path';
  */
 const config = [
   {
-    external: ['react'],
+    external: ['react', 'react/jsx-runtime'],
     input: require.resolve('../../react-strict-dom/dist/native/index.js'),
     output: {
       file: path.join(__dirname, './build/react-strict-dom.js'),

--- a/packages/react-strict-dom/src/native/html.js
+++ b/packages/react-strict-dom/src/native/html.js
@@ -22,6 +22,12 @@ import type { StrictReactDOMTextAreaProps } from '../types/StrictReactDOMTextAre
 // $FlowFixMe[nonstrict-import]
 import { createStrictDOMComponent as createStrict } from './modules/createStrictDOMComponent';
 // $FlowFixMe[nonstrict-import]
+import { createStrictDOMImageComponent as createStrictImage } from './modules/createStrictDOMImageComponent';
+// $FlowFixMe[nonstrict-import]
+import { createStrictDOMTextComponent as createStrictText } from './modules/createStrictDOMTextComponent';
+// $FlowFixMe[nonstrict-import]
+import { createStrictDOMTextInputComponent as createStrictTextInput } from './modules/createStrictDOMTextInputComponent';
+// $FlowFixMe[nonstrict-import]
 import { Platform } from 'react-native';
 import * as stylex from './stylex';
 
@@ -79,7 +85,7 @@ const headingProps = {
 export const a: React$AbstractComponent<
   StrictReactDOMAnchorProps,
   HTMLAnchorElement
-> = createStrict('a', { style: styles.a });
+> = createStrictText('a', { style: styles.a });
 
 /**
  * "article" (block)
@@ -99,19 +105,19 @@ export const aside: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
  * "b" (inline)
  */
 export const b: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('b', { style: styles.bold });
+  createStrictText('b', { style: styles.bold });
 
 /**
  * "bdi" (inline)
  */
 export const bdi: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('bdi');
+  createStrictText('bdi');
 
 /**
  * "bdo" (inline)
  */
 export const bdo: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('bdo');
+  createStrictText('bdo');
 
 /**
  * "blockquote" (block)
@@ -125,7 +131,7 @@ export const blockquote: React$AbstractComponent<
  * "br"
  */
 export const br: React$AbstractComponent<StrictReactDOMProps, HTMLBRElement> =
-  createStrict('br');
+  createStrictText('br');
 
 /**
  * "button" (inline-block)
@@ -142,13 +148,13 @@ export const button: React$AbstractComponent<
  * "code" (inline)
  */
 export const code: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('code', { style: styles.code });
+  createStrictText('code', { style: styles.code });
 
 /**
  * "del" (inline)
  */
 export const del: React$AbstractComponent<StrictReactDOMProps, HTMLModElement> =
-  createStrict('del', { style: styles.lineThrough });
+  createStrictText('del', { style: styles.lineThrough });
 
 /**
  * "div" (block)
@@ -160,7 +166,7 @@ export const div: React$AbstractComponent<StrictReactDOMProps, HTMLDivElement> =
  * "em" (inline)
  */
 export const em: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('em', { style: styles.italic });
+  createStrictText('em', { style: styles.italic });
 
 /**
  * "fieldset" (block)
@@ -190,27 +196,27 @@ export const form: React$AbstractComponent<
 export const h1: React$AbstractComponent<
   StrictReactDOMProps,
   HTMLHeadingElement
-> = createStrict('h1', headingProps);
+> = createStrictText('h1', headingProps);
 export const h2: React$AbstractComponent<
   StrictReactDOMProps,
   HTMLHeadingElement
-> = createStrict('h2', headingProps);
+> = createStrictText('h2', headingProps);
 export const h3: React$AbstractComponent<
   StrictReactDOMProps,
   HTMLHeadingElement
-> = createStrict('h3', headingProps);
+> = createStrictText('h3', headingProps);
 export const h4: React$AbstractComponent<
   StrictReactDOMProps,
   HTMLHeadingElement
-> = createStrict('h4', headingProps);
+> = createStrictText('h4', headingProps);
 export const h5: React$AbstractComponent<
   StrictReactDOMProps,
   HTMLHeadingElement
-> = createStrict('h5', headingProps);
+> = createStrictText('h5', headingProps);
 export const h6: React$AbstractComponent<
   StrictReactDOMProps,
   HTMLHeadingElement
-> = createStrict('h6', headingProps);
+> = createStrictText('h6', headingProps);
 
 /**
  * "header" (block)
@@ -228,7 +234,7 @@ export const hr: React$AbstractComponent<StrictReactDOMProps, HTMLHRElement> =
  * "i" (inline)
  */
 export const i: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('i', { style: styles.italic });
+  createStrictText('i', { style: styles.italic });
 
 /**
  * "img" (inline)
@@ -236,7 +242,7 @@ export const i: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
 export const img: React$AbstractComponent<
   StrictReactDOMImageProps,
   HTMLImageElement
-> = createStrict('img', { style: styles.img });
+> = createStrictImage('img', { style: styles.img });
 
 /**
  * "input" (inline-block)
@@ -244,7 +250,7 @@ export const img: React$AbstractComponent<
 export const input: React$AbstractComponent<
   StrictReactDOMInputProps,
   HTMLInputElement
-> = createStrict('input', {
+> = createStrictTextInput('input', {
   style: styles.input
 });
 
@@ -252,13 +258,13 @@ export const input: React$AbstractComponent<
  * "ins" (inline)
  */
 export const ins: React$AbstractComponent<StrictReactDOMProps, HTMLModElement> =
-  createStrict('ins', { style: styles.underline });
+  createStrictText('ins', { style: styles.underline });
 
 /**
  * "kbd" (inline)
  */
 export const kbd: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('kbd', { style: styles.code });
+  createStrictText('kbd', { style: styles.code });
 
 /**
  * "label" (inline)
@@ -266,7 +272,7 @@ export const kbd: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
 export const label: React$AbstractComponent<
   StrictReactDOMLabelProps,
   HTMLLabelElement
-> = createStrict('label');
+> = createStrictText('label');
 
 /**
  * "li" (block)
@@ -310,7 +316,7 @@ export const optgroup: React$AbstractComponent<
 export const option: React$AbstractComponent<
   StrictReactDOMOptionProps,
   HTMLOptionElement
-> = createStrict('option');
+> = createStrictText('option');
 
 /**
  * "p" (block)
@@ -318,19 +324,19 @@ export const option: React$AbstractComponent<
 export const p: React$AbstractComponent<
   StrictReactDOMProps,
   HTMLParagraphElement
-> = createStrict('p');
+> = createStrictText('p');
 
 /**
  * "pre" (block)
  */
 export const pre: React$AbstractComponent<StrictReactDOMProps, HTMLPreElement> =
-  createStrict('pre', { style: styles.code });
+  createStrictText('pre', { style: styles.code });
 
 /**
  * "s" (inline)
  */
 export const s: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('s', { style: styles.lineThrough });
+  createStrictText('s', { style: styles.lineThrough });
 
 /**
  * "section" (block)
@@ -354,25 +360,25 @@ export const select: React$AbstractComponent<
 export const span: React$AbstractComponent<
   StrictReactDOMProps,
   HTMLSpanElement
-> = createStrict('span');
+> = createStrictText('span');
 
 /**
  * "strong" (inline)
  */
 export const strong: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('strong', { style: styles.bold });
+  createStrictText('strong', { style: styles.bold });
 
 /**
  * "sub" (inline)
  */
 export const sub: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('sub');
+  createStrictText('sub');
 
 /**
  * "sup" (inline)
  */
 export const sup: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('sup');
+  createStrictText('sup');
 
 /**
  * "textarea" (inline-block)
@@ -380,7 +386,7 @@ export const sup: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
 export const textarea: React$AbstractComponent<
   StrictReactDOMTextAreaProps,
   HTMLTextAreaElement
-> = createStrict('textarea', {
+> = createStrictTextInput('textarea', {
   style: styles.textarea
 });
 
@@ -388,7 +394,7 @@ export const textarea: React$AbstractComponent<
  * "u" (inline)
  */
 export const u: React$AbstractComponent<StrictReactDOMProps, HTMLElement> =
-  createStrict('u', { style: styles.underline });
+  createStrictText('u', { style: styles.underline });
 
 /**
  * "ul" (block)

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -138,7 +138,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       }
 
       // $FlowFixMe
-      let element = React.createElement(NativeComponent, nativeProps);
+      let element = <NativeComponent {...nativeProps} />;
 
       if (
         nativeProps.children != null &&

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -10,161 +10,39 @@
 import type { StrictProps } from '../../types/StrictProps';
 
 import * as React from 'react';
-import {
-  Animated,
-  Image,
-  TextInput,
-  Platform,
-  Pressable,
-  Text
-} from 'react-native';
+import { Animated, Pressable } from 'react-native';
 import { View } from '../react-native';
 
 import { ProvideCustomProperties } from './ContextCustomProperties';
 import { ProvideDisplayInside, useDisplayInside } from './ContextDisplayInside';
 import { ProvideInheritedStyles } from './ContextInheritedStyles';
 import { TextString } from './TextString';
-import { errorMsg, warnMsg } from '../../shared/logUtils';
+import { warnMsg } from '../../shared/logUtils';
 import { mergeRefs } from '../../shared/mergeRefs';
 import { useNativeProps } from './useNativeProps';
 import { useStrictDOMElement } from './useStrictDOMElement';
-import * as stylex from '../stylex';
-
-function getComponentFromElement(tagName: string) {
-  switch (tagName) {
-    case 'article':
-    case 'aside':
-    case 'blockquote':
-    case 'div':
-    case 'fieldset':
-    case 'footer':
-    case 'form':
-    case 'header':
-    case 'hr':
-    case 'li':
-    case 'main':
-    case 'nav':
-    case 'ol':
-    case 'optgroup':
-    case 'section':
-    case 'select':
-    case 'ul': {
-      return View;
-    }
-    case 'a':
-    case 'b':
-    case 'bdi':
-    case 'bdo':
-    case 'br':
-    case 'code':
-    case 'del':
-    case 'em':
-    case 'h1':
-    case 'h2':
-    case 'h3':
-    case 'h4':
-    case 'h5':
-    case 'h6':
-    case 'i':
-    case 'ins':
-    case 'kbd':
-    case 'label':
-    case 'option':
-    case 'p':
-    case 'pre':
-    case 's':
-    case 'span':
-    case 'strong':
-    case 'sub':
-    case 'sup':
-    case 'u': {
-      return Text;
-    }
-    case 'button': {
-      return Pressable;
-    }
-    case 'img': {
-      return Image;
-    }
-    case 'input':
-    case 'textarea': {
-      return TextInput;
-    }
-    default:
-      return Text;
-  }
-}
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
 export function createStrictDOMComponent<T, P: StrictProps>(
   tagName: string,
-  _defaultProps?: P
+  defaultProps?: P
 ): React.AbstractComponent<P, T> {
   const component: React.AbstractComponent<P, T> = React.forwardRef(
     function (props, forwardedRef) {
-      let NativeComponent = getComponentFromElement(tagName);
+      let NativeComponent = tagName === 'button' ? Pressable : View;
       const elementRef = useStrictDOMElement<T>({ tagName });
-
-      /**
-       * Construct props
-       */
-      const {
-        alt,
-        autoComplete,
-        crossOrigin,
-        defaultValue,
-        disabled,
-        enterKeyHint,
-        height,
-        hidden,
-        href,
-        inputMode,
-        label,
-        maxLength,
-        onChange,
-        onError,
-        onInput,
-        onKeyDown,
-        onLoad,
-        placeholder,
-        readOnly,
-        referrerPolicy,
-        rows,
-        spellCheck,
-        src,
-        srcSet,
-        type,
-        value,
-        width
-      } = props;
 
       /**
        * Resolve global HTML and style props
        */
 
-      const defaultProps = { style: _defaultProps?.style };
-
-      if (tagName === 'img') {
-        defaultProps.style = [
-          defaultProps?.style,
-          height != null && width != null && styles.aspectRatio(width, height)
-        ];
-      } else if (NativeComponent === Text) {
-        defaultProps.style = [defaultProps?.style, styles.userSelectAuto];
-      }
-
       const { customProperties, nativeProps, inheritableStyle } =
         useNativeProps(defaultProps, props, {
           provideInheritableStyle:
-            tagName !== 'br' ||
-            tagName !== 'hr' ||
-            tagName !== 'img' ||
-            tagName !== 'option' ||
-            NativeComponent !== TextInput,
-          withInheritedStyle: NativeComponent === Text,
-          withTextStyle:
-            NativeComponent === Text || NativeComponent === TextInput
+            tagName !== 'br' || tagName !== 'hr' || tagName !== 'option',
+          withInheritedStyle: false,
+          withTextStyle: false
         });
 
       if (nativeProps.onPress != null && NativeComponent === View) {
@@ -173,181 +51,16 @@ export function createStrictDOMComponent<T, P: StrictProps>(
 
       // Tag-specific props
 
-      if (tagName === 'a') {
-        nativeProps.role = nativeProps.role ?? 'link';
-        if (href != null) {
-          nativeProps.onPress = function (e) {
-            if (__DEV__) {
-              errorMsg(
-                '<a> "href" handling is not implemented in React Native.'
-              );
-            }
-          };
-        }
-      } else if (tagName === 'br') {
-        nativeProps.children = '\n';
-      } else if (tagName === 'header') {
+      if (tagName === 'header') {
         nativeProps.role = nativeProps.role ?? 'header';
-      } else if (tagName === 'input') {
-        let _inputMode = inputMode;
-        if (type === 'email') {
-          _inputMode = 'email';
-        }
-        if (type === 'search') {
-          _inputMode = 'search';
-        }
-        if (type === 'tel') {
-          _inputMode = 'tel';
-        }
-        if (type === 'url') {
-          _inputMode = 'url';
-        }
-        if (type === 'number') {
-          _inputMode = 'numeric';
-        }
-        if (_inputMode != null) {
-          nativeProps.inputMode = _inputMode;
-        }
-        if (type === 'password') {
-          nativeProps.secureTextEntry = true;
-        }
-        if (type === 'checkbox' || type === 'date' || type === 'radio') {
-          if (__DEV__) {
-            errorMsg(
-              `<input type="${type}" /> is not implemented in React Native.`
-            );
-          }
-        }
-      } else if (tagName === 'img') {
-        if (alt != null) {
-          nativeProps.alt = alt;
-        }
-        if (crossOrigin != null) {
-          nativeProps.crossOrigin = crossOrigin;
-        }
-        if (height != null) {
-          nativeProps.height = height;
-        }
-        if (onError != null) {
-          nativeProps.onError = function () {
-            onError({
-              type: 'error'
-            });
-          };
-        }
-        if (onLoad != null) {
-          nativeProps.onLoad = function (e) {
-            const { source } = e.nativeEvent;
-            onLoad({
-              target: {
-                naturalHeight: source?.height,
-                naturalWidth: source?.width
-              },
-              type: 'load'
-            });
-          };
-        }
-        if (referrerPolicy != null) {
-          nativeProps.referrerPolicy = referrerPolicy;
-        }
-        if (src != null) {
-          nativeProps.src = src;
-        }
-        if (srcSet != null) {
-          nativeProps.srcSet = srcSet;
-        }
-        if (width != null) {
-          nativeProps.width = width;
-        }
-      } else if (tagName === 'option') {
-        nativeProps.children = label;
-      } else if (tagName === 'textarea') {
-        nativeProps.multiline = true;
-        if (rows != null) {
-          nativeProps.numberOfLines = rows;
-        }
       }
 
       // Component-specific props
 
       if (NativeComponent === Pressable) {
-        if (disabled === true) {
+        if (props.disabled === true) {
           nativeProps.disabled = true;
           nativeProps.focusable = false;
-        }
-      } else if (NativeComponent === TextInput) {
-        if (autoComplete != null) {
-          nativeProps.autoComplete = autoComplete;
-        }
-        if (defaultValue != null) {
-          nativeProps.defaultValue = defaultValue;
-        }
-        if (disabled === true) {
-          // polyfill disabled elements
-          nativeProps.disabled = true;
-          nativeProps.editable = false;
-          nativeProps.focusable = false;
-        }
-        if (enterKeyHint != null) {
-          nativeProps.enterKeyHint = enterKeyHint;
-        }
-        if (maxLength != null) {
-          nativeProps.maxLength = maxLength;
-        }
-        if (onChange != null || onInput != null) {
-          nativeProps.onChange = function (e) {
-            const { text } = e.nativeEvent;
-            if (onInput != null) {
-              onInput({
-                target: {
-                  value: text
-                },
-                type: 'input'
-              });
-            }
-            if (onChange != null) {
-              onChange({
-                target: {
-                  value: text
-                },
-                type: 'change'
-              });
-            }
-          };
-        }
-        if (onKeyDown != null) {
-          nativeProps.onKeyPress = function (e) {
-            const { key } = e.nativeEvent;
-            // Filter out bad iOS keypress data on submit
-            if (
-              key === 'Backspace' ||
-              (tagName === 'textarea' && key === 'Enter') ||
-              key.length === 1
-            ) {
-              onKeyDown({
-                key,
-                type: 'keydown'
-              });
-            }
-          };
-          nativeProps.onSubmitEditing = function (e) {
-            onKeyDown({
-              key: 'Enter',
-              type: 'keydown'
-            });
-          };
-        }
-        if (placeholder != null) {
-          nativeProps.placeholder = placeholder;
-        }
-        if (readOnly != null) {
-          nativeProps.editable = !readOnly;
-        }
-        if (spellCheck != null) {
-          nativeProps.spellCheck = spellCheck;
-        }
-        if (value != null && typeof value === 'string') {
-          nativeProps.value = value;
         }
       }
 
@@ -358,12 +71,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
 
       // Workaround: React Native doesn't support raw text children of View
       // Sometimes we can auto-fix this
-      if (
-        typeof nativeProps.children === 'string' &&
-        NativeComponent !== Text &&
-        NativeComponent !== TextInput &&
-        NativeComponent !== Image
-      ) {
+      if (typeof nativeProps.children === 'string') {
         nativeProps.children = <TextString children={nativeProps.children} />;
       }
 
@@ -403,11 +111,6 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         nativeProps.style.flexShrink = 0;
         nativeProps.style.flexWrap = 'nowrap';
         nativeProps.style.justifyContent = 'flex-start';
-      } else if (displayValue == null) {
-        // 'hidden' polyfill (overridden by "display" is set)
-        if (hidden && hidden !== 'until-found') {
-          nativeProps.style.display = 'none';
-        }
       }
 
       if (displayInsideValue === 'flex') {
@@ -415,27 +118,10 @@ export function createStrictDOMComponent<T, P: StrictProps>(
         nativeProps.style.flexShrink ??= 1;
       }
 
-      if (NativeComponent === Text) {
-        // Workaround: Android doesn't support ellipsis truncation if Text is selectable
-        // See #136
-        const disableUserSelect =
-          Platform.OS === 'android' &&
-          nativeProps.numberOfLines != null &&
-          nativeProps.style.userSelect !== 'none';
-
-        nativeProps.style = Object.assign(
-          nativeProps.style,
-          disableUserSelect ? { userSelect: 'none' } : null
-        );
-      }
-
       // Use Animated components if necessary
       if (nativeProps.animated === true) {
         if (NativeComponent === View) {
           NativeComponent = Animated.View;
-        }
-        if (NativeComponent === Text) {
-          NativeComponent = Animated.Text;
         }
         if (NativeComponent === Pressable) {
           NativeComponent = AnimatedPressable;
@@ -452,7 +138,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       }
 
       // $FlowFixMe
-      let element = <NativeComponent {...nativeProps} />;
+      let element = React.createElement(NativeComponent, nativeProps);
 
       if (
         nativeProps.children != null &&
@@ -491,14 +177,3 @@ export function createStrictDOMComponent<T, P: StrictProps>(
   component.displayName = `html.${tagName}`;
   return component;
 }
-
-const styles = stylex.create({
-  aspectRatio: (width: number, height: number) => ({
-    aspectRatio: width / height,
-    width,
-    height
-  }),
-  userSelectAuto: {
-    userSelect: 'auto'
-  }
-});

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
@@ -110,7 +110,7 @@ export function createStrictDOMImageComponent<P: StrictReactDOMImageProps, T>(
       }
 
       // $FlowFixMe
-      const element = React.createElement(NativeComponent, nativeProps);
+      const element = <NativeComponent {...nativeProps} />;
 
       return element;
     }

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
@@ -1,0 +1,129 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import type { StrictReactDOMImageProps } from '../../types/StrictReactDOMImageProps';
+
+import * as React from 'react';
+import { Animated, Image } from 'react-native';
+import { mergeRefs } from '../../shared/mergeRefs';
+import { useNativeProps } from './useNativeProps';
+import { useStrictDOMElement } from './useStrictDOMElement';
+import * as stylex from '../stylex';
+
+export function createStrictDOMImageComponent<P: StrictReactDOMImageProps, T>(
+  tagName: string,
+  _defaultProps?: P
+): React.AbstractComponent<P, T> {
+  const component: React.AbstractComponent<P, T> = React.forwardRef(
+    function (props, forwardedRef) {
+      let NativeComponent = Image;
+      const elementRef = useStrictDOMElement<T>({ tagName });
+
+      const {
+        alt,
+        crossOrigin,
+        height,
+        onError,
+        onLoad,
+        referrerPolicy,
+        src,
+        srcSet,
+        width
+      } = props;
+
+      /**
+       * Resolve global HTML and style props
+       */
+
+      const defaultProps = {
+        style: [
+          _defaultProps?.style,
+          height != null && width != null && styles.aspectRatio(width, height)
+        ]
+      };
+
+      const { nativeProps } = useNativeProps(defaultProps, props, {
+        provideInheritableStyle: false,
+        withInheritedStyle: false,
+        withTextStyle: false
+      });
+
+      // Tag-specific props
+
+      if (alt != null) {
+        nativeProps.alt = alt;
+      }
+      if (crossOrigin != null) {
+        nativeProps.crossOrigin = crossOrigin;
+      }
+      if (height != null) {
+        nativeProps.height = height;
+      }
+      if (onError != null) {
+        nativeProps.onError = function () {
+          onError({
+            type: 'error'
+          });
+        };
+      }
+      if (onLoad != null) {
+        nativeProps.onLoad = function (e) {
+          const { source } = e.nativeEvent;
+          onLoad({
+            target: {
+              naturalHeight: source?.height,
+              naturalWidth: source?.width
+            },
+            type: 'load'
+          });
+        };
+      }
+      if (referrerPolicy != null) {
+        nativeProps.referrerPolicy = referrerPolicy;
+      }
+      if (src != null) {
+        nativeProps.src = src;
+      }
+      if (srcSet != null) {
+        nativeProps.srcSet = srcSet;
+      }
+      if (width != null) {
+        nativeProps.width = width;
+      }
+
+      // Component-specific props
+
+      nativeProps.ref = React.useMemo(
+        () => mergeRefs(elementRef, forwardedRef),
+        [elementRef, forwardedRef]
+      );
+
+      // Use Animated components if necessary
+      if (nativeProps.animated === true) {
+        NativeComponent = Animated.Image;
+      }
+
+      // $FlowFixMe
+      const element = React.createElement(NativeComponent, nativeProps);
+
+      return element;
+    }
+  );
+
+  component.displayName = `html.${tagName}`;
+  return component;
+}
+
+const styles = stylex.create({
+  aspectRatio: (width: number, height: number) => ({
+    aspectRatio: width / height,
+    width,
+    height
+  })
+});

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
@@ -100,7 +100,7 @@ export function createStrictDOMTextComponent<T, P: StrictProps>(
        */
 
       // $FlowFixMe
-      let element = React.createElement(NativeComponent, nativeProps);
+      let element: $FlowFixMe = <NativeComponent {...nativeProps} />;
 
       if (hasElementChildren(nativeProps.children)) {
         if (inheritableStyle != null) {

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import type { StrictProps } from '../../types/StrictProps';
+
+import * as React from 'react';
+import { Animated, Platform, Text } from 'react-native';
+import { ProvideCustomProperties } from './ContextCustomProperties';
+import { ProvideInheritedStyles } from './ContextInheritedStyles';
+import { errorMsg } from '../../shared/logUtils';
+import { mergeRefs } from '../../shared/mergeRefs';
+import { useNativeProps } from './useNativeProps';
+import { useStrictDOMElement } from './useStrictDOMElement';
+import * as stylex from '../stylex';
+
+function hasElementChildren(children: mixed): boolean {
+  return children != null && typeof children !== 'string';
+}
+
+export function createStrictDOMTextComponent<T, P: StrictProps>(
+  tagName: string,
+  _defaultProps?: P
+): React.AbstractComponent<P, T> {
+  const component: React.AbstractComponent<P, T> = React.forwardRef(
+    function (props, forwardedRef) {
+      let NativeComponent = Text;
+      const elementRef = useStrictDOMElement<T>({ tagName });
+
+      const { href, label } = props;
+
+      /**
+       * Resolve global HTML and style props
+       */
+
+      const defaultProps = {
+        style: [_defaultProps?.style, styles.userSelectAuto]
+      };
+
+      const { customProperties, nativeProps, inheritableStyle } =
+        useNativeProps(defaultProps, props, {
+          provideInheritableStyle:
+            tagName !== 'br' ||
+            tagName !== 'option' ||
+            hasElementChildren(props.children),
+          withInheritedStyle: true,
+          withTextStyle: true
+        });
+
+      // Tag-specific props
+
+      if (tagName === 'a') {
+        nativeProps.role = nativeProps.role ?? 'link';
+        if (href != null) {
+          nativeProps.onPress = function (e) {
+            if (__DEV__) {
+              errorMsg(
+                '<a> "href" handling is not implemented in React Native.'
+              );
+            }
+          };
+        }
+      } else if (tagName === 'br') {
+        nativeProps.children = '\n';
+      } else if (tagName === 'option') {
+        nativeProps.children = label;
+      }
+
+      // Component-specific props
+
+      nativeProps.ref = React.useMemo(
+        () => mergeRefs(elementRef, forwardedRef),
+        [elementRef, forwardedRef]
+      );
+
+      // Workaround: Android doesn't support ellipsis truncation if Text is selectable
+      // See #136
+      const disableUserSelect =
+        Platform.OS === 'android' &&
+        nativeProps.numberOfLines != null &&
+        nativeProps.style.userSelect !== 'none';
+
+      nativeProps.style = Object.assign(
+        nativeProps.style,
+        disableUserSelect ? { userSelect: 'none' } : null
+      );
+
+      // Use Animated components if necessary
+      if (nativeProps.animated === true) {
+        NativeComponent = Animated.Text;
+      }
+
+      /**
+       * Construct tree
+       */
+
+      // $FlowFixMe
+      let element = React.createElement(NativeComponent, nativeProps);
+
+      if (hasElementChildren(nativeProps.children)) {
+        if (inheritableStyle != null) {
+          element = (
+            <ProvideInheritedStyles
+              children={element}
+              value={inheritableStyle}
+            />
+          );
+        }
+        if (customProperties != null) {
+          element = (
+            <ProvideCustomProperties
+              children={element}
+              value={customProperties}
+            />
+          );
+        }
+      }
+
+      return element;
+    }
+  );
+
+  component.displayName = `html.${tagName}`;
+  return component;
+}
+
+const styles = stylex.create({
+  userSelectAuto: {
+    userSelect: 'auto'
+  }
+});

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMTextInputComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMTextInputComponent.js
@@ -182,7 +182,7 @@ export function createStrictDOMTextInputComponent<
       }
 
       // $FlowFixMe
-      const element = React.createElement(NativeComponent, nativeProps);
+      const element = <NativeComponent {...nativeProps} />;
 
       return element;
     }

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMTextInputComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMTextInputComponent.js
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import type { StrictReactDOMInputProps } from '../../types/StrictReactDOMInputProps';
+import type { StrictReactDOMTextAreaProps } from '../../types/StrictReactDOMTextAreaProps';
+
+import * as React from 'react';
+import { Animated, TextInput } from 'react-native';
+import { errorMsg } from '../../shared/logUtils';
+import { mergeRefs } from '../../shared/mergeRefs';
+import { useNativeProps } from './useNativeProps';
+import { useStrictDOMElement } from './useStrictDOMElement';
+
+const AnimatedTextInput = Animated.createAnimatedComponent(TextInput);
+
+export function createStrictDOMTextInputComponent<
+  P: StrictReactDOMInputProps | StrictReactDOMTextAreaProps,
+  T
+>(tagName: string, defaultProps?: P): React.AbstractComponent<P, T> {
+  const component: React.AbstractComponent<P, T> = React.forwardRef(
+    function (props, forwardedRef) {
+      let NativeComponent = TextInput;
+      const elementRef = useStrictDOMElement<T>({ tagName });
+
+      const {
+        autoComplete,
+        defaultValue,
+        disabled,
+        enterKeyHint,
+        inputMode,
+        maxLength,
+        onChange,
+        onInput,
+        onKeyDown,
+        placeholder,
+        readOnly,
+        rows,
+        spellCheck,
+        type,
+        value
+      } = props;
+
+      /**
+       * Resolve global HTML and style props
+       */
+
+      const { nativeProps } = useNativeProps(defaultProps, props, {
+        provideInheritableStyle: false,
+        withInheritedStyle: false,
+        withTextStyle: true
+      });
+
+      // Tag-specific props
+
+      if (tagName === 'input') {
+        let _inputMode = inputMode;
+        if (type === 'email') {
+          _inputMode = 'email';
+        }
+        if (type === 'search') {
+          _inputMode = 'search';
+        }
+        if (type === 'tel') {
+          _inputMode = 'tel';
+        }
+        if (type === 'url') {
+          _inputMode = 'url';
+        }
+        if (type === 'number') {
+          _inputMode = 'numeric';
+        }
+        if (_inputMode != null) {
+          nativeProps.inputMode = _inputMode;
+        }
+        if (type === 'password') {
+          nativeProps.secureTextEntry = true;
+        }
+        if (type === 'checkbox' || type === 'date' || type === 'radio') {
+          if (__DEV__) {
+            errorMsg(
+              `<input type="${type}" /> is not implemented in React Native.`
+            );
+          }
+        }
+      } else if (tagName === 'textarea') {
+        nativeProps.multiline = true;
+        if (rows != null) {
+          nativeProps.numberOfLines = rows;
+        }
+      }
+
+      // Component-specific props
+
+      if (autoComplete != null) {
+        nativeProps.autoComplete = autoComplete;
+      }
+      if (defaultValue != null) {
+        nativeProps.defaultValue = defaultValue;
+      }
+      if (disabled === true) {
+        // polyfill disabled elements
+        nativeProps.disabled = true;
+        nativeProps.editable = false;
+        nativeProps.focusable = false;
+      }
+      if (enterKeyHint != null) {
+        nativeProps.enterKeyHint = enterKeyHint;
+      }
+      if (maxLength != null) {
+        nativeProps.maxLength = maxLength;
+      }
+      if (onChange != null || onInput != null) {
+        nativeProps.onChange = function (e) {
+          const { text } = e.nativeEvent;
+          if (onInput != null) {
+            onInput({
+              target: {
+                value: text
+              },
+              type: 'input'
+            });
+          }
+          if (onChange != null) {
+            onChange({
+              target: {
+                value: text
+              },
+              type: 'change'
+            });
+          }
+        };
+      }
+      if (onKeyDown != null) {
+        nativeProps.onKeyPress = function (e) {
+          const { key } = e.nativeEvent;
+          // Filter out bad iOS keypress data on submit
+          if (
+            key === 'Backspace' ||
+            (tagName === 'textarea' && key === 'Enter') ||
+            key.length === 1
+          ) {
+            onKeyDown({
+              key,
+              type: 'keydown'
+            });
+          }
+        };
+        nativeProps.onSubmitEditing = function (e) {
+          onKeyDown({
+            key: 'Enter',
+            type: 'keydown'
+          });
+        };
+      }
+      if (placeholder != null) {
+        nativeProps.placeholder = placeholder;
+      }
+      if (readOnly != null) {
+        nativeProps.editable = !readOnly;
+      }
+      if (spellCheck != null) {
+        nativeProps.spellCheck = spellCheck;
+      }
+      if (value != null && typeof value === 'string') {
+        nativeProps.value = value;
+      }
+
+      nativeProps.ref = React.useMemo(
+        () => mergeRefs(elementRef, forwardedRef),
+        [elementRef, forwardedRef]
+      );
+
+      // Use Animated components if necessary
+      if (nativeProps.animated === true) {
+        NativeComponent = AnimatedTextInput;
+      }
+
+      // $FlowFixMe
+      const element = React.createElement(NativeComponent, nativeProps);
+
+      return element;
+    }
+  );
+
+  component.displayName = `html.${tagName}`;
+  return component;
+}

--- a/packages/react-strict-dom/src/native/modules/useNativeProps.js
+++ b/packages/react-strict-dom/src/native/modules/useNativeProps.js
@@ -83,7 +83,7 @@ type ReturnType = {|
 |};
 
 export function useNativeProps(
-  defaultProps: StrictProps,
+  defaultProps: ?StrictProps,
   props: StrictProps,
   options: OptionsType
 ): ReturnType {
@@ -112,6 +112,7 @@ export function useNativeProps(
     'data-testid': dataTestID,
     dir,
     //disabled,
+    hidden,
     id,
     onBlur,
     onClick,
@@ -166,6 +167,22 @@ export function useNativeProps(
     withInheritedStyle: options.withInheritedStyle,
     writingDirection: dir
   });
+
+  const displayValue = nativeProps.style.display;
+  if (
+    displayValue != null &&
+    displayValue !== 'flex' &&
+    displayValue !== 'none' &&
+    displayValue !== 'block'
+  ) {
+    if (__DEV__) {
+      warnMsg(`unsupported style value in "display:${String(displayValue)}"`);
+    }
+  }
+  // 'hidden' polyfill (only if "display" is not set)
+  if (displayValue == null && hidden && hidden !== 'until-found') {
+    nativeProps.style.display = 'none';
+  }
 
   /**
    * Resolve common props

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -195,6 +195,17 @@ exports[`properties: general boxSizing: content-box: minWidth 1`] = `
 }
 `;
 
+exports[`properties: general boxSizing: content-box: null 1`] = `
+{
+  "style": {
+    "borderWidth": 2,
+    "height": 74,
+    "padding": 10,
+    "width": null,
+  },
+}
+`;
+
 exports[`properties: general boxSizing: content-box: units 1`] = `
 {
   "style": {

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -127,6 +127,17 @@ describe('properties: general', () => {
     expect(css.props.call(mockOptions, styles.root)).toMatchSnapshot();
   });
 
+  test('animationName', () => {
+    css.keyframes({
+      '100%': {
+        width: 1000
+      }
+    });
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('css.keyframes() is not supported')
+    );
+  });
+
   test('backgroundImage', () => {
     const styles = css.create({
       root: {
@@ -249,6 +260,20 @@ describe('properties: general', () => {
         padding: 10,
         height: 50,
         width: 'auto'
+      },
+      null: {
+        boxSizing: 'content-box',
+        borderWidth: 2,
+        padding: 10,
+        height: 50,
+        width: null
+      },
+      string: {
+        boxSizing: 'content-box',
+        borderWidth: 2,
+        padding: 10,
+        height: 50,
+        width: '50%'
       }
     });
     expect(css.props.call(mockOptions, styles.width)).toMatchSnapshot('width');
@@ -272,6 +297,10 @@ describe('properties: general', () => {
       'allDifferent'
     );
     expect(css.props.call(mockOptions, styles.auto)).toMatchSnapshot('auto');
+    expect(css.props.call(mockOptions, styles.null)).toMatchSnapshot('null');
+
+    css.props.call(mockOptions, styles.string);
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
   test('caretColor', () => {
@@ -282,12 +311,18 @@ describe('properties: general', () => {
       redCaret: {
         caretColor: 'red'
       },
-      unsupportedCaret: {
+      inheritCaret: {
         caretColor: 'inherit'
+      },
+      autoCaret: {
+        caretColor: 'auto'
       }
     });
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('unsupported style value in "caretColor:inherit"')
+    );
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('unsupported style value in "caretColor:auto"')
     );
     expect(
       css.props.call(mockOptions, styles.transparentCaret)

--- a/packages/react-strict-dom/tools/babel.config.js
+++ b/packages/react-strict-dom/tools/babel.config.js
@@ -7,7 +7,15 @@
 
 const createConfig = ({ modules, target }) => {
   const plugins = ['babel-plugin-syntax-hermes-parser'];
-  const presets = ['@babel/preset-react', '@babel/preset-flow'];
+  const presets = [
+    [
+      '@babel/preset-react',
+      {
+        runtime: 'automatic'
+      }
+    ],
+    '@babel/preset-flow'
+  ];
 
   if (process.env.NODE_ENV === 'test') {
     if (target === 'dom') {

--- a/packages/react-strict-dom/tools/rollup.config.js
+++ b/packages/react-strict-dom/tools/rollup.config.js
@@ -47,7 +47,7 @@ const sharedPlugins = [
 const webConfigs = [
   // OSS build
   {
-    external: ['react', 'react-dom', '@stylexjs/stylex'],
+    external: ['react', 'react/jsx-runtime', 'react-dom', '@stylexjs/stylex'],
     input: require.resolve('../src/dom/index.js'),
     output: {
       file: path.join(__dirname, '../dist/dom/index.js'),
@@ -57,7 +57,7 @@ const webConfigs = [
   },
   // Runtime
   {
-    external: ['react', 'react-dom', '@stylexjs/stylex'],
+    external: ['react', 'react/jsx-runtime', 'react-dom', '@stylexjs/stylex'],
     input: require.resolve('../src/dom/runtime.js'),
     output: {
       file: path.join(__dirname, '../dist/dom/runtime.js'),
@@ -73,7 +73,12 @@ const webConfigs = [
 const nativeConfigs = [
   // OSS build
   {
-    external: ['react', /^react-native.*/, '@stylexjs/stylex'],
+    external: [
+      'react',
+      'react/jsx-runtime',
+      /^react-native.*/,
+      '@stylexjs/stylex'
+    ],
     input: require.resolve('../src/native/index.js'),
     output: {
       file: path.join(__dirname, '../dist/native/index.js'),


### PR DESCRIPTION
Break up 'createStrictDOMComponent' into separate functions for different types of React Native component. This can help to reduce the amount of unused logic and hooks needed by each type of native component.