### PR TITLE
Fix default value of alignContent on native

### DIFF
--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -106,6 +106,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
 
       if (displayValue === 'flex') {
         nextDisplayInsideValue = 'flex';
+        nativeProps.style.alignContent ??= 'stretch';
         nativeProps.style.alignItems ??= 'stretch';
         nativeProps.style.flexBasis ??= 'auto';
         nativeProps.style.flexDirection ??= 'row';

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -68,6 +68,7 @@ exports[`<html.*> default flex layout: flex layout 1`] = `
   experimental_layoutConformance="strict"
   style={
     {
+      "alignContent": "stretch",
       "alignItems": "stretch",
       "boxSizing": "content-box",
       "display": "flex",
@@ -901,6 +902,7 @@ exports[`<html.*> prop polyfills global "hidden" prop: display set 1`] = `
   experimental_layoutConformance="strict"
   style={
     {
+      "alignContent": "stretch",
       "alignItems": "stretch",
       "boxSizing": "content-box",
       "display": "flex",


### PR DESCRIPTION
The web's default value for alignContent is 'stetch', whereas in React Native it is 'flex-start'. This patch aligns native with the web.