### PR TITLE
Prevent avoidable re-renders of html.div on native

### DIFF
--- a/packages/react-strict-dom/src/native/modules/__tests__/shallowEqual-test.js
+++ b/packages/react-strict-dom/src/native/modules/__tests__/shallowEqual-test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import { shallowEqual } from '../shallowEqual';
+
+describe('shallowEqual', () => {
+  test('returns false if either argument is null', () => {
+    expect(shallowEqual(null, {})).toBe(false);
+    expect(shallowEqual({}, null)).toBe(false);
+  });
+
+  test('returns true if both arguments are null or undefined', () => {
+    expect(shallowEqual(null, null)).toBe(true);
+    expect(shallowEqual(undefined, undefined)).toBe(true);
+  });
+
+  test('returns true if arguments are not objects and are equal', () => {
+    expect(shallowEqual(1, 1)).toBe(true);
+  });
+
+  test('returns true if arguments are shallow equal', () => {
+    expect(shallowEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2, c: 3 })).toBe(true);
+  });
+
+  test('returns true when comparing NaN', () => {
+    expect(shallowEqual(NaN, NaN)).toBe(true);
+
+    expect(
+      shallowEqual({ a: 1, b: 2, c: 3, d: NaN }, { a: 1, b: 2, c: 3, d: NaN })
+    ).toBe(true);
+  });
+
+  test('returns false if arguments are not objects and not equal', () => {
+    expect(shallowEqual(1, 2)).toBe(false);
+  });
+
+  test('returns false if only one argument is not an object', () => {
+    expect(shallowEqual(1, {})).toBe(false);
+  });
+
+  test('returns false if first argument has too many keys', () => {
+    expect(shallowEqual({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 })).toBe(false);
+  });
+
+  test('returns false if second argument has too many keys', () => {
+    expect(shallowEqual({ a: 1, b: 2 }, { a: 1, b: 2, c: 3 })).toBe(false);
+  });
+
+  test('returns false if arguments are not shallow equal', () => {
+    expect(shallowEqual({ a: 1, b: 2, c: {} }, { a: 1, b: 2, c: {} })).toBe(
+      false
+    );
+  });
+});

--- a/packages/react-strict-dom/src/native/modules/shallowEqual.js
+++ b/packages/react-strict-dom/src/native/modules/shallowEqual.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Copied from the fbjs implementation
+ *
+ * @flow strict
+ */
+
+'use strict';
+
+// $FlowFixMe[method-unbinding] added when improving typing for this parameters
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * Performs equality by iterating through keys on an object and returning false
+ * when any key has values which are not strictly equal between the arguments.
+ * Returns true when the values of all keys are strictly equal.
+ */
+export function shallowEqual(objA: mixed, objB: mixed): boolean {
+  if (Object.is(objA, objB)) {
+    return true;
+  }
+
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (let i = 0; i < keysA.length; i++) {
+    if (
+      !hasOwnProperty.call(objB, keysA[i]) ||
+      // $FlowFixMe[incompatible-use]
+      !Object.is(objA[keysA[i]], objB[keysA[i]])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}


### PR DESCRIPTION
Optimization to avoid re-renders of html.div with unchanged contexts. Includes full memoization of inherited styles so updates without changes don't force all children to re-render.