### PR TITLE
Add missing 'dist' folder before publish

### DIFF
--- a/packages/react-strict-dom/package.json
+++ b/packages/react-strict-dom/package.json
@@ -18,7 +18,8 @@
     "dev": "npm run build -- --watch",
     "jest": "jest --config ./tools/jest.config.js",
     "jest:report": "jest --config ./tools/jest.config.js --collect-coverage",
-    "prebuild": "npm run clean && generate-types -i src/ -o dist"
+    "prebuild": "npm run clean && generate-types -i src/ -o dist",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@stylexjs/stylex": "^0.9.3",


### PR DESCRIPTION
This exports the dist folder, but it does not generate the dist folder during publish, resulting in the error: 
```shell
Cannot find module 'react-strict-dom' or its corresponding type declarations.ts(2307).
``` 
To fix this issue, I added a `prepublishOnly` script to perform the build process before publishing.