### PR TITLE
Babel preset with integrated StyleX

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,6 @@
     "build",
     "coverage",
     "dist",
-    "docs",
     "flow-typed",
     "logs",
     "node_modules"

--- a/apps/examples/babel.config.js
+++ b/apps/examples/babel.config.js
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const stylexPlugin = require('@stylexjs/babel-plugin');
-const reactStrictPlugin = require('react-strict-dom/babel');
+const reactStrictPreset = require('react-strict-dom/babel-preset');
 
 function getPlatform(caller) {
   return caller && caller.platform;
@@ -27,30 +26,18 @@ module.exports = function (api) {
   const platform = api.caller(getPlatform);
   const isDev = api.caller(getIsDev);
 
+  const presets = ['babel-preset-expo'];
   const plugins = [];
 
   if (platform === 'web') {
-    plugins.push([reactStrictPlugin, { debug: true }]);
-    plugins.push([
-      stylexPlugin,
-      {
-        dev: isDev,
-        importSources: [
-          '@stylexjs/stylex',
-          { from: 'react-strict-dom', as: 'css' }
-        ],
-        runtimeInjection: isDev,
-        styleResolution: 'property-specificity',
-        unstable_moduleResolution: {
-          rootDir: __dirname,
-          type: 'commonJS'
-        }
-      }
+    presets.push([
+      reactStrictPreset,
+      { debug: true, dev: isDev, rootDir: __dirname }
     ]);
   }
 
   return {
     plugins,
-    presets: ['babel-preset-expo']
+    presets
   };
 };

--- a/apps/examples/metro.config.js
+++ b/apps/examples/metro.config.js
@@ -7,11 +7,9 @@
 
 // Learn more https://docs.expo.dev/guides/monorepos
 const { getDefaultConfig } = require('expo/metro-config');
-const path = require('path');
 
 // Find the project and workspace directories
 const projectRoot = __dirname;
-const workspaceRoot = path.resolve(projectRoot, '../..');
 
 const config = getDefaultConfig(projectRoot);
 // 1. Enable Metro support for symlinks and package exports

--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -10,7 +10,7 @@
 import * as React from 'react';
 import { ScrollView } from 'react-native';
 import { css, html } from 'react-strict-dom';
-import { tokens } from './tokens.stylex';
+import { tokens, themeColors, systemColors } from './tokens.stylex';
 
 type ExampleBlockProps = $ReadOnly<{
   title: string,
@@ -34,6 +34,63 @@ function ExampleBlock(props: ExampleBlockProps) {
     <html.div style={egStyles.container}>
       <html.h1 style={egStyles.h1}>{title}</html.h1>
       <html.div style={egStyles.content}>{children}</html.div>
+    </html.div>
+  );
+}
+
+const redBlueTheme = css.createTheme(themeColors, {
+  primary100: 'red',
+  primary200: 'blue'
+});
+const purpleYellowTheme = css.createTheme(themeColors, {
+  primary100: 'purple',
+  primary200: 'yellow'
+});
+const greenPinkTheme = css.createTheme(themeColors, {
+  primary100: 'green',
+  primary200: 'pink'
+});
+
+const themedStyles = css.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    backgroundColor: '#bbb',
+    padding: 8
+  },
+  square: {
+    width: 100,
+    height: 100,
+    backgroundColor: systemColors.squareColor,
+    borderColor: systemColors.outlineColor,
+    borderStyle: 'solid',
+    borderWidth: 5
+  }
+});
+
+function ThemeExample() {
+  return (
+    <html.div style={themedStyles.container}>
+      {/* default theme */}
+      <html.div style={themedStyles.square} />
+      {/* redblue theme */}
+      <html.div style={redBlueTheme}>
+        <html.div style={themedStyles.square} />
+      </html.div>
+      {/* purpleyellow theme */}
+      <html.div style={purpleYellowTheme}>
+        <html.div style={themedStyles.square} />
+      </html.div>
+      {/* greenpink theme */}
+      <html.div style={greenPinkTheme}>
+        <html.div style={themedStyles.square} />
+      </html.div>
+      {/* nested theme */}
+      <html.div style={redBlueTheme}>
+        <html.div style={greenPinkTheme}>
+          <html.div style={themedStyles.square} />
+        </html.div>
+      </html.div>
     </html.div>
   );
 }
