### PR TITLE
Remove _experimental prefix from boxShadow and filter

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -629,16 +629,6 @@ export function props(
       nextStyle.alignContent = nextStyle.alignContent ?? styleValue;
       nextStyle.justifyContent = nextStyle.justifyContent ?? styleValue;
     }
-    // boxShadow
-    else if (styleProp === 'boxShadow') {
-      nextStyle.boxShadow = styleValue;
-      nextStyle.experimental_boxShadow = styleValue;
-    }
-    // filter
-    else if (styleProp === 'filter') {
-      nextStyle.filter = styleValue;
-      nextStyle.experimental_filter = styleValue;
-    }
     // experimental styles
     else if (styleProp === 'mixBlendMode') {
       nextStyle.experimental_mixBlendMode = styleValue;

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -94,7 +94,6 @@ exports[`properties: general boxShadow 1`] = `
 {
   "style": {
     "boxShadow": "1px 2px 3px 4px red",
-    "experimental_boxShadow": "1px 2px 3px 4px red",
   },
 }
 `;
@@ -103,7 +102,6 @@ exports[`properties: general boxShadow 2`] = `
 {
   "style": {
     "boxShadow": "1px 2px 3px 4px red, 2px 3px 4px 5px blue",
-    "experimental_boxShadow": "1px 2px 3px 4px red, 2px 3px 4px 5px blue",
   },
 }
 `;
@@ -112,7 +110,6 @@ exports[`properties: general boxShadow 3`] = `
 {
   "style": {
     "boxShadow": "inset 1px 2px 3px 4px red",
-    "experimental_boxShadow": "inset 1px 2px 3px 4px red",
   },
 }
 `;
@@ -267,7 +264,6 @@ exports[`properties: general direction: rtl 1`] = `
 exports[`properties: general filter 1`] = `
 {
   "style": {
-    "experimental_filter": "blur(1px)",
     "filter": "blur(1px)",
   },
 }


### PR DESCRIPTION
experimental_ for boxShadow and filter has been removed from React Native so now we can do the same for RSD