### PR TITLE
Get fontScale value from useWindowDimensions

### DIFF
--- a/packages/benchmarks/perf/mocks/react-native.js
+++ b/packages/benchmarks/perf/mocks/react-native.js
@@ -108,4 +108,9 @@ export const View = 'View';
 
 export const useColorScheme = () => 'light';
 
-export const useWindowDimensions = () => ({ width: 2000, height: 1000 });
+export const useWindowDimensions = () => ({
+  fontScale: 1,
+  height: 1000,
+  scale: 1,
+  width: 2000
+});

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -12,7 +12,7 @@ import type { Props as ReactNativeProps } from '../../types/react-native';
 import type { Style as ReactNativeStyle } from '../../types/react-native';
 
 import * as stylex from '../stylex';
-import { PixelRatio, useColorScheme, useWindowDimensions } from 'react-native';
+import { useColorScheme, useWindowDimensions } from 'react-native';
 import { flattenStyle } from './flattenStyle';
 import { useInheritedStyles } from './ContextInheritedStyles';
 import { usePseudoStates } from './usePseudoStates';
@@ -61,9 +61,8 @@ export function useStyleProps(
     writingDirection: dir
   } = options;
 
-  const { height, width } = useWindowDimensions();
+  const { fontScale, height, width } = useWindowDimensions();
   const colorScheme = useColorScheme();
-  const fontScale = PixelRatio.getFontScale();
 
   // These values are already computed
   const {

--- a/packages/react-strict-dom/tests/__mocks__/react-native/index.js
+++ b/packages/react-strict-dom/tests/__mocks__/react-native/index.js
@@ -106,4 +106,4 @@ export const useColorScheme = jest.fn().mockReturnValue('light');
 
 export const useWindowDimensions = jest
   .fn()
-  .mockReturnValue({ width: 2000, height: 1000 });
+  .mockReturnValue({ fontScale: 1, height: 1000, scale: 1, width: 2000 });


### PR DESCRIPTION
The value of fontScale is available from useWindowDimensions, so PixelRatio is not needed.