### PR TITLE
Bump flow and related tools

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-0.243.0
+0.248.1
 
 [ignore]
 .*/malformed_package_json/.*

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@babel/preset-react": "^7.24.7",
         "@testing-library/react": "^14.0.0",
         "babel-jest": "^29.7.0",
-        "babel-plugin-syntax-hermes-parser": "^0.23.1",
+        "babel-plugin-syntax-hermes-parser": "^0.25.0",
         "del-cli": "^5.0.0",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^8.9.0",
@@ -33,8 +33,8 @@
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-react": "^7.33.1",
         "eslint-plugin-react-hooks": "^4.5.0",
-        "flow-api-translator": "^0.23.1",
-        "flow-bin": "^0.243.0",
+        "flow-api-translator": "^0.25.0",
+        "flow-bin": "^0.248.1",
         "husky": "^8.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -43,7 +43,7 @@
         "npm-run-all": "^4.1.3",
         "patch-package": "^8.0.0",
         "prettier": "^3.3.3",
-        "prettier-plugin-hermes-parser": "0.23.1"
+        "prettier-plugin-hermes-parser": "0.25.0"
       },
       "engines": {
         "node": ">=20.11.0",
@@ -11520,27 +11520,30 @@
       "license": "MIT"
     },
     "node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.23.1.tgz",
-      "integrity": "sha512-uNLD0tk2tLUjGFdmCk+u/3FEw2o+BAwW4g+z2QVlxJrzZYOOPADroEcNtTPt5lNiScctaUmnsTkVEnOwZUOLhA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.0.tgz",
+      "integrity": "sha512-QUFu3FP0Ub/p0ilSizpS1CwHIZcF5OvZwzJu8PK1zy6U7Q++n9fGwi79c5yh2O2h2CagYDcLY9ngLKwT41D4qg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hermes-parser": "0.23.1"
+        "hermes-parser": "0.25.0"
       }
     },
     "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-estree": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
-      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
-      "dev": true
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.0.tgz",
+      "integrity": "sha512-xjILoUIyOpLoOHqj8UJs/HNYQ279IfLKTTv9nmXKNT2+QKT/TQF9AyQFrRMo+3xwZoO7k4azocYpCzA1cSvBDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-plugin-syntax-hermes-parser/node_modules/hermes-parser": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
-      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.0.tgz",
+      "integrity": "sha512-CeAdhgMfbZcrYh+HHKVKsj7VNhOTr0jiLFlcVVoRORbZ/Nr4J90WjEq2CZoahgH15/DYY/VBhuLqpIzJqfdBEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.23.1"
+        "hermes-estree": "0.25.0"
       }
     },
     "node_modules/babel-plugin-transform-flow-enums": {
@@ -16753,19 +16756,20 @@
       "license": "ISC"
     },
     "node_modules/flow-api-translator": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/flow-api-translator/-/flow-api-translator-0.23.1.tgz",
-      "integrity": "sha512-iK62XrAC7Lkyw3q9rEYsPQuwSh+AlgOp3HTKFRtZQp83w0EfDqYYMxLljkLb7ij0B9XxB6VQ8OuoPvvk8vFATg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/flow-api-translator/-/flow-api-translator-0.25.0.tgz",
+      "integrity": "sha512-W7IpeCqiqogJ3swGc0K0aiGxfTMMiB2VUwJ0vP176WLufn90gEEbf53JB/xzlIxOkvrJ97tOU+vgBp/SW5IDDw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.16.0",
         "@typescript-eslint/parser": "7.2.0",
         "@typescript-eslint/visitor-keys": "7.2.0",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-eslint": "0.23.1",
-        "hermes-estree": "0.23.1",
-        "hermes-parser": "0.23.1",
-        "hermes-transform": "0.23.1",
+        "hermes-eslint": "0.25.0",
+        "hermes-estree": "0.25.0",
+        "hermes-parser": "0.25.0",
+        "hermes-transform": "0.25.0",
         "typescript": "5.3.2"
       },
       "peerDependencies": {
@@ -16773,55 +16777,40 @@
       }
     },
     "node_modules/flow-api-translator/node_modules/hermes-eslint": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-eslint/-/hermes-eslint-0.23.1.tgz",
-      "integrity": "sha512-DaEpbJobK1KwpTSXrPIKkHs2h+B+RTw2F1g9S70tjtJ14a3zM+2gPVUtc8xyffQqRJ6tPfs+/zRKwV17lwDvqA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-eslint/-/hermes-eslint-0.25.0.tgz",
+      "integrity": "sha512-D9rdrqt7dudZHI5AJKS+1vXBbxxR6Wj9J1JI7eYowYCbXUIvHclsWFy8gSuRmug2V6HSYpsiyPwP3kQs/Q/Y8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esrecurse": "^4.3.0",
-        "hermes-estree": "0.23.1",
-        "hermes-parser": "0.23.1"
+        "hermes-estree": "0.25.0",
+        "hermes-parser": "0.25.0"
       }
     },
     "node_modules/flow-api-translator/node_modules/hermes-estree": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
-      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
-      "dev": true
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.0.tgz",
+      "integrity": "sha512-xjILoUIyOpLoOHqj8UJs/HNYQ279IfLKTTv9nmXKNT2+QKT/TQF9AyQFrRMo+3xwZoO7k4azocYpCzA1cSvBDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/flow-api-translator/node_modules/hermes-parser": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
-      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.0.tgz",
+      "integrity": "sha512-CeAdhgMfbZcrYh+HHKVKsj7VNhOTr0jiLFlcVVoRORbZ/Nr4J90WjEq2CZoahgH15/DYY/VBhuLqpIzJqfdBEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.23.1"
-      }
-    },
-    "node_modules/flow-api-translator/node_modules/hermes-transform": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-transform/-/hermes-transform-0.23.1.tgz",
-      "integrity": "sha512-rS4nYF87InorhUL29gJeJe7Hi15wuy1cDNc6RhHi2CTPGvCfiElp4lzpsJiPj4GjAXp8xeacjV0N6t1q/AXDfQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "esquery": "^1.4.0",
-        "flow-enums-runtime": "^0.0.6",
-        "hermes-eslint": "0.23.1",
-        "hermes-estree": "0.23.1",
-        "hermes-parser": "0.23.1",
-        "string-width": "4.2.3"
-      },
-      "peerDependencies": {
-        "prettier": "^3.0.0 || ^2.7.1",
-        "prettier-plugin-hermes-parser": "0.23.1"
+        "hermes-estree": "0.25.0"
       }
     },
     "node_modules/flow-bin": {
-      "version": "0.243.0",
-      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.243.0.tgz",
-      "integrity": "sha512-4OyCAkI26Bm8wGd1eNt+EBkHYAGB5PsGnykxLB0y7wK8wPitQi6pi3HsoNlk3yM6gyJsDqkRJrlkpnBB6WDgjQ==",
+      "version": "0.248.1",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.248.1.tgz",
+      "integrity": "sha512-WnISMV7p4rRY2LIMGnryR7Pnml9wFs0bTdniI1Dj2dXIJigOGfV74FjhMG7BmZkuKztNxlTvK56zpuhpcne+sg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "flow": "cli.js"
       },
@@ -17959,6 +17948,55 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.19.1"
+      }
+    },
+    "node_modules/hermes-transform": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-transform/-/hermes-transform-0.25.0.tgz",
+      "integrity": "sha512-yzg09cEXJYoODF8+gxa4GldNrB2CtqD5/bEJaWPdNhPhAxKVvM2u8TJ995cHRCb0NLDPxSzIExomaNPh7Cz0Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.16.0",
+        "esquery": "^1.4.0",
+        "flow-enums-runtime": "^0.0.6",
+        "hermes-eslint": "0.25.0",
+        "hermes-estree": "0.25.0",
+        "hermes-parser": "0.25.0",
+        "string-width": "4.2.3"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0 || ^2.7.1",
+        "prettier-plugin-hermes-parser": "0.25.0"
+      }
+    },
+    "node_modules/hermes-transform/node_modules/hermes-eslint": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-eslint/-/hermes-eslint-0.25.0.tgz",
+      "integrity": "sha512-D9rdrqt7dudZHI5AJKS+1vXBbxxR6Wj9J1JI7eYowYCbXUIvHclsWFy8gSuRmug2V6HSYpsiyPwP3kQs/Q/Y8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "hermes-estree": "0.25.0",
+        "hermes-parser": "0.25.0"
+      }
+    },
+    "node_modules/hermes-transform/node_modules/hermes-estree": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.0.tgz",
+      "integrity": "sha512-xjILoUIyOpLoOHqj8UJs/HNYQ279IfLKTTv9nmXKNT2+QKT/TQF9AyQFrRMo+3xwZoO7k4azocYpCzA1cSvBDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-transform/node_modules/hermes-parser": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.0.tgz",
+      "integrity": "sha512-CeAdhgMfbZcrYh+HHKVKsj7VNhOTr0jiLFlcVVoRORbZ/Nr4J90WjEq2CZoahgH15/DYY/VBhuLqpIzJqfdBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.0"
       }
     },
     "node_modules/history": {
@@ -27807,35 +27845,35 @@
       }
     },
     "node_modules/prettier-plugin-hermes-parser": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.23.1.tgz",
-      "integrity": "sha512-fZNzKmP8E+xPnOzOBvZfdSSbUk/A79ZjohTFL/TTqtO+fTAjLY0n+P7ooOC9cYl/FKHMaXR0kNiNOS4y9ZxsFg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.25.0.tgz",
+      "integrity": "sha512-B5vzcDyTA/T0R7LGMSkLTp3VtRCEe1NItzsM6L/4gDOBGzDDMMMOwxRxogwL9xL07GPBOJrzlggwFaSQOhLVLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.23.1",
-        "hermes-parser": "0.23.1",
-        "prettier-plugin-hermes-parser": "0.23.1"
+        "hermes-estree": "0.25.0",
+        "hermes-parser": "0.25.0",
+        "prettier-plugin-hermes-parser": "0.25.0"
       },
       "peerDependencies": {
         "prettier": "^3.0.0 || ^2.7.1"
       }
     },
     "node_modules/prettier-plugin-hermes-parser/node_modules/hermes-estree": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
-      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.0.tgz",
+      "integrity": "sha512-xjILoUIyOpLoOHqj8UJs/HNYQ279IfLKTTv9nmXKNT2+QKT/TQF9AyQFrRMo+3xwZoO7k4azocYpCzA1cSvBDg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/prettier-plugin-hermes-parser/node_modules/hermes-parser": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
-      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.0.tgz",
+      "integrity": "sha512-CeAdhgMfbZcrYh+HHKVKsj7VNhOTr0jiLFlcVVoRORbZ/Nr4J90WjEq2CZoahgH15/DYY/VBhuLqpIzJqfdBEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.23.1"
+        "hermes-estree": "0.25.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -33631,113 +33669,11 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "flow-api-translator": "^0.20.1",
+        "flow-api-translator": "^0.25.0",
         "yargs": "17.7.2"
       },
       "bin": {
         "generate-types": "generate-types.js"
-      }
-    },
-    "packages/scripts/node_modules/@typescript-eslint/types": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "packages/scripts/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-      "dependencies": {
-        "@typescript-eslint/types": "5.62.0",
-        "eslint-visitor-keys": "^3.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "packages/scripts/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "packages/scripts/node_modules/flow-api-translator": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/flow-api-translator/-/flow-api-translator-0.20.1.tgz",
-      "integrity": "sha512-RY/flm0omS6LjKna93HUUtx2bUf9qTX9i90RtUdZoVSB7u41nEAebmyM+mpOPsNqvCEIHQxxXs/22/PkQW1OCw==",
-      "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@typescript-eslint/visitor-keys": "^5.42.0",
-        "flow-enums-runtime": "^0.0.6",
-        "hermes-eslint": "0.20.1",
-        "hermes-estree": "0.20.1",
-        "hermes-parser": "0.20.1",
-        "hermes-transform": "0.20.1"
-      },
-      "peerDependencies": {
-        "prettier": "^3.0.0 || ^2.7.1"
-      }
-    },
-    "packages/scripts/node_modules/hermes-estree": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
-      "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg=="
-    },
-    "packages/scripts/node_modules/hermes-parser": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
-      "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
-      "dependencies": {
-        "hermes-estree": "0.20.1"
-      }
-    },
-    "packages/scripts/node_modules/hermes-transform": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/hermes-transform/-/hermes-transform-0.20.1.tgz",
-      "integrity": "sha512-gpetyzAQvuLXVWIk8/I2A/ei/5+o8eT+QuSGd8FcWpXoYxVkYjVKLVNE9xKLsEkk2wQ1tXODY5OeOZoaz9jL7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "esquery": "^1.4.0",
-        "flow-enums-runtime": "^0.0.6",
-        "hermes-eslint": "0.20.1",
-        "hermes-estree": "0.20.1",
-        "hermes-parser": "0.20.1"
-      },
-      "peerDependencies": {
-        "prettier": "^3.0.0 || ^2.7.1",
-        "prettier-plugin-hermes-parser": "0.20.1"
-      }
-    },
-    "packages/scripts/node_modules/prettier-plugin-hermes-parser": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.20.1.tgz",
-      "integrity": "sha512-T6dfa1++ckTxd3MbLxS6sTv1T3yvTu1drahNt3g34hyCzSwYTKTByocLyhd1A9j9uCUlIPD+ogum7+i1h3+CEw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "hermes-estree": "0.20.1",
-        "hermes-parser": "0.20.1",
-        "prettier-plugin-hermes-parser": "0.20.1"
-      },
-      "peerDependencies": {
-        "prettier": "^3.0.0 || ^2.7.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@babel/preset-react": "^7.24.7",
     "@testing-library/react": "^14.0.0",
     "babel-jest": "^29.7.0",
-    "babel-plugin-syntax-hermes-parser": "^0.23.1",
+    "babel-plugin-syntax-hermes-parser": "^0.25.0",
     "del-cli": "^5.0.0",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^8.9.0",
@@ -35,8 +35,8 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.33.1",
     "eslint-plugin-react-hooks": "^4.5.0",
-    "flow-api-translator": "^0.23.1",
-    "flow-bin": "^0.243.0",
+    "flow-api-translator": "^0.25.0",
+    "flow-bin": "^0.248.1",
     "husky": "^8.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
@@ -45,7 +45,7 @@
     "npm-run-all": "^4.1.3",
     "patch-package": "^8.0.0",
     "prettier": "^3.3.3",
-    "prettier-plugin-hermes-parser": "0.23.1"
+    "prettier-plugin-hermes-parser": "0.25.0"
   },
   "engines": {
     "node": ">=20.11.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -8,7 +8,7 @@
     "generate-types": "./generate-types.js"
   },
   "dependencies": {
-    "flow-api-translator": "^0.20.1",
+    "flow-api-translator": "^0.25.0",
     "yargs": "17.7.2"
   }
 }


### PR DESCRIPTION
This PR bumps flow and related tools in the repo to prepare for moving away from `React.AbstractComponent` in favor of the new [component types](https://flow.org/en/docs/react/component-types/).