### PR TITLE
Disentangle platform-specific flow types

### DIFF
--- a/packages/react-strict-dom/src/dom/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/dom/modules/createStrictDOMComponent.js
@@ -8,7 +8,8 @@
  */
 
 import type { CompiledStyles } from '@stylexjs/stylex/lib/StyleXTypes';
-import type { StrictProps, ReactDOMStyleProps } from '../../types/StrictProps';
+import type { ReactDOMStyleProps } from '../../types/renderer.web';
+import type { StrictProps } from '../../types/StrictProps';
 
 import * as React from 'react';
 import * as stylex from '@stylexjs/stylex';

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -7,7 +7,8 @@
  * @flow strict-local
  */
 
-import type { StrictPropsWithCompat } from '../../types/StrictProps';
+import type { ReactNativeProps } from '../../types/renderer.native';
+import type { StrictProps as StrictPropsOriginal } from '../../types/StrictProps';
 
 import * as React from 'react';
 import { Animated, Pressable } from 'react-native';
@@ -22,9 +23,14 @@ import { mergeRefs } from '../../shared/mergeRefs';
 import { useNativeProps } from './useNativeProps';
 import { useStrictDOMElement } from './useStrictDOMElement';
 
+type StrictProps = $ReadOnly<{
+  ...StrictPropsOriginal,
+  children?: React.Node | ((ReactNativeProps) => React.Node)
+}>;
+
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
 
-export function createStrictDOMComponent<T, P: StrictPropsWithCompat>(
+export function createStrictDOMComponent<T, P: StrictProps>(
   tagName: string,
   defaultProps?: P
 ): component(ref?: React.RefSetter<T>, ...P) {

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
@@ -7,7 +7,8 @@
  * @flow strict-local
  */
 
-import type { StrictPropsWithCompat } from '../../types/StrictProps';
+import type { ReactNativeProps } from '../../types/renderer.native';
+import type { StrictProps as StrictPropsOriginal } from '../../types/StrictProps';
 
 import * as React from 'react';
 import { Animated, Platform, Text } from 'react-native';
@@ -19,11 +20,16 @@ import { useNativeProps } from './useNativeProps';
 import { useStrictDOMElement } from './useStrictDOMElement';
 import * as stylex from '../stylex';
 
+type StrictProps = $ReadOnly<{
+  ...StrictPropsOriginal,
+  children?: React.Node | ((ReactNativeProps) => React.Node)
+}>;
+
 function hasElementChildren(children: mixed): boolean {
   return children != null && typeof children !== 'string';
 }
 
-export function createStrictDOMTextComponent<T, P: StrictPropsWithCompat>(
+export function createStrictDOMTextComponent<T, P: StrictProps>(
   tagName: string,
   _defaultProps?: P
 ): component(ref?: React.RefSetter<T>, ...P) {

--- a/packages/react-strict-dom/src/native/modules/useNativeProps.js
+++ b/packages/react-strict-dom/src/native/modules/useNativeProps.js
@@ -8,9 +8,9 @@
  */
 
 import type { CustomProperties } from '../../types/styles';
-import type { StrictPropsWithCompat } from '../../types/StrictProps';
+import type { ReactNativeProps } from '../../types/renderer.native';
+import type { StrictProps as StrictPropsOriginal } from '../../types/StrictProps';
 import type { Style } from '../../types/styles';
-import type { Props as ReactNativeProps } from '../../types/react-native';
 
 import * as stylex from '../stylex';
 import { errorMsg, warnMsg } from '../../shared/logUtils';
@@ -18,6 +18,11 @@ import { extractStyleThemes } from './extractStyleThemes';
 import { isPropAllowed } from '../../shared/isPropAllowed';
 import { useCustomProperties } from './ContextCustomProperties';
 import { useStyleProps } from './useStyleProps';
+
+type StrictProps = $ReadOnly<{
+  ...StrictPropsOriginal,
+  children?: React.Node | ((ReactNativeProps) => React.Node)
+}>;
 
 /**
  * Props validation
@@ -29,7 +34,7 @@ const unsupportedProps = new Set([
   'onSelectionChange'
 ]);
 
-function validateStrictProps(props: StrictPropsWithCompat) {
+function validateStrictProps(props: StrictProps) {
   Object.keys(props).forEach((key) => {
     const isValidProp = isPropAllowed(key);
     const isUnsupportedProp = unsupportedProps.has(key);
@@ -83,8 +88,8 @@ type ReturnType = {|
 |};
 
 export function useNativeProps(
-  defaultProps: ?StrictPropsWithCompat,
-  props: StrictPropsWithCompat,
+  defaultProps: ?StrictProps,
+  props: StrictProps,
   options: OptionsType
 ): ReturnType {
   if (__DEV__) {

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -8,8 +8,10 @@
  */
 
 import type { CustomProperties, Styles, Style } from '../../types/styles';
-import type { Props as ReactNativeProps } from '../../types/react-native';
-import type { Style as ReactNativeStyle } from '../../types/react-native';
+import type {
+  ReactNativeProps,
+  ReactNativeStyle
+} from '../../types/renderer.native';
 
 import * as stylex from '../stylex';
 import { useColorScheme, useWindowDimensions } from 'react-native';

--- a/packages/react-strict-dom/src/native/modules/useStyleTransition.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleTransition.js
@@ -8,16 +8,18 @@
  */
 
 import type {
-  Style as ReactNativeStyle,
-  StyleValue,
-  Transform
-} from '../../types/react-native';
+  ReactNativeStyle,
+  ReactNativeStyleValue,
+  ReactNativeTransform
+} from '../../types/renderer.native';
 
 import { useEffect, useRef, useState } from 'react';
 import { warnMsg } from '../../shared/logUtils';
 import { Animated, Easing } from 'react-native';
 
-type AnimatedStyle = { [string]: ?StyleValue | $ReadOnlyArray<mixed> };
+type AnimatedStyle = {
+  [string]: ?ReactNativeStyleValue | $ReadOnlyArray<mixed>
+};
 
 type TransitionMetadata = $ReadOnly<{
   delay: number,
@@ -88,8 +90,8 @@ function getTransitionProperties(property: mixed): ?(string[]) {
 }
 
 function transformsHaveSameLengthTypesAndOrder(
-  transformsA: $ReadOnlyArray<Transform>,
-  transformsB: $ReadOnlyArray<Transform>
+  transformsA: $ReadOnlyArray<ReactNativeTransform>,
+  transformsB: $ReadOnlyArray<ReactNativeTransform>
 ): boolean {
   if (transformsA.length !== transformsB.length) {
     return false;
@@ -119,8 +121,8 @@ function transformsHaveSameLengthTypesAndOrder(
 }
 
 function transformListsAreEqual(
-  transformsA: $ReadOnlyArray<Transform>,
-  transformsB: $ReadOnlyArray<Transform>
+  transformsA: $ReadOnlyArray<ReactNativeTransform>,
+  transformsB: $ReadOnlyArray<ReactNativeTransform>
 ): boolean {
   if (!transformsHaveSameLengthTypesAndOrder(transformsA, transformsB)) {
     return false;

--- a/packages/react-strict-dom/src/native/stylex/fixContentBox.js
+++ b/packages/react-strict-dom/src/native/stylex/fixContentBox.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-import type { Style as ReactNativeStyle } from '../../types/react-native';
+import type { ReactNativeStyle } from '../../types/renderer.native';
 
 import { warnMsg } from '../../shared/logUtils';
 

--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -8,15 +8,15 @@
  */
 
 import type {
+  ReactNativeProps,
+  ReactNativeStyle
+} from '../../types/renderer.native';
+
+import type {
   CustomProperties,
   MutableCustomProperties,
   IStyleX
 } from '../../types/styles';
-
-import type {
-  Props as ReactNativeProps,
-  Style as ReactNativeStyle
-} from '../../types/react-native';
 
 import { CSSLengthUnitValue } from './CSSLengthUnitValue';
 import { CSSUnparsedValue } from './typed-om/CSSUnparsedValue';

--- a/packages/react-strict-dom/src/native/stylex/parseTransform.js
+++ b/packages/react-strict-dom/src/native/stylex/parseTransform.js
@@ -7,16 +7,18 @@
  * @flow strict
  */
 
-import type { Transform } from '../../types/react-native';
+import type { ReactNativeTransform } from '../../types/renderer.native';
 
 const transformRegex1 =
   /(perspective|scale|scaleX|scaleY|scaleZ|translateX|translateY)\(([0-9.+\-eE]+)(px|%)?\)/;
 const transformRegex2 = /(rotate|rotateX|rotateY|rotateZ|skewX|skewY)\((.*)\)/;
 const transformRegex3 = /matrix\((.*)\)/;
 
-const memoizedValues = new Map<string, Transform[]>();
+const memoizedValues = new Map<string, ReactNativeTransform[]>();
 
-export function parseTransform(transform: string): $ReadOnlyArray<Transform> {
+export function parseTransform(
+  transform: string
+): $ReadOnlyArray<ReactNativeTransform> {
   const memoizedValue = memoizedValues.get(transform);
   if (memoizedValue != null) {
     return memoizedValue;
@@ -25,7 +27,7 @@ export function parseTransform(transform: string): $ReadOnlyArray<Transform> {
   const transforms = transform
     .split(')')
     .flatMap((s) => (s === '' ? ([] as string[]) : [s + ')']));
-  const parsedTransforms: Transform[] = [];
+  const parsedTransforms: ReactNativeTransform[] = [];
 
   for (const txf of transforms) {
     let match = txf.match(transformRegex1);

--- a/packages/react-strict-dom/src/types/StrictProps.js
+++ b/packages/react-strict-dom/src/types/StrictProps.js
@@ -7,8 +7,6 @@
  * @flow strict
  */
 
-import type { Props as ReactNativeProps } from './react-native';
-
 import type { StrictReactDOMProps } from './StrictReactDOMProps';
 
 import type { StrictReactDOMAnchorProps } from './StrictReactDOMAnchorProps';
@@ -32,14 +30,4 @@ export type StrictProps = $ReadOnly<{
   ...StrictReactDOMOptionProps,
   ...StrictReactDOMSelectProps,
   ...StrictReactDOMTextAreaProps
-}>;
-
-export type StrictPropsWithCompat = $ReadOnly<{
-  ...StrictProps,
-  children?: React.Node | ((ReactNativeProps) => React.Node)
-}>;
-
-export type ReactDOMStyleProps = $ReadOnly<{
-  className?: string,
-  style?: $ReadOnly<{ [string]: string | number }>
 }>;

--- a/packages/react-strict-dom/src/types/renderer.native.js
+++ b/packages/react-strict-dom/src/types/renderer.native.js
@@ -28,7 +28,7 @@ import type {
   ViewProps
 } from 'react-native/Libraries/Components/View/ViewPropTypes';
 
-type Props = {
+type ReactNativeProps = {
   accessible?: ViewProps['accessible'],
   accessibilityLabel?: ViewProps['accessibilityLabel'],
   accessibilityLabelledBy?: ViewProps['accessibilityLabelledBy'],
@@ -110,13 +110,13 @@ type Props = {
   spellCheck?: TextInputProps['spellCheck'],
   src?: ImageProps['src'],
   srcSet?: ImageProps['srcSet'],
-  style: Style,
+  style: ReactNativeStyle,
   testID?: ViewProps['testID'],
   value?: TextInputProps['value'],
   width?: ImageProps['width']
 };
 
-type Transform =
+type ReactNativeTransform =
   | $ReadOnly<{ matrix: number[] }>
   | $ReadOnly<{ perspective: number }>
   | $ReadOnly<{ rotate: string }>
@@ -132,7 +132,18 @@ type Transform =
   | $ReadOnly<{ skewX: string }>
   | $ReadOnly<{ skewY: string }>;
 
-type StyleValue = number | string | Transform[] | AnimatedNode;
-type Style = { [string]: ?StyleValue };
+type ReactNativeStyleValue =
+  | number
+  | string
+  | ReactNativeTransform[]
+  | AnimatedNode;
 
-export type { Props, Style, StyleValue, SyntheticEvent, Transform };
+type ReactNativeStyle = { [string]: ?ReactNativeStyleValue };
+
+export type {
+  ReactNativeProps,
+  ReactNativeStyle,
+  ReactNativeStyleValue,
+  ReactNativeTransform,
+  SyntheticEvent
+};

--- a/packages/react-strict-dom/src/types/renderer.web.js
+++ b/packages/react-strict-dom/src/types/renderer.web.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+export type ReactDOMStyleProps = $ReadOnly<{
+  className?: string,
+  style?: $ReadOnly<{ [string]: string | number }>
+}>;


### PR DESCRIPTION
Separate the platform-specific types into `*.native` and `*.web` files. This helps generate libdefs that type check correctly in different environments.