### PR TITLE
Fix path resolve for rollup config

### DIFF
--- a/packages/react-strict-dom/tools/rollup.config.mjs
+++ b/packages/react-strict-dom/tools/rollup.config.mjs
@@ -8,9 +8,10 @@
 import { babel } from '@rollup/plugin-babel';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
-import path from 'path';
+import path, { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
-const __dirname = import.meta.dirname;
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const babelPlugin = babel({
   babelHelpers: 'bundled',


### PR DESCRIPTION
Ran into this when trying to run `npm i`. Similar fix to https://github.com/facebook/stylex/pull/1029

```
[!] TypeError: The "paths[0]" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at Object.resolve (node:path:1115:7)
    at file:///Users/mellyeliu/react-strict-dom/packages/react-strict-dom/tools/rollup.config.mjs:17:20
```