### PR TITLE
Fix occasional flicker when transitioning a property

### DIFF
--- a/packages/react-strict-dom/src/native/modules/useStyleTransition.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleTransition.js
@@ -400,6 +400,10 @@ export function useStyleTransition(style: ReactNativeStyle): ReactNativeStyle {
     }
   }, [currentStyle, style, transitionStyleHasChangedResult]);
 
+  if (transitionStyleHasChangedResult) {
+    return currentStyle ?? style;
+  }
+
   if (
     _delay == null &&
     _duration == null &&


### PR DESCRIPTION
If transitionStyleHasChangedResult is true, the code in useLayoutEffect should run synchronously without rendering the style being transitioned to, but this doesn't appear to be the case 100% of the time because I've got one transition that momentarily shows the target style before running the transition. Even this doesn't repro reliably.

Even though I'd expect returning the current style if transitionStyleHasChangedResult is true to be a no-op (because the useLayoutEffect should cause a synchronous render with a new value), it doesn't seem to always be that way and this PR fixes the issue