### PR TITLE
Add missing postcss files in package.json `files` field

### DIFF
--- a/packages/react-strict-dom/package.json
+++ b/packages/react-strict-dom/package.json
@@ -22,6 +22,7 @@
     "README.md",
     "package.json",
     "babel/*",
+    "postcss/*",
     "dist/*"
   ],
   "sideEffects": false,


### PR DESCRIPTION
# Why
v0.0.38 published to npm does not include `postcss/plugin.js` due to missing package.json `files` field.

https://github.com/facebook/react-strict-dom/pull/308 added postcss exports but did not include the actual `postcss/plugin.js` files, causing the files to be not included when publishing to npm.

<img width="556" alt="Screenshot 2025-07-04 at 12 04 26" src="https://github.com/user-attachments/assets/34283cb4-5b17-4a9b-be6e-b77ded019995" />

# How
Adds `"postcss/*"` to `files` field similar to `babel` preset files.

