### PR TITLE
fix: Add textDecoration properties to list of inheritable styles

### DIFF
--- a/packages/react-strict-dom/src/native/modules/flattenStyle.js
+++ b/packages/react-strict-dom/src/native/modules/flattenStyle.js
@@ -28,10 +28,26 @@ export function flattenStyle(
 
   const flatArray = style.flat(Infinity);
   const result: { ...Style } = {};
-  for (let i = 0; i < flatArray.length; i++) {
-    const style = flatArray[i];
+  for (const style of flatArray) {
     if (style != null && typeof style === 'object') {
-      Object.assign(result, style);
+      for (const [key, val] of Object.entries(style)) {
+        if (
+          (key.startsWith('@') || key.startsWith(':')) &&
+          val != null &&
+          typeof val === 'object'
+        ) {
+          result[key] = Object.assign(
+            {},
+            result[key] != null && typeof result[key] === 'object'
+              ? result[key]
+              : null,
+            val
+          );
+        } else {
+          // $FlowFixMe
+          result[key] = val;
+        }
+      }
     }
   }
   return result;

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -79,7 +79,10 @@ export function useStyleProps(
     textIndent: inheritedTextIndent,
     textTransform: inheritedTextTransform,
     whiteSpace: inheritedWhiteSpace,
-    writingDirection: inheritedWritingDirection
+    writingDirection: inheritedWritingDirection,
+    textDecorationLine: inheritedTextDecorationLine,
+    textDecorationStyle: inheritedTextDecorationStyle,
+    textDecorationColor: inheritedTextDecorationColor
   } = useInheritedStyles();
 
   const flatStyle = flattenStyle(style);
@@ -152,6 +155,9 @@ export function useStyleProps(
     textTransform,
     whiteSpace,
     writingDirection,
+    textDecorationLine,
+    textDecorationStyle,
+    textDecorationColor,
     ...viewStyle
   } = styleProps.style;
 
@@ -171,7 +177,10 @@ export function useStyleProps(
     ['textIndent', textIndent, inheritedTextIndent],
     ['textTransform', textTransform, inheritedTextTransform],
     ['whiteSpace', whiteSpace, inheritedWhiteSpace],
-    ['writingDirection', writingDirection, inheritedWritingDirection]
+    ['writingDirection', writingDirection, inheritedWritingDirection],
+    ['textDecorationLine', textDecorationLine, inheritedTextDecorationLine],
+    ['textDecorationStyle', textDecorationStyle, inheritedTextDecorationStyle],
+    ['textDecorationColor', textDecorationColor, inheritedTextDecorationColor]
   ].forEach(([key, value, inheritedValue]) => {
     let val = value;
     if (


### PR DESCRIPTION
Just adds the additional styles that should be inherited.

Also fixes style flattenning logic to support legacy "@" and ":" styles in StyleX.