### PR TITLE
Prepare to remove experimental_ prefix from mix-blend-mode

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -641,6 +641,7 @@ export function props(
     }
     // experimental styles
     else if (styleProp === 'mixBlendMode') {
+      nextStyle.mixBlendMode = styleValue;
       nextStyle.experimental_mixBlendMode = styleValue;
     }
     // Everything else

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -396,6 +396,7 @@ exports[`properties: general mixBlendMode 1`] = `
 {
   "style": {
     "experimental_mixBlendMode": "multiply",
+    "mixBlendMode": "multiply",
   },
 }
 `;


### PR DESCRIPTION
We are looking into removing experimental_ from mix-blend-mode. Setting RSD to handle both prop names for now to later clean up