### PR TITLE
Fix support for % translate transforms

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/parseTransform.js
+++ b/packages/react-strict-dom/src/native/stylex/parseTransform.js
@@ -10,7 +10,7 @@
 import type { Transform } from '../../types/react-native';
 
 const transformRegex1 =
-  /(perspective|scale|scaleX|scaleY|scaleZ|translateX|translateY)\(([0-9.+\-eE]+)(px)?\)/;
+  /(perspective|scale|scaleX|scaleY|scaleZ|translateX|translateY)\(([0-9.+\-eE]+)(px|%)?\)/;
 const transformRegex2 = /(rotate|rotateX|rotateY|rotateZ|skewX|skewY)\((.*)\)/;
 const transformRegex3 = /matrix\((.*)\)/;
 
@@ -32,6 +32,8 @@ export function parseTransform(transform: string): $ReadOnlyArray<Transform> {
     if (match != null) {
       const t = match[1];
       const value = parseFloat(match[2]);
+      const unit = match[3];
+
       if (isNaN(value)) {
         continue;
       }
@@ -46,9 +48,13 @@ export function parseTransform(transform: string): $ReadOnlyArray<Transform> {
       } else if (t === 'scaleZ') {
         parsedTransforms.push({ scaleZ: value });
       } else if (t === 'translateX') {
-        parsedTransforms.push({ translateX: value });
+        parsedTransforms.push({
+          translateX: unit === '%' ? value + unit : value
+        });
       } else if (t === 'translateY') {
-        parsedTransforms.push({ translateY: value });
+        parsedTransforms.push({
+          translateY: unit === '%' ? value + unit : value
+        });
       }
       continue;
     }

--- a/packages/react-strict-dom/src/types/react-native.js
+++ b/packages/react-strict-dom/src/types/react-native.js
@@ -127,8 +127,8 @@ type Transform =
   | $ReadOnly<{ scaleX: number }>
   | $ReadOnly<{ scaleY: number }>
   | $ReadOnly<{ scaleZ: number }>
-  | $ReadOnly<{ translateX: number }>
-  | $ReadOnly<{ translateY: number }>
+  | $ReadOnly<{ translateX: number | string }>
+  | $ReadOnly<{ translateY: number | string }>
   | $ReadOnly<{ skewX: string }>
   | $ReadOnly<{ skewY: string }>;
 

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -734,6 +734,21 @@ exports[`properties: general transform: skew 1`] = `
 }
 `;
 
+exports[`properties: general transform: translate (percentages) 1`] = `
+{
+  "style": {
+    "transform": [
+      {
+        "translateX": "10%",
+      },
+      {
+        "translateY": "20%",
+      },
+    ],
+  },
+}
+`;
+
 exports[`properties: general transform: translate 1`] = `
 {
   "style": {

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -719,6 +719,9 @@ describe('properties: general', () => {
         transform:
           'translate(10px, 20px) translateX(11px) translateY(12px) translateZ(13px) translate3d(20px, 30px, 40px)'
       },
+      translatePercentage: {
+        transform: 'translateX(10%) translateY(20%)'
+      },
       mixed: {
         transform: `
           rotateX(1deg) rotateY(2deg) rotateZ(3deg) rotate3d(1deg, 2deg, 3deg)
@@ -742,6 +745,9 @@ describe('properties: general', () => {
     expect(css.props.call(mockOptions, styles.translate)).toMatchSnapshot(
       'translate'
     );
+    expect(
+      css.props.call(mockOptions, styles.translatePercentage)
+    ).toMatchSnapshot('translate (percentages)');
     expect(css.props.call(mockOptions, styles.rotate)).toMatchSnapshot(
       'rotate'
     );


### PR DESCRIPTION
The original implementation of `parseTransform` was written before React Native supported `%` units for translations, and assumed that only `px` values are allowed.