### PR TITLE
Add name prop to StrictReactDOMInputProps

### DIFF
--- a/apps/examples/src/components/App.js
+++ b/apps/examples/src/components/App.js
@@ -220,7 +220,11 @@ function Shell(): React.MixedElement {
           <html.div />
           {/*<html.input placeholder="input type:date" type="date" />*/}
           <html.div />
-          <html.input placeholder="input type:email" type="email" />
+          <html.input
+            name="email"
+            placeholder="input type:email"
+            type="email"
+          />
           <html.div />
           <html.input placeholder="input type:number" type="number" />
           <html.div />

--- a/packages/react-strict-dom/src/types/StrictReactDOMInputProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMInputProps.js
@@ -21,6 +21,7 @@ export type StrictReactDOMInputProps = $ReadOnly<{
   min?: ?(string | number),
   minLength?: ?number,
   multiple?: ?boolean,
+  name?: ?Stringish,
   onBeforeInput?: $FlowFixMe,
   onChange?: $FlowFixMe,
   onInput?: $FlowFixMe,


### PR DESCRIPTION
Adds support for input attribute `name`.

https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input#name