### PR TITLE
allow passing @stylexjs/babel-plugin aliases through react-strict-dom/babel-preset

### DIFF
--- a/packages/react-strict-dom/babel/preset.js
+++ b/packages/react-strict-dom/babel/preset.js
@@ -28,6 +28,7 @@ function reactStrictPreset(_, options = {}) {
       styleXPlugin,
       {
         dev: opts.dev,
+        aliases: opts.aliases,
         importSources: [{ from: 'react-strict-dom', as: 'css' }],
         runtimeInjection: false,
         styleResolution: 'property-specificity',


### PR DESCRIPTION
Until https://github.com/facebook/stylex/pull/856 is merged and released, this is kind of the only option to be able to write imports like defined in a tsconfig file.