### PR TITLE
Remove flex warning for flex item properties

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/index.js
+++ b/packages/react-strict-dom/src/native/stylex/index.js
@@ -725,13 +725,8 @@ export function props(
       if (
         nextStyle.alignContent != null ||
         nextStyle.alignItems != null ||
-        nextStyle.alignSelf != null ||
         nextStyle.columnGap != null ||
-        nextStyle.flex != null ||
-        nextStyle.flexBasis != null ||
         nextStyle.flexDirection != null ||
-        nextStyle.flexGrow != null ||
-        nextStyle.flexShrink != null ||
         nextStyle.flexWrap != null ||
         nextStyle.gap != null ||
         nextStyle.justifyContent != null ||


### PR DESCRIPTION
This PR removes the stylex flex warning for flex item (child) properties, since they don't need to be used with `display: 'flex'`.

 - `alignSelf`
 - `flex`
 - `flexBasis`
 - `flexGrow`
 - `flexShrink`