@@ -457,6 +514,8 @@ function Shell(): React.MixedElement {
               />
             </html.div>
           </html.div>
+
+          <ThemeExample />
         </ExampleBlock>
 
         {/* hover */}

--- a/apps/examples/src/App.js
+++ b/apps/examples/src/App.js
@@ -81,7 +81,6 @@ function Shell(): React.MixedElement {
   const [opacity, setOpacity] = React.useState(1);
   const [transform, setTransform] = React.useState(TRANSLATE_NONE);
   const [scale, setScale] = React.useState(SCALE_INACTIVE);
-  const [toggleTransform, setToggleTransform] = React.useState(false);
   const [rotate, setRotate] = React.useState(ROTATE_INACTIVE);
   const [skew, setSkew] = React.useState(SKEW_INACTIVE);
   const [fadeUpActive, setFadeUpActive] = React.useState(true);
@@ -149,13 +148,13 @@ function Shell(): React.MixedElement {
             <html.li>unordered list item: one</html.li>
           </html.ul>
           <html.img
+            height={150}
             onLoad={(e) => {
               console.log(e.type, e);
             }}
-            width={150}
-            height={150}
             src="http://placehold.jp/150x150.png"
             style={styles.objContain}
+            width={150}
           />
           <html.div />
           <html.label for="id">label</html.label>
@@ -175,11 +174,11 @@ function Shell(): React.MixedElement {
           <html.input placeholder="input type:text" type="text" />
           <html.div />
           <html.input
-            placeholder="input inputMode:numeric"
             inputMode="numeric"
+            placeholder="input inputMode:numeric"
           />
           <html.div />
-          <html.input placeholder="input enterKeyHint:go" enterKeyHint="go" />
+          <html.input enterKeyHint="go" placeholder="input enterKeyHint:go" />
           <html.div />
           <html.select>
             <html.optgroup label="optgroup">
@@ -471,22 +470,22 @@ function Shell(): React.MixedElement {
             onChange={(e) => {
               console.log(e.type, e.target.value);
             }}
-            onKeyDown={(e) => {
-              console.log(e.type, e.key);
-            }}
             onInput={(e) => {
               console.log(e.type, e.target.value);
+            }}
+            onKeyDown={(e) => {
+              console.log(e.type, e.key);
             }}
           />
           <html.textarea
             onChange={(e) => {
               console.log(e.type, e.target.value);
             }}
-            onKeyDown={(e) => {
-              console.log(e.type, e.key);
-            }}
             onInput={(e) => {
               console.log(e.type, e.target.value);
+            }}
+            onKeyDown={(e) => {
+              console.log(e.type, e.key);
             }}
           />
           <html.div
@@ -546,23 +545,23 @@ function Shell(): React.MixedElement {
           </html.div>
 
           <html.img
+            height={150}
             onLoad={(e) => {
               setImageLoadText(`${e.type}: loaded`);
             }}
-            width={150}
-            height={150}
             src="http://placehold.jp/150x150.png"
             style={styles.objContain}
+            width={150}
           />
           <html.span>{imageLoadText}</html.span>
           <html.img
+            height={150}
             onError={(e) => {
               setImageErrorText(`${e.type}: errored`);
             }}
-            width={150}
-            height={150}
             src="http://error"
             style={styles.objContain}
+            width={150}
           />
           <html.span>{imageErrorText}</html.span>
         </ExampleBlock>

--- a/apps/examples/src/tokens.stylex.js
+++ b/apps/examples/src/tokens.stylex.js
@@ -7,11 +7,11 @@
  * @flow strict-local
  */
 
-import type { VarGroup } from '@stylexjs/stylex';
+import type { StyleVars } from 'react-strict-dom';
 
 import { css } from 'react-strict-dom';
 
-export const tokens: VarGroup<
+export const tokens: StyleVars<
   $ReadOnly<{
     squareColor: string,
     textColor: string,
@@ -26,4 +26,24 @@ export const tokens: VarGroup<
   },
   inputColor: 'red',
   inputPlaceholderColor: 'pink'
+});
+
+export const themeColors: StyleVars<
+  $ReadOnly<{
+    primary100: string,
+    primary200: string
+  }>
+> = css.defineVars({
+  primary100: 'black',
+  primary200: 'white'
+});
+
+export const systemColors: StyleVars<
+  $ReadOnly<{
+    squareColor: string,
+    outlineColor: string
+  }>
+> = css.defineVars({
+  squareColor: themeColors.primary100,
+  outlineColor: themeColors.primary200
 });

--- a/apps/website/src/pages/index.js
+++ b/apps/website/src/pages/index.js
@@ -10,7 +10,7 @@ function HomepageHeader() {
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
-        <img src="./img/logo.svg" height="100" />
+        <img height="100" src="./img/logo.svg" />
         <Heading as="h1" className="hero__title">
           {siteConfig.title}
         </Heading>
@@ -32,8 +32,8 @@ export default function Home() {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
       description="Description will go into a meta tag in <head />"
+      title={`Hello from ${siteConfig.title}`}
     >
       <HomepageHeader />
     </Layout>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "jest": "npm run jest --workspaces --if-present --",
     "jest:report": "npm run jest:report --workspaces --if-present --",
     "lint": "npm run lint:report -- --fix",
-    "lint:report": "eslint packages",
+    "lint:report": "eslint \"**/*.js\"",
     "test": "npm run flow && npm run lint:report && npm run jest:report",
     "postinstall": "patch-package && npm run jest -- --clearCache && npm run build",
     "prepare": "husky install tools/husky"
@@ -59,7 +59,7 @@
     "**/*.js": [
       "prettier --write",
       "git update-index --again",
-      "eslint --config .eslintrc"
+      "eslint"
     ]
   },
   "prettier": {

--- a/packages/react-strict-dom/package.json
+++ b/packages/react-strict-dom/package.json
@@ -7,7 +7,7 @@
       "react-native": "./dist/native/index.js",
       "default": "./dist/dom/index.js"
     },
-    "./babel": "./babel/index.js",
+    "./babel-preset": "./babel/index.js",
     "./runtime": "./dist/dom/runtime.js",
     "./package.json": "./package.json"
   },

--- a/packages/react-strict-dom/src/dom/index.js
+++ b/packages/react-strict-dom/src/dom/index.js
@@ -7,7 +7,22 @@
  * @flow strict
  */
 
+import type {
+  StyleXStyles,
+  StyleXStylesWithout,
+  StaticStyles,
+  Theme,
+  VarGroup
+} from '@stylexjs/stylex';
+
 import * as html from './html';
 import * as css from '@stylexjs/stylex';
+
+type StyleTheme<V, T> = Theme<V, T>;
+type StyleVars<T> = VarGroup<T>;
+type Styles<T> = StyleXStyles<T>;
+type StylesWithout<T> = StyleXStylesWithout<T>;
+
+export type { StaticStyles, StyleTheme, StyleVars, Styles, StylesWithout };
 
 export { css, html };

--- a/packages/react-strict-dom/src/dom/runtime.js
+++ b/packages/react-strict-dom/src/dom/runtime.js
@@ -176,3 +176,5 @@ export const defaultStyles = {
   u: u as typeof u,
   ul: ul as typeof ul
 };
+
+export const resolveStyle = stylex.props;

--- a/packages/react-strict-dom/src/native/index.js
+++ b/packages/react-strict-dom/src/native/index.js
@@ -7,12 +7,25 @@
  * @flow
  */
 
+import type {
+  StyleXStyles,
+  StyleXStylesWithout,
+  StaticStyles,
+  Theme,
+  VarGroup
+} from '@stylexjs/stylex';
+
 import typeof * as TStyleX from '@stylexjs/stylex';
 
 import * as React from 'react';
 import * as html from './html';
 import * as cssRaw from './stylex';
 import { ProvideCustomProperties } from './modules/ContextCustomProperties';
+
+type StyleTheme<V, T> = Theme<V, T>;
+type StyleVars<T> = VarGroup<T>;
+type Styles<T> = StyleXStyles<T>;
+type StylesWithout<T> = StyleXStylesWithout<T>;
 
 type ProviderValue = $ReadOnly<{ [string]: string | number }>;
 
@@ -37,5 +50,7 @@ const contexts = {
 
 // Export using StyleX types as the shim has divergent types internally.
 const css: TStyleX = cssRaw as $FlowFixMe;
+
+export type { StaticStyles, StyleTheme, StyleVars, Styles, StylesWithout };
 
 export { contexts, css, html };

--- a/packages/react-strict-dom/tests/__snapshots__/babel-test.node.js.snap-node
+++ b/packages/react-strict-dom/tests/__snapshots__/babel-test.node.js.snap-node
@@ -1,82 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`react-strict-dom/babel [transform] <html.*> elements aliased imports 1`] = `
-"import * as _stylex from "@stylexjs/stylex";
-import { defaultStyles as _defaultStyles } from "react-strict-dom/runtime";
+"import { defaultStyles as _defaultStyles, resolveStyle as _resolveStyle } from "react-strict-dom/runtime";
 import { html as h } from 'react-strict-dom';
 function App() {
-  return <div {..._stylex.props(_defaultStyles.div, styles.root)} />;
+  return <div {..._resolveStyle(_defaultStyles.div, styles.root)} />;
 }
 ;"
 `;
 
 exports[`react-strict-dom/babel [transform] <html.*> elements basic element 1`] = `
-"import * as _stylex from "@stylexjs/stylex";
-import { defaultStyles as _defaultStyles } from "react-strict-dom/runtime";
+"import { defaultStyles as _defaultStyles, resolveStyle as _resolveStyle } from "react-strict-dom/runtime";
 import { html } from 'react-strict-dom';
 function App() {
-  return <div {..._stylex.props(_defaultStyles.div)} />;
+  return <div {..._resolveStyle(_defaultStyles.div)} />;
 }
 ;"
 `;
 
 exports[`react-strict-dom/babel [transform] <html.*> elements debug mode 1`] = `
-"import * as _stylex from "@stylexjs/stylex";
-import { defaultStyles as _defaultStyles } from "react-strict-dom/runtime";
+"import { defaultStyles as _defaultStyles, resolveStyle as _resolveStyle } from "react-strict-dom/runtime";
 import { html as h } from 'react-strict-dom';
 function App() {
-  return <div data-react-src="bar/baz.js:5" {..._stylex.props(_defaultStyles.div)} />;
+  return <div data-element-src="bar/baz.js:5" {..._resolveStyle(_defaultStyles.div)} />;
 }
 ;"
 `;
 
 exports[`react-strict-dom/babel [transform] <html.*> elements other props 1`] = `
-"import * as _stylex from "@stylexjs/stylex";
-import { defaultStyles as _defaultStyles } from "react-strict-dom/runtime";
+"import { defaultStyles as _defaultStyles, resolveStyle as _resolveStyle } from "react-strict-dom/runtime";
 import { html } from 'react-strict-dom';
 function App() {
-  return <div role="presentation" {..._stylex.props(_defaultStyles.div)}>
-                <label htmlFor="for" {..._stylex.props(_defaultStyles.label)} />
-                <input dir="auto" {..._stylex.props(_defaultStyles.input)} />
-                <textarea dir="auto" {..._stylex.props(_defaultStyles.textarea)} />
-                <input dir="rtl" {..._stylex.props(_defaultStyles.input)} />
-                <textarea dir="rtl" {..._stylex.props(_defaultStyles.textarea)} />
-                <button type="button" {..._stylex.props(_defaultStyles.button)} />
-                <button type="submit" {..._stylex.props(_defaultStyles.button)} />
+  return <div role="presentation" {..._resolveStyle(_defaultStyles.div)}>
+                <label htmlFor="for" {..._resolveStyle(_defaultStyles.label)} />
+                <input dir="auto" {..._resolveStyle(_defaultStyles.input)} />
+                <textarea dir="auto" {..._resolveStyle(_defaultStyles.textarea)} />
+                <input dir="rtl" {..._resolveStyle(_defaultStyles.input)} />
+                <textarea dir="rtl" {..._resolveStyle(_defaultStyles.textarea)} />
+                <button type="button" {..._resolveStyle(_defaultStyles.button)} />
+                <button type="submit" {..._resolveStyle(_defaultStyles.button)} />
               </div>;
 }
 ;"
 `;
 
 exports[`react-strict-dom/babel [transform] <html.*> elements repeated imports 1`] = `
-"import * as _stylex from "@stylexjs/stylex";
-import { defaultStyles as _defaultStyles } from "react-strict-dom/runtime";
+"import { defaultStyles as _defaultStyles, resolveStyle as _resolveStyle } from "react-strict-dom/runtime";
 import { html } from 'react-strict-dom';
 import { html as h } from 'react-strict-dom';
 function App() {
-  return <div {..._stylex.props(_defaultStyles.div, styles.root)}>
-              <span {..._stylex.props(_defaultStyles.span)} />
+  return <div {..._resolveStyle(_defaultStyles.div, styles.root)}>
+              <span {..._resolveStyle(_defaultStyles.span)} />
             </div>;
 }
 ;"
 `;
 
 exports[`react-strict-dom/babel [transform] <html.*> elements styled elements: array 1`] = `
-"import * as _stylex from "@stylexjs/stylex";
-import { defaultStyles as _defaultStyles } from "react-strict-dom/runtime";
+"import { defaultStyles as _defaultStyles, resolveStyle as _resolveStyle } from "react-strict-dom/runtime";
 import { html } from 'react-strict-dom';
 function App() {
-  return <div {..._stylex.props(_defaultStyles.div, styles.one, styles.two)} />;
+  return <div {..._resolveStyle(_defaultStyles.div, styles.one, styles.two)} />;
 }
 ;"
 `;
 
 exports[`react-strict-dom/babel [transform] <html.*> elements styled elements: simple 1`] = `
-"import * as _stylex from "@stylexjs/stylex";
-import { defaultStyles as _defaultStyles } from "react-strict-dom/runtime";
+"import { defaultStyles as _defaultStyles, resolveStyle as _resolveStyle } from "react-strict-dom/runtime";
 import { html } from 'react-strict-dom';
 function App() {
-  return <div {..._stylex.props(_defaultStyles.div, styles.one)} />;
+  return <div {..._resolveStyle(_defaultStyles.div, styles.one)} />;
 }
 ;"
 `;

--- a/packages/react-strict-dom/tests/babel-test.node.js
+++ b/packages/react-strict-dom/tests/babel-test.node.js
@@ -12,7 +12,7 @@
 jest.autoMockOff();
 
 const { transformSync } = require('@babel/core');
-const babelReactStrictPlugin = require('react-strict-dom/babel');
+const reactStrictPreset = require('../babel');
 const jsx = require('@babel/plugin-syntax-jsx');
 
 function transform(source, pluginOptions = {}) {
@@ -21,7 +21,8 @@ function transform(source, pluginOptions = {}) {
     parserOpts: {
       flow: 'all'
     },
-    plugins: [jsx, [babelReactStrictPlugin, { debug: false, ...pluginOptions }]]
+    presets: [[reactStrictPreset, { debug: false, ...pluginOptions }]],
+    plugins: [jsx]
   }).code;
 }
 

--- a/patches/@stylexjs+babel-plugin+0.7.5.patch
+++ b/patches/@stylexjs+babel-plugin+0.7.5.patch
@@ -1,0 +1,128 @@
+diff --git a/node_modules/@stylexjs/babel-plugin/lib/index.js b/node_modules/@stylexjs/babel-plugin/lib/index.js
+index 2e13acd..268d254 100644
+--- a/node_modules/@stylexjs/babel-plugin/lib/index.js
++++ b/node_modules/@stylexjs/babel-plugin/lib/index.js
+@@ -661,15 +661,9 @@ function readImportDeclarations(path, state) {
+             if (importedName === 'props') {
+               state.stylexPropsImport.add(localName);
+             }
+-            if (importedName === 'attrs') {
+-              state.stylexAttrsImport.add(localName);
+-            }
+             if (importedName === 'keyframes') {
+               state.stylexKeyframesImport.add(localName);
+             }
+-            if (importedName === 'include') {
+-              state.stylexIncludeImport.add(localName);
+-            }
+             if (importedName === 'firstThatWorks') {
+               state.stylexFirstThatWorksImport.add(localName);
+             }
+@@ -712,15 +706,9 @@ function readRequires(path, state) {
+           if (prop.key.name === 'props') {
+             state.stylexPropsImport.add(value.name);
+           }
+-          if (prop.key.name === 'attrs') {
+-            state.stylexAttrsImport.add(value.name);
+-          }
+           if (prop.key.name === 'keyframes') {
+             state.stylexKeyframesImport.add(value.name);
+           }
+-          if (prop.key.name === 'include') {
+-            state.stylexIncludeImport.add(value.name);
+-          }
+           if (prop.key.name === 'firstThatWorks') {
+             state.stylexFirstThatWorksImport.add(value.name);
+           }
+@@ -2681,7 +2669,8 @@ function _interopRequireDefault$5(obj) { return obj && obj.__esModule ? obj : {
+ function convertStyleToClassName(objEntry, pseudos, atRules) {
+   let options = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : _defaultOptions$4.defaultOptions;
+   const {
+-    classNamePrefix = 'x'
++    classNamePrefix = 'x',
++    dev
+   } = options;
+   const [key, rawValue] = objEntry;
+   const dashedKey = (0, _dashify$1.default)(key);
+@@ -2695,7 +2684,7 @@ function convertStyleToClassName(objEntry, pseudos, atRules) {
+   const pseudoHashString = sortedAtRules.join('');
+   const modifierHashString = atRuleHashString + pseudoHashString || 'null';
+   const stringToHash = Array.isArray(value) ? dashedKey + value.join(', ') + modifierHashString : dashedKey + value + modifierHashString;
+-  const className = classNamePrefix + (0, _hash$4.default)('<>' + stringToHash);
++  const className = (dev ? key + '-' : '') + classNamePrefix + (0, _hash$4.default)('<>' + stringToHash);
+   const cssRules = (0, _generateCssRule.generateRule)(className, dashedKey, value, pseudos, atRules);
+   return [key, className, cssRules];
+ }
+@@ -3327,7 +3316,7 @@ function styleXDefineVars(variables, options) {
+     } = _ref;
+     return `var(--${nameHash})`;
+   });
+-  const injectableStyles = constructCssVariablesString(variablesMap, themeNameHash);
++  const injectableStyles = constructCssVariablesString(variablesMap, themeNameHash, classNamePrefix);
+   const injectableTypes = (0, _objectUtils$1.objMap)(typedVariables, (_ref2, nameHash) => {
+     let {
+       initialValue: iv,
+@@ -3347,7 +3336,7 @@ function styleXDefineVars(variables, options) {
+     ...injectableStyles
+   }];
+ }
+-function constructCssVariablesString(variables, themeNameHash) {
++function constructCssVariablesString(variables, themeNameHash, classNamePrefix) {
+   const rulesByAtRule = {};
+   for (const [key, {
+     nameHash,
+@@ -3361,7 +3350,7 @@ function constructCssVariablesString(variables, themeNameHash) {
+   const result = {};
+   for (const [atRule, value] of Object.entries(rulesByAtRule)) {
+     const suffix = atRule === 'default' ? '' : `-${(0, _hash$3.default)(atRule)}`;
+-    let ltr = `:root{${value.join('')}}`;
++    let ltr = `:root,.${classNamePrefix}vars{${value.join('')}}`;
+     if (atRule !== 'default') {
+       ltr = (0, _stylexVarsUtils$1.wrapWithAtRules)(ltr, atRule);
+     }
+@@ -3428,7 +3417,8 @@ function styleXCreateTheme(themeVars, variables, options) {
+   }
+   return [{
+     $$css: true,
+-    [themeVars.__themeName__]: overrideClassName
++    [themeVars.__themeName__]: overrideClassName,
++    __overrideRootVars__: `${classNamePrefix}vars`
+   }, stylesToInject];
+ }
+ 
+@@ -3584,7 +3574,7 @@ function injectDevClassNames(obj, varName, state) {
+   for (const [key, value] of Object.entries(obj)) {
+     const devClassName = namespaceToDevClassName(key, varName, state.filename ?? 'UnknownFile');
+     result[key] = {
+-      [devClassName]: devClassName,
++      //['dev_' + devClassName]: devClassName,
+       ...value
+     };
+   }
+@@ -3595,7 +3585,7 @@ function convertToTestStyles(obj, varName, state) {
+   for (const [key, _value] of Object.entries(obj)) {
+     const devClassName = namespaceToDevClassName(key, varName, state.filename ?? 'UnknownFile');
+     result[key] = {
+-      [devClassName]: devClassName,
++      //['dev_' + devClassName]: devClassName,
+       $$css: true
+     };
+   }
+@@ -4641,7 +4631,7 @@ function transformStyleXCreateTheme(callExpressionPath, state) {
+       const basename = path.basename(fileName).split('.')[0];
+       const devClassName = `${basename}__${variableName}`;
+       overridesObj = {
+-        [devClassName]: devClassName,
++        ['dev_' + devClassName]: devClassName,
+         $$css: true
+       };
+     } else if (state.isDev) {
+@@ -4649,7 +4639,7 @@ function transformStyleXCreateTheme(callExpressionPath, state) {
+       const basename = path.basename(fileName).split('.')[0];
+       const devClassName = `${basename}__${variableName}`;
+       overridesObj = {
+-        [devClassName]: devClassName,
++        ['dev_' + devClassName]: devClassName,
+         ...overridesObj
+       };
+     }

--- a/patches/@stylexjs+shared+0.7.5.patch
+++ b/patches/@stylexjs+shared+0.7.5.patch
@@ -1,0 +1,48 @@
+diff --git a/node_modules/@stylexjs/shared/.DS_Store b/node_modules/@stylexjs/shared/.DS_Store
+new file mode 100644
+index 0000000..97cc27b
+Binary files /dev/null and b/node_modules/@stylexjs/shared/.DS_Store differ
+diff --git a/node_modules/@stylexjs/shared/lib/stylex-create-theme.js b/node_modules/@stylexjs/shared/lib/stylex-create-theme.js
+index 656d271..69be46c 100644
+--- a/node_modules/@stylexjs/shared/lib/stylex-create-theme.js
++++ b/node_modules/@stylexjs/shared/lib/stylex-create-theme.js
+@@ -52,6 +52,7 @@ function styleXCreateTheme(themeVars, variables, options) {
+   }
+   return [{
+     $$css: true,
+-    [themeVars.__themeName__]: overrideClassName
++    [themeVars.__themeName__]: overrideClassName,
++    __overrideRootVars__: `${classNamePrefix}vars`
+   }, stylesToInject];
+ }
+diff --git a/node_modules/@stylexjs/shared/lib/stylex-define-vars.js b/node_modules/@stylexjs/shared/lib/stylex-define-vars.js
+index bb4283e..3f59010 100644
+--- a/node_modules/@stylexjs/shared/lib/stylex-define-vars.js
++++ b/node_modules/@stylexjs/shared/lib/stylex-define-vars.js
+@@ -44,7 +44,7 @@ function styleXDefineVars(variables, options) {
+     } = _ref;
+     return `var(--${nameHash})`;
+   });
+-  const injectableStyles = constructCssVariablesString(variablesMap, themeNameHash);
++  const injectableStyles = constructCssVariablesString(variablesMap, themeNameHash, classNamePrefix);
+   const injectableTypes = (0, _objectUtils.objMap)(typedVariables, (_ref2, nameHash) => {
+     let {
+       initialValue: iv,
+@@ -64,7 +64,7 @@ function styleXDefineVars(variables, options) {
+     ...injectableStyles
+   }];
+ }
+-function constructCssVariablesString(variables, themeNameHash) {
++function constructCssVariablesString(variables, themeNameHash, classNamePrefix) {
+   const rulesByAtRule = {};
+   for (const [key, {
+     nameHash,
+@@ -78,7 +78,7 @@ function constructCssVariablesString(variables, themeNameHash) {
+   const result = {};
+   for (const [atRule, value] of Object.entries(rulesByAtRule)) {
+     const suffix = atRule === 'default' ? '' : `-${(0, _hash.default)(atRule)}`;
+-    let ltr = `:root{${value.join('')}}`;
++    let ltr = `:root,.${classNamePrefix}vars{${value.join('')}}`;
+     if (atRule !== 'default') {
+       ltr = (0, _stylexVarsUtils.wrapWithAtRules)(ltr, atRule);
+     }

--- a/patches/@stylexjs+stylex+0.7.5.patch
+++ b/patches/@stylexjs+stylex+0.7.5.patch
@@ -1,0 +1,180 @@
+diff --git a/node_modules/@stylexjs/stylex/lib/StyleXSheet.js b/node_modules/@stylexjs/stylex/lib/StyleXSheet.js
+index 24f6592..db761b4 100644
+--- a/node_modules/@stylexjs/stylex/lib/StyleXSheet.js
++++ b/node_modules/@stylexjs/stylex/lib/StyleXSheet.js
+@@ -6,8 +6,6 @@ Object.defineProperty(exports, "__esModule", {
+ exports.styleSheet = exports.StyleXSheet = void 0;
+ var _invariant = _interopRequireDefault(require("invariant"));
+ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+-const LIGHT_MODE_CLASS_NAME = '__fb-light-mode';
+-const DARK_MODE_CLASS_NAME = '__fb-dark-mode';
+ function buildTheme(selector, theme) {
+   const lines = [];
+   lines.push(`${selector} {`);
+@@ -32,15 +30,12 @@ function doesSupportCSSVariables() {
+ }
+ const VARIABLE_MATCH = /var\(--(.*?)\)/g;
+ class StyleXSheet {
+-  static LIGHT_MODE_CLASS_NAME = LIGHT_MODE_CLASS_NAME;
+-  static DARK_MODE_CLASS_NAME = DARK_MODE_CLASS_NAME;
+   constructor(opts) {
+     this.tag = null;
+     this.injected = false;
+     this.ruleForPriority = new Map();
+     this.rules = [];
+-    this.rootTheme = opts.rootTheme;
+-    this.rootDarkTheme = opts.rootDarkTheme;
++    this.rootTheme = null;
+     this.supportsVariables = opts.supportsVariables ?? doesSupportCSSVariables();
+   }
+   getVariableMatch() {
+@@ -70,20 +65,7 @@ class StyleXSheet {
+       return;
+     }
+     this.injected = true;
+-    if (globalThis.document?.body == null) {
+-      this.injectTheme();
+-      return;
+-    }
+     this.tag = makeStyleTag();
+-    this.injectTheme();
+-  }
+-  injectTheme() {
+-    if (this.rootTheme != null) {
+-      this.insert(buildTheme(`:root, .${LIGHT_MODE_CLASS_NAME}`, this.rootTheme), 0);
+-    }
+-    if (this.rootDarkTheme != null) {
+-      this.insert(buildTheme(`.${DARK_MODE_CLASS_NAME}:root, .${DARK_MODE_CLASS_NAME}`, this.rootDarkTheme), 0);
+-    }
+   }
+   __injectCustomThemeForTesting(selector, theme) {
+     if (theme != null) {
+@@ -179,7 +161,5 @@ function addSpecificityLevel(selector, index) {
+   return `${beforeCurly}${pseudo}${afterCurly}`;
+ }
+ const styleSheet = exports.styleSheet = new StyleXSheet({
+-  supportsVariables: true,
+-  rootTheme: {},
+-  rootDarkTheme: {}
++  supportsVariables: true
+ });
+diff --git a/node_modules/@stylexjs/stylex/lib/es/StyleXSheet.mjs b/node_modules/@stylexjs/stylex/lib/es/StyleXSheet.mjs
+index 67ea8ae..ec3e5af 100644
+--- a/node_modules/@stylexjs/stylex/lib/es/StyleXSheet.mjs
++++ b/node_modules/@stylexjs/stylex/lib/es/StyleXSheet.mjs
+@@ -54,8 +54,6 @@ var invariant_1 = invariant;
+ 
+ var invariant$1 = /*@__PURE__*/getDefaultExportFromCjs(invariant_1);
+ 
+-const LIGHT_MODE_CLASS_NAME = '__fb-light-mode';
+-const DARK_MODE_CLASS_NAME = '__fb-dark-mode';
+ function buildTheme(selector, theme) {
+   const lines = [];
+   lines.push(`${selector} {`);
+@@ -80,15 +78,12 @@ function doesSupportCSSVariables() {
+ }
+ const VARIABLE_MATCH = /var\(--(.*?)\)/g;
+ class StyleXSheet {
+-  static LIGHT_MODE_CLASS_NAME = LIGHT_MODE_CLASS_NAME;
+-  static DARK_MODE_CLASS_NAME = DARK_MODE_CLASS_NAME;
+   constructor(opts) {
+     this.tag = null;
+     this.injected = false;
+     this.ruleForPriority = new Map();
+     this.rules = [];
+-    this.rootTheme = opts.rootTheme;
+-    this.rootDarkTheme = opts.rootDarkTheme;
++    this.rootTheme = null;
+     this.supportsVariables = opts.supportsVariables ?? doesSupportCSSVariables();
+   }
+   getVariableMatch() {
+@@ -118,20 +113,7 @@ class StyleXSheet {
+       return;
+     }
+     this.injected = true;
+-    if (globalThis.document?.body == null) {
+-      this.injectTheme();
+-      return;
+-    }
+     this.tag = makeStyleTag();
+-    this.injectTheme();
+-  }
+-  injectTheme() {
+-    if (this.rootTheme != null) {
+-      this.insert(buildTheme(`:root, .${LIGHT_MODE_CLASS_NAME}`, this.rootTheme), 0);
+-    }
+-    if (this.rootDarkTheme != null) {
+-      this.insert(buildTheme(`.${DARK_MODE_CLASS_NAME}:root, .${DARK_MODE_CLASS_NAME}`, this.rootDarkTheme), 0);
+-    }
+   }
+   __injectCustomThemeForTesting(selector, theme) {
+     if (theme != null) {
+diff --git a/node_modules/@stylexjs/stylex/lib/stylex.js b/node_modules/@stylexjs/stylex/lib/stylex.js
+index 7c9e41e..9481fda 100644
+--- a/node_modules/@stylexjs/stylex/lib/stylex.js
++++ b/node_modules/@stylexjs/stylex/lib/stylex.js
+@@ -4,8 +4,6 @@ Object.defineProperty(exports, "__esModule", {
+   value: true
+ });
+ exports.__monkey_patch__ = __monkey_patch__;
+-exports.attrs = attrs;
+-exports.legacyMerge = exports.keyframes = exports.include = exports.firstThatWorks = exports.defineVars = exports.default = exports.createTheme = exports.create = void 0;
+ exports.props = props;
+ exports.types = void 0;
+ var _styleq = require("styleq");
+@@ -29,20 +27,6 @@ function props() {
+   }
+   return result;
+ }
+-function attrs() {
+-  const {
+-    className,
+-    style
+-  } = props(...arguments);
+-  const result = {};
+-  if (className != null && className !== '') {
+-    result.class = className;
+-  }
+-  if (style != null && Object.keys(style).length > 0) {
+-    result.style = Object.keys(style).map(key => `${key}:${style[key]};`).join('');
+-  }
+-  return result;
+-}
+ function stylexCreate(styles) {
+   if (__implementations.create != null) {
+     const create = __implementations.create;
+@@ -62,16 +46,9 @@ const stylexCreateTheme = (baseTokens, overrides) => {
+   }
+   throw errorForFn('createTheme');
+ };
+-const stylexInclude = styles => {
+-  if (__implementations.include) {
+-    return __implementations.include(styles);
+-  }
+-  throw errorForFn('include');
+-};
+ const create = exports.create = stylexCreate;
+ const defineVars = exports.defineVars = stylexDefineVars;
+ const createTheme = exports.createTheme = stylexCreateTheme;
+-const include = exports.include = stylexInclude;
+ const types = exports.types = {
+   angle: _v => {
+     throw errorForType('angle');
+@@ -135,11 +112,9 @@ function _stylex() {
+   return className;
+ }
+ _stylex.props = props;
+-_stylex.attrs = attrs;
+ _stylex.create = create;
+ _stylex.defineVars = defineVars;
+ _stylex.createTheme = createTheme;
+-_stylex.include = include;
+ _stylex.keyframes = keyframes;
+ _stylex.firstThatWorks = firstThatWorks;
+ _stylex.types = types;
+@@ -151,5 +126,4 @@ function __monkey_patch__(key, implementation) {
+     __implementations[key] = implementation;
+   }
+ }
+-const legacyMerge = exports.legacyMerge = _stylex;
+ var _default = exports.default = _stylex;


### PR DESCRIPTION
This patch changes RSD to export a babel preset (not plugin), which integrates StyleX to simplify developer setup and ensure that the correct configuration is used.

StyleX itself is also patched to fix theming on web and remove deprecated or unrelated APIs for cross-platform React.