### PR TITLE
Replace React utility types with $ with the namespaced ones

### DIFF
--- a/packages/react-strict-dom/src/native/index.js
+++ b/packages/react-strict-dom/src/native/index.js
@@ -30,11 +30,11 @@ type StylesWithout<T> = StyleXStylesWithout<T>;
 type ProviderValue = $ReadOnly<{ [string]: string | number }>;
 
 type ProviderProps = $ReadOnly<{
-  children: React$MixedElement,
+  children: React.MixedElement,
   customProperties: ProviderValue
 }>;
 
-function ThemeProvider(props: ProviderProps): React$MixedElement {
+function ThemeProvider(props: ProviderProps): React.MixedElement {
   const { children, customProperties } = props;
 
   return customProperties ? (

--- a/packages/react-strict-dom/src/native/modules/ContextCustomProperties.js
+++ b/packages/react-strict-dom/src/native/modules/ContextCustomProperties.js
@@ -13,7 +13,7 @@ import * as React from 'react';
 import { __customProperties } from '../stylex';
 
 const defaultContext = __customProperties;
-const ContextCustomProperties: React$Context<CustomProperties> =
+const ContextCustomProperties: React.Context<CustomProperties> =
   React.createContext(defaultContext);
 
 if (__DEV__) {

--- a/packages/react-strict-dom/src/native/modules/ContextDisplayInside.js
+++ b/packages/react-strict-dom/src/native/modules/ContextDisplayInside.js
@@ -12,7 +12,7 @@ import * as React from 'react';
 type Value = 'flow' | 'flex';
 
 const defaultContext = 'flow';
-const ContextDisplayInside: React$Context<Value> =
+const ContextDisplayInside: React.Context<Value> =
   React.createContext(defaultContext);
 
 if (__DEV__) {

--- a/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
+++ b/packages/react-strict-dom/src/native/modules/ContextInheritedStyles.js
@@ -17,12 +17,12 @@ import { shallowEqual } from './shallowEqual';
 type Value = Style;
 
 type ProviderProps = $ReadOnly<{
-  children: React$MixedElement,
+  children: React.MixedElement,
   value: Value
 }>;
 
 const defaultContext = {};
-const ContextInheritedStyles: React$Context<Value> =
+const ContextInheritedStyles: React.Context<Value> =
   React.createContext(defaultContext);
 
 if (__DEV__) {
@@ -33,7 +33,7 @@ if (__DEV__) {
 // The 'em' unit polyfill in stylex assumes the inherited fontSize is always a computed number.
 export function ProvideInheritedStyles(
   props: ProviderProps
-): React$MixedElement {
+): React.MixedElement {
   const { children, value } = props;
   const inheritedStyles = useInheritedStyles();
   const flatStyle = useMemo(() => {

--- a/packages/react-strict-dom/src/native/modules/TextString.js
+++ b/packages/react-strict-dom/src/native/modules/TextString.js
@@ -16,7 +16,7 @@ type Props = $ReadOnly<{|
   children: string
 |}>;
 
-export function TextString(props: Props): React$MixedElement {
+export function TextString(props: Props): React.MixedElement {
   const { children } = props;
 
   const customProperties = useCustomProperties();

--- a/packages/react-strict-dom/src/types/StrictReactDOMProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMProps.js
@@ -289,7 +289,7 @@ export type StrictReactDOMProps = $ReadOnly<{
     | 'characters'
   ),
   autoFocus?: ?boolean,
-  children?: React$Node,
+  children?: React.Node,
   'data-testid'?: ?string,
   dir?: ?('auto' | 'ltr' | 'rtl'),
   elementTiming?: ?string,

--- a/packages/react-strict-dom/src/types/react-native.js
+++ b/packages/react-strict-dom/src/types/react-native.js
@@ -55,7 +55,7 @@ type Props = {
   animated?: ?boolean, // non-standard
   caretHidden?: TextInputProps['caretHidden'],
   cursorColor?: TextInputProps['cursorColor'],
-  children?: ?React$Node,
+  children?: ?React.Node,
   crossOrigin?: ImageProps['crossOrigin'],
   defaultValue?: TextInputProps['defaultValue'],
   disabled?: ?boolean,


### PR DESCRIPTION
One day, Flow will delete `React$MixedElement`, `React$Node` and all other dollar types from the global libdef, since they are considered to be internal. All these react utility types can already be used without importing React so there is no practical benefit of keeping these dollar types either.