### PR TITLE
chore: mark `borderRadius % values` as supported

### DIFF
--- a/apps/website/docs/api/02-css/index.md
+++ b/apps/website/docs/api/02-css/index.md
@@ -108,7 +108,7 @@ The following tables represent the compatibility status of the strict CSS API fo
 | borderLeftStyle | ✅ | ✅ | |
 | borderLeftWidth | ✅ | ✅ | |
 | borderRadius | ✅ | ✅ | |
-| borderRadius % values | ❌ | ❌ | |
+| borderRadius % values | ✅ | ✅ | |
 | borderRightColor | ✅ | ✅ | |
 | borderRightStyle | ✅ | ✅ | |
 | borderRightWidth | ✅ | ✅ | |


### PR DESCRIPTION
See https://github.com/facebook/react-native/pull/44408 and https://github.com/facebook/react-native-website/issues/4264 for more info.

> 0.76 supports border radius % on new arch.