### PR TITLE
Fix typo in Docs

### DIFF
--- a/apps/website/docs/api/02-css/index.md
+++ b/apps/website/docs/api/02-css/index.md
@@ -216,8 +216,8 @@ The following tables represent the compatibility status of the strict CSS API fo
 | paddingInlineEnd | 🟡 | 🟡 | |
 | paddingInlineStart | 🟡 | 🟡 | |
 | paddingLeft | ✅ | ✅ | |
-| pointerRight | ✅ | ✅ | |
-| pointerTop | ✅ | ✅ | |
+| paddingRight | ✅ | ✅ | |
+| paddingTop | ✅ | ✅ | |
 | placeContent | 🟡 | 🟡 | |
 | placeItems | ❌ | ❌ | |
 | placeSelf | ❌ | ❌ | |

--- a/apps/website/docs/contribute/01-development/04-author-patch.md
+++ b/apps/website/docs/contribute/01-development/04-author-patch.md
@@ -117,7 +117,7 @@ npm run compare -w benchmarks -- <path-to-base.json> <path-to-patch.json>
 Branches should be cleaned up before review. An interactive rebase can be used to squash commits, reorder commits, and reword commits. For example, this will run an interactive rebase for the last 5 commits from `HEAD` on a branch.
 
 ```
-git rebase -i HEAD^5
+git rebase -i HEAD~5
 ```
 
 Once the branch has been prepared for review, it should be pushed to GitHub:

--- a/apps/website/docs/contribute/02-technicals/01-design-goals.md
+++ b/apps/website/docs/contribute/02-technicals/01-design-goals.md
@@ -8,7 +8,7 @@ slug: /contribute/design-goals
 
 ## Motivation
 
-React Strict DOM (RSD) began as a way to prototype and drive the development of "[React DOM for Native](https://github.com/react-native-community/discussions-and-proposals/pull/496)". It enables engineers to quickly and easily reuse existing React web code and knowledge on native platforms. Our goal is to quickily and easily reuse React web code to also produce high-quality native interfaces, to reduce product time-to-market, and to improve engineering efficiency and product quality.
+React Strict DOM (RSD) began as a way to prototype and drive the development of "[React DOM for Native](https://github.com/react-native-community/discussions-and-proposals/pull/496)". It enables engineers to quickly and easily reuse existing React web code and knowledge on native platforms. Our goal is to quickly and easily reuse React web code to also produce high-quality native interfaces, to reduce product time-to-market, and to improve engineering efficiency and product quality.
 
 React Strict DOM aims to leverage the many framework investments we've made to React over the years (e.g., [React Native Fabric](https://reactnative.dev/architecture/fabric-renderer), [React Compiler](https://react.dev/learn/react-compiler), [React Developer Tools](https://react.dev/learn/react-developer-tools), [Yoga](https://www.yogalayout.dev/), etc.) that now make it possible to dramatically improve cross-platform product development.
 
@@ -38,7 +38,7 @@ React Strict DOM provides a well-defined target API for implementations. By alig
 
 ### Unified elements and styles
 
-Standardizing on HTML element and CSS styles makes it possible for web engineers to re-use their existing knowledge of React DOM and StyleX to target platforms beyond web. React Strict DOM solves problems with some React Native APIs being based on W3C APIs but not conforming to the standards, and others (which are declarative on web) have inherit performance drawbacks on web.
+Standardizing on HTML element and CSS styles makes it possible for web engineers to re-use their existing knowledge of React DOM and StyleX to target platforms beyond web. React Strict DOM solves problems with some React Native APIs being based on W3C APIs but not conforming to the standards, and others (which are declarative on web) have inherent performance drawbacks on web.
 
 ### Unified types
 
@@ -48,7 +48,7 @@ React Strict DOM allows developers to use existing DOM types (e.g., `HTMLElement
 
 React Strict DOM is able to provide a unified, cross-platform API for React developers by 1) polyfilling a large number of standard APIs, 2) leveraging new capabilities coming to React Native such as DOM traversal APIs and a well-defined Event Loop processing model. Where possible, capabilities are built in native code. React Strict DOM encapsulates a large number of polyfills and shims that convert React DOM APIs to React Native equivalents. We prioritize user-space shims in JavaScript where they are faster to ship and allow us to gather feedback and drive adoption.
 
-Other approaches that we expored were either based on React Native's API (e.g., [React Native for Web](https://necolas.github.io/react-native-web/)) or a another custom API. But they introduced performance regressions on web, implementation and migration complexity for all platforms, and ongoing design costs associated with developing non-standard APIs.
+Other approaches that we explored were either based on React Native's API (e.g., [React Native for Web](https://necolas.github.io/react-native-web/)) or a another custom API. But they introduced performance regressions on web, implementation and migration complexity for all platforms, and ongoing design costs associated with developing non-standard APIs.
 
 ## Tradeoffs
 

--- a/apps/website/docs/contribute/02-technicals/04-tests.md
+++ b/apps/website/docs/contribute/02-technicals/04-tests.md
@@ -30,4 +30,4 @@ Expo currently lacks built-in integrations for React Strict DOM, but the goal of
 
 ## Performance benchmarks
 
-Bundle sizes on web and native are also monitored for regressions. The polyfills for native platforms are also subject to performance monitoring. Currently only the style polyfills are benchmarked for regressions in Node.js, running it jitless mode to better emulate the Hermes runtime used by React Native. These benchmarks are automatically run and reported for each Pull Request submitted on GitHub.
+Bundle sizes on web and native are also monitored for regressions. The polyfills for native platforms are also subject to performance monitoring. Currently only the style polyfills are benchmarked for regressions in Node.js, running in jitless mode to better emulate the Hermes runtime used by React Native. These benchmarks are automatically run and reported for each Pull Request submitted on GitHub.


### PR DESCRIPTION
Fix typo in [Contribute](https://facebook.github.io/react-strict-dom/contribute/) docs,

The last 5 commits from `HEAD` would translate to `HEAD~5`.  
`HEAD^5` would mean **_5th parent of HEAD_** (octopus merge commit) which seems to be not the intent here.