### PR TITLE
feat: expose the useCustomProperties hook

### DIFF
--- a/packages/react-strict-dom/src/native/index.js
+++ b/packages/react-strict-dom/src/native/index.js
@@ -20,7 +20,10 @@ import typeof * as TStyleX from '@stylexjs/stylex';
 import * as React from 'react';
 import * as html from './html';
 import * as cssRaw from './stylex';
-import { ProvideCustomProperties } from './modules/ContextCustomProperties';
+import {
+  ProvideCustomProperties,
+  useCustomProperties
+} from './modules/ContextCustomProperties';
 
 type StyleTheme<V, T> = Theme<V, T>;
 type StyleVars<T> = VarGroup<T>;
@@ -53,4 +56,4 @@ const css: TStyleX = cssRaw as $FlowFixMe;
 
 export type { StaticStyles, StyleTheme, StyleVars, Styles, StylesWithout };
 
-export { contexts, css, html };
+export { contexts, css, html, useCustomProperties };


### PR DESCRIPTION
When trying to style "native" (not RSD) components with StyleX APIs, it should be possible to resolve the themes that have been applied with `stylex.createTheme` APIs within the RSD tree.

This PR simply exposes the `useCustomProperties` hook to make this possible.