### PR TITLE
feat: add `eslint-plugin-react-compiler`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,15 +18,13 @@
     "requireConfigFile": false,
     "sourceType": "module"
   },
-  "extends": [
-    "plugin:ft-flow/recommended",
-    "prettier"
-  ],
+  "extends": ["plugin:ft-flow/recommended", "prettier"],
   "plugins": [
     "ft-flow",
     "promise",
     "react",
-    "react-hooks"
+    "react-hooks",
+    "eslint-plugin-react-compiler"
   ],
   "env": {
     "browser": true,
@@ -51,7 +49,7 @@
     "constructor-super": 2,
     "default-case": [2, { "commentPattern": "^no default$" }],
     "eqeqeq": [2, "allow-null"],
-    "handle-callback-err": [2, "^(err|error)$" ],
+    "handle-callback-err": [2, "^(err|error)$"],
     "new-cap": [2, { "newIsCap": true, "capIsNew": false }],
     "no-alert": 1,
     "no-array-constructor": 2,
@@ -166,6 +164,9 @@
 
     // react-hooks
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "error"
+    "react-hooks/exhaustive-deps": "error",
+
+    // react-compiler
+    "react-compiler/react-compiler": "warn"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "eslint-plugin-ft-flow": "^3.0.7",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-react": "^7.33.1",
+        "eslint-plugin-react-compiler": "^19.0.0-beta-8a03594-20241020",
         "eslint-plugin-react-hooks": "^4.5.0",
         "flow-api-translator": "^0.25.0",
         "flow-bin": "^0.248.1",
@@ -1069,6 +1070,24 @@
         "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-proposal-private-methods": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -15196,6 +15215,57 @@
       },
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/eslint-plugin-react-compiler": {
+      "version": "19.0.0-beta-8a03594-20241020",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-8a03594-20241020.tgz",
+      "integrity": "sha512-bYg1COih1s3r14IV/AKdQs/SN7CQmNI0ZaMtPdgZ6gp1S1Q/KGP9P43w7R6dHJ4wYpuMBvekNJHQdVu+x6UM+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/plugin-proposal-private-methods": "^7.18.6",
+        "hermes-parser": "^0.20.1",
+        "zod": "^3.22.4",
+        "zod-validation-error": "^3.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.0.0 || >= 18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7"
+      }
+    },
+    "node_modules/eslint-plugin-react-compiler/node_modules/hermes-estree": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.20.1.tgz",
+      "integrity": "sha512-SQpZK4BzR48kuOg0v4pb3EAGNclzIlqMj3Opu/mu7bbAoFw6oig6cEt/RAi0zTFW/iW6Iz9X9ggGuZTAZ/yZHg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint-plugin-react-compiler/node_modules/hermes-parser": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.20.1.tgz",
+      "integrity": "sha512-BL5P83cwCogI8D7rrDCgsFY0tdYUtmFP9XaXtl2IQjC+2Xo+4okjfXintlTxcIwl4qeGddEl28Z11kbVIw0aNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.20.1"
+      }
+    },
+    "node_modules/eslint-plugin-react-compiler/node_modules/zod-validation-error": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-3.4.0.tgz",
+      "integrity": "sha512-ZOPR9SVY6Pb2qqO5XHt+MkkTRxGXb4EVtnjc9JpXUOtUB1T9Ru7mZOT361AN3MsetVe7R0a1KZshJDZdgp9miQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-ft-flow": "^3.0.7",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.33.1",
+    "eslint-plugin-react-compiler": "^19.0.0-beta-8a03594-20241020",
     "eslint-plugin-react-hooks": "^4.5.0",
     "flow-api-translator": "^0.25.0",
     "flow-bin": "^0.248.1",

--- a/packages/react-strict-dom/src/dom/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/dom/modules/createStrictDOMComponent.js
@@ -43,7 +43,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
        * get host props
        */
       const { for: htmlFor, style, ...restProps } = props;
-      const hostProps: { ...P, htmlFor?: string } = restProps;
+      const hostProps: { ...P, htmlFor?: string } = { ...restProps };
       validateStrictProps(hostProps);
 
       if (htmlFor != null) {


### PR DESCRIPTION
This PR fixes #216

Currently, we're doing a lot of `nativeProps.PROP = VALUE;` assignments and the compiler doesn't like at all. I throws:

```txt
Mutating a value returned from a function whose return value should not be mutated react-compiler/react-compiler
```

I fixed it by doing shallow copies, but I don't know if this is the right approach. If this is ok I can continue doing the rest.

Tried to dig dive a little and found this: https://github.com/facebook/react/issues/29093#issuecomment-2116484361