### PR TITLE
fix(useStyleTransition): add an early return if we don't have anything to animate

### DIFF
--- a/packages/react-strict-dom/src/native/modules/useStyleTransition.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleTransition.js
@@ -273,6 +273,16 @@ export function useStyleTransition(style: ReactNativeStyle): ReactNativeStyle {
     }
   }, [animatedValue]);
 
+  if (
+    _delay == null &&
+    _duration == null &&
+    _transitionProperty == null &&
+    _timingFunction == null
+  ) {
+    // Avoid further calculations if we don't have anything to animate
+    return style;
+  }
+
   if (transitionStyleHasChanged(transitionStyle, currentStyle)) {
     setCurrentStyle(style);
     setPreviousStyle(currentStyle);


### PR DESCRIPTION
Currently, we use the `useStyleTransition` hook every time `useStyleProps` is being used. No matter if the styles being evaluated don't include any transition at all. 

This PR tries to solve the problem by adding an early return when we don't have any transition.