### PR TITLE
Expose the aliases option from the Stylex babel plugin to react-strict-dom

### DIFF
--- a/packages/react-strict-dom/babel/index.js
+++ b/packages/react-strict-dom/babel/index.js
@@ -217,7 +217,8 @@ function reactStrictPlugin({ types: t }, options = {}) {
 const defaultOptions = {
   dev: true,
   debug: true,
-  rootDir: process.cwd()
+  rootDir: process.cwd(),
+  aliases: null
 };
 
 function reactStrictPreset(_, options = {}) {
@@ -243,7 +244,8 @@ function reactStrictPreset(_, options = {}) {
             rootDir: opts.rootDir
             //themeFileExtension: '.cssvars.js',
           },
-          useRemForFontSize: false
+          useRemForFontSize: false,
+          aliases: opts.aliases
         }
       ]
     ]


### PR DESCRIPTION
I am using the RSD babel preset together with the `@stylexjs/rollup-plugin`.

Due to using import aliases for my stylex vars the build fails with error:
```
Only static values are allowed inside of a stylex.create() call
```

This should be resolved by enabling forwarding of the aliases to the Stylex babel plugin.