### PR TITLE
Optimized Fast Path For re-renders of divs with unchanged contexts

### DIFF
--- a/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
+++ b/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
@@ -10,7 +10,9 @@
 import type { Style } from '../../types/styles';
 
 import * as React from 'react';
+import { useMemo, useState } from 'react';
 import { flattenStyle } from './flattenStyle';
+import { shallowEqual } from './shallowEqual';
 
 type Value = Style;
 
@@ -34,20 +36,35 @@ export function ProvideInheritedStyles(
 ): React$MixedElement {
   const { children, value } = props;
   const inheritedStyles = useInheritedStyles();
-  let flatStyle;
+  const flatStyle = useMemo(() => {
+    if (
+      value == null ||
+      (typeof value === 'object' && Object.keys(value).length === 0)
+    ) {
+      return inheritedStyles;
+    } else if (inheritedStyles === defaultContext) {
+      return value;
+    } else {
+      return flattenStyle([inheritedStyles as ?Style, value as ?Style]);
+    }
+  }, [inheritedStyles, value]);
+
+  const [cachedFlatStyle, setCachedFlatStyle] = useState(flatStyle);
+
   if (
-    value == null ||
-    (typeof value === 'object' && Object.keys(value).length === 0)
+    flatStyle !== cachedFlatStyle &&
+    !shallowEqual(flatStyle, cachedFlatStyle)
   ) {
-    flatStyle = inheritedStyles;
-  } else if (inheritedStyles === defaultContext) {
-    flatStyle = value;
-  } else {
-    flatStyle = flattenStyle([inheritedStyles as ?Style, value as ?Style]);
+    // this functions as a local useMemo here, so that we only re-render children
+    // if the actual *values* of the styles have changed
+    setCachedFlatStyle(flatStyle);
   }
 
   return (
-    <ContextInheritedStyles.Provider children={children} value={flatStyle} />
+    <ContextInheritedStyles.Provider
+      children={children}
+      value={cachedFlatStyle}
+    />
   );
 }
 

--- a/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
+++ b/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
@@ -34,7 +34,17 @@ export function ProvideInheritedStyles(
 ): React$MixedElement {
   const { children, value } = props;
   const inheritedStyles = useInheritedStyles();
-  const flatStyle = flattenStyle([inheritedStyles as ?Style, value as ?Style]);
+  let flatStyle;
+  if (
+    value == null ||
+    (typeof value === 'object' && Object.keys(value).length === 0)
+  ) {
+    flatStyle = inheritedStyles;
+  } else if (inheritedStyles === defaultContext) {
+    flatStyle = value;
+  } else {
+    flatStyle = flattenStyle([inheritedStyles as ?Style, value as ?Style]);
+  }
 
   return (
     <ContextInheritedStyles.Provider children={children} value={flatStyle} />

--- a/packages/react-strict-dom/src/native/modules/shallowEqual.js
+++ b/packages/react-strict-dom/src/native/modules/shallowEqual.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * Copied from the fbjs implementation
+ * Copied from the fbjs implementation, but without Object.is polyfill
  *
  * @flow strict
  */
@@ -17,29 +17,12 @@
 const hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
- * inlined Object.is polyfill to avoid requiring consumers ship their own
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
- */
-function is(x: mixed, y: mixed): boolean {
-  // SameValue algorithm
-  if (x === y) {
-    // Steps 1-5, 7-10
-    // Steps 6.b-6.e: +0 != -0
-    // Added the nonzero y check to make Flow happy, but it is redundant
-    return x !== 0 || y !== 0 || 1 / x === 1 / y;
-  } else {
-    // Step 6.a: NaN == NaN
-    return x !== x && y !== y;
-  }
-}
-
-/**
  * Performs equality by iterating through keys on an object and returning false
  * when any key has values which are not strictly equal between the arguments.
  * Returns true when the values of all keys are strictly equal.
  */
 export function shallowEqual(objA: mixed, objB: mixed): boolean {
-  if (is(objA, objB)) {
+  if (Object.is(objA, objB)) {
     return true;
   }
 
@@ -64,7 +47,7 @@ export function shallowEqual(objA: mixed, objB: mixed): boolean {
     if (
       !hasOwnProperty.call(objB, keysA[i]) ||
       // $FlowFixMe[incompatible-use]
-      !is(objA[keysA[i]], objB[keysA[i]])
+      !Object.is(objA[keysA[i]], objB[keysA[i]])
     ) {
       return false;
     }

--- a/packages/react-strict-dom/src/native/modules/shallowEqual.js
+++ b/packages/react-strict-dom/src/native/modules/shallowEqual.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Copied from the fbjs implementation
+ *
+ * @flow strict
+ */
+
+/*eslint-disable no-self-compare */
+
+'use strict';
+
+// $FlowFixMe[method-unbinding] added when improving typing for this parameters
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * inlined Object.is polyfill to avoid requiring consumers ship their own
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+ */
+function is(x: mixed, y: mixed): boolean {
+  // SameValue algorithm
+  if (x === y) {
+    // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    // Added the nonzero y check to make Flow happy, but it is redundant
+    return x !== 0 || y !== 0 || 1 / x === 1 / y;
+  } else {
+    // Step 6.a: NaN == NaN
+    return x !== x && y !== y;
+  }
+}
+
+/**
+ * Performs equality by iterating through keys on an object and returning false
+ * when any key has values which are not strictly equal between the arguments.
+ * Returns true when the values of all keys are strictly equal.
+ */
+export function shallowEqual(objA: mixed, objB: mixed): boolean {
+  if (is(objA, objB)) {
+    return true;
+  }
+
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (let i = 0; i < keysA.length; i++) {
+    if (
+      !hasOwnProperty.call(objB, keysA[i]) ||
+      // $FlowFixMe[incompatible-use]
+      !is(objA[keysA[i]], objB[keysA[i]])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
If I'm not missing anything, any time any RSD div re-renders for any reaason, all RSD components below it will re-render, no matter what, because this context *always* changes. This adds a fast path so that at the very least, this will now only happen when you re-render a div that actually *does* include any new inheritable styles. 

It also adds a tiny bit of a bail out (no need to object.assign to a new object) if the new inheritable styles are added to a div that has no parent inherited styles (so the parent is using the default context value, which now will get transferred down thanks to the first if). But it'll still be a new object there, because a new object will be created for "value" every time.

The way to fix this properly would be to actually do some kind of proper memoization of this value - but this hack is quick and dirty and *most* of the time won't result in re-rendering the entire subtree of RSD components, so I'll take it for now. 

Will see if I can add tests in the morning but wanted to get this out there first to take a look at as it should be fairly self explanatory.