### PR TITLE
Add support for non-prefixed `boxShadow` and `filter` properties

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -625,12 +625,18 @@ export function props(
       nextStyle.alignContent = nextStyle.alignContent ?? styleValue;
       nextStyle.justifyContent = nextStyle.justifyContent ?? styleValue;
     }
-    // experimental styles
+    // boxShadow
     else if (styleProp === 'boxShadow') {
+      nextStyle.boxShadow = styleValue;
       nextStyle.experimental_boxShadow = styleValue;
-    } else if (styleProp === 'filter') {
+    }
+    // filter
+    else if (styleProp === 'filter') {
+      nextStyle.filter = styleValue;
       nextStyle.experimental_filter = styleValue;
-    } else if (styleProp === 'mixBlendMode') {
+    }
+    // experimental styles
+    else if (styleProp === 'mixBlendMode') {
       nextStyle.experimental_mixBlendMode = styleValue;
     }
     // Everything else

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -93,6 +93,7 @@ exports[`properties: general borderStyle 2`] = `
 exports[`properties: general boxShadow 1`] = `
 {
   "style": {
+    "boxShadow": "1px 2px 3px 4px red",
     "experimental_boxShadow": "1px 2px 3px 4px red",
   },
 }
@@ -101,6 +102,7 @@ exports[`properties: general boxShadow 1`] = `
 exports[`properties: general boxShadow 2`] = `
 {
   "style": {
+    "boxShadow": "1px 2px 3px 4px red, 2px 3px 4px 5px blue",
     "experimental_boxShadow": "1px 2px 3px 4px red, 2px 3px 4px 5px blue",
   },
 }
@@ -109,6 +111,7 @@ exports[`properties: general boxShadow 2`] = `
 exports[`properties: general boxShadow 3`] = `
 {
   "style": {
+    "boxShadow": "inset 1px 2px 3px 4px red",
     "experimental_boxShadow": "inset 1px 2px 3px 4px red",
   },
 }
@@ -254,6 +257,7 @@ exports[`properties: general filter 1`] = `
 {
   "style": {
     "experimental_filter": "blur(1px)",
+    "filter": "blur(1px)",
   },
 }
 `;


### PR DESCRIPTION
Experimental prefixes for these props will be eventually deleted but while we are changing this we'll accept both names