### PR TITLE
Fix postcss-value-parser flow types

### DIFF
--- a/packages/react-strict-dom/src/native/stylex/typed-om/CSSUnparsedValue.js
+++ b/packages/react-strict-dom/src/native/stylex/typed-om/CSSUnparsedValue.js
@@ -7,6 +7,8 @@
  * @flow strict
  */
 
+import type { CSSValueASTNode } from '../../../types/value-parser';
+
 import valueParser from 'postcss-value-parser';
 import { CSSVariableReferenceValue } from './CSSVariableReferenceValue';
 import { errorMsg, warnMsg } from '../../../shared/logUtils';
@@ -17,8 +19,8 @@ type CSSUnparsedSegment = string | CSSVariableReferenceValue;
 const MAX_RESOLVE_DEPTH = 50;
 
 function splitComponentValueListByComma(
-  input: PostCSSValueASTNode[]
-): PostCSSValueASTNode[][] {
+  input: CSSValueASTNode[]
+): CSSValueASTNode[][] {
   const output = [];
   let current = [];
   for (const value of input) {
@@ -39,7 +41,7 @@ const memoizedValues = new Map<string, CSSUnparsedValue>();
 
 // https://drafts.css-houdini.org/css-typed-om-1/#cssunparsedvalue
 export class CSSUnparsedValue /*extends CSSStyleValue*/ {
-  static _resolveVariableName(input: PostCSSValueASTNode[]): string | null {
+  static _resolveVariableName(input: CSSValueASTNode[]): string | null {
     const cleanedInput = input.filter((i) => i.type === 'word');
     if (cleanedInput.length !== 1) {
       return null;
@@ -48,7 +50,7 @@ export class CSSUnparsedValue /*extends CSSStyleValue*/ {
   }
 
   static _resolveUnparsedValue(
-    input: PostCSSValueASTNode[],
+    input: CSSValueASTNode[],
     depth: number = 0
   ): CSSUnparsedValue {
     if (depth > MAX_RESOLVE_DEPTH) {

--- a/packages/react-strict-dom/src/types/value-parser.js
+++ b/packages/react-strict-dom/src/types/value-parser.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ */
+
+export type CSSValueASTNode =
+  | {
+      type: 'word' | 'unicode-range',
+      value: string,
+      sourceIndex: number,
+      sourceEndIndex: number
+    }
+  | {
+      type: 'string' | 'comment',
+      value: string,
+      quote: '"' | "'",
+      sourceIndex: number,
+      sourceEndIndex: number,
+      unclosed?: boolean
+    }
+  | {
+      type: 'comment',
+      value: string,
+      sourceIndex: number,
+      sourceEndIndex: number,
+      unclosed?: boolean
+    }
+  | {
+      type: 'div',
+      value: ',' | '/' | ':',
+      sourceIndex: number,
+      sourceEndIndex: number,
+      before: '' | ' ' | '  ' | '   ',
+      after: '' | ' ' | '  ' | '   '
+    }
+  | {
+      type: 'space',
+      value: ' ' | '  ' | '   ',
+      sourceIndex: number,
+      sourceEndIndex: number
+    }
+  | {
+      type: 'function',
+      value: string,
+      before: '' | ' ' | '  ' | '   ',
+      after: '' | ' ' | '  ' | '   ',
+      nodes: Array<CSSValueASTNode>,
+      unclosed?: boolean,
+      sourceIndex: number,
+      sourceEndIndex: number
+    };

--- a/tools/flow-typed/npm/postcss-value-parser_vx.x.x.js
+++ b/tools/flow-typed/npm/postcss-value-parser_vx.x.x.js
@@ -7,75 +7,75 @@
  * @flow strict
  */
 
-type PostCSSValueASTNode =
-  | {
-      type: 'word' | 'unicode-range',
-      value: string,
-      sourceIndex: number,
-      sourceEndIndex: number
-    }
-  | {
-      type: 'string' | 'comment',
-      value: string,
-      quote: '"' | "'",
-      sourceIndex: number,
-      sourceEndIndex: number,
-      unclosed?: boolean
-    }
-  | {
-      type: 'comment',
-      value: string,
-      sourceIndex: number,
-      sourceEndIndex: number,
-      unclosed?: boolean
-    }
-  | {
-      type: 'div',
-      value: ',' | '/' | ':',
-      sourceIndex: number,
-      sourceEndIndex: number,
-      before: '' | ' ' | '  ' | '   ',
-      after: '' | ' ' | '  ' | '   '
-    }
-  | {
-      type: 'space',
-      value: ' ' | '  ' | '   ',
-      sourceIndex: number,
-      sourceEndIndex: number
-    }
-  | {
-      type: 'function',
-      value: string,
-      before: '' | ' ' | '  ' | '   ',
-      after: '' | ' ' | '  ' | '   ',
-      nodes: Array<PostCSSValueASTNode>,
-      unclosed?: boolean,
-      sourceIndex: number,
-      sourceEndIndex: number
-    };
-
-declare interface PostCSSValueAST {
-  nodes: Array<PostCSSValueASTNode>;
-  walk(
-    callback: (PostCSSValueASTNode, number, PostCSSValueAST) => ?false,
-    bubble?: boolean
-  ): void;
-}
-
-type PostCSSValueParser = {
-  (string): PostCSSValueAST,
-  unit(string): { number: string, unit: string } | false,
-  stringify(
-    nodes: PostCSSValueAST | PostCSSValueASTNode | PostCSSValueAST['nodes'],
-    custom?: (PostCSSValueASTNode) => string
-  ): string,
-  walk(
-    ast: PostCSSValueAST,
-    callback: (PostCSSValueASTNode, number, PostCSSValueAST) => ?false,
-    bubble?: boolean
-  ): void
-};
-
 declare module 'postcss-value-parser' {
+  declare export type PostCSSValueASTNode =
+    | {
+        type: 'word' | 'unicode-range',
+        value: string,
+        sourceIndex: number,
+        sourceEndIndex: number
+      }
+    | {
+        type: 'string' | 'comment',
+        value: string,
+        quote: '"' | "'",
+        sourceIndex: number,
+        sourceEndIndex: number,
+        unclosed?: boolean
+      }
+    | {
+        type: 'comment',
+        value: string,
+        sourceIndex: number,
+        sourceEndIndex: number,
+        unclosed?: boolean
+      }
+    | {
+        type: 'div',
+        value: ',' | '/' | ':',
+        sourceIndex: number,
+        sourceEndIndex: number,
+        before: '' | ' ' | '  ' | '   ',
+        after: '' | ' ' | '  ' | '   '
+      }
+    | {
+        type: 'space',
+        value: ' ' | '  ' | '   ',
+        sourceIndex: number,
+        sourceEndIndex: number
+      }
+    | {
+        type: 'function',
+        value: string,
+        before: '' | ' ' | '  ' | '   ',
+        after: '' | ' ' | '  ' | '   ',
+        nodes: Array<PostCSSValueASTNode>,
+        unclosed?: boolean,
+        sourceIndex: number,
+        sourceEndIndex: number
+      };
+
+  declare interface PostCSSValueAST {
+    nodes: Array<PostCSSValueASTNode>;
+    walk(
+      callback: (PostCSSValueASTNode, number, PostCSSValueAST) => ?false,
+      bubble?: boolean
+    ): void;
+  }
+
+  declare type PostCSSValueParser = {
+    (string): PostCSSValueAST,
+    unit(string): { number: string, unit: string } | false,
+    stringify(
+      nodes: PostCSSValueAST | PostCSSValueASTNode | PostCSSValueAST['nodes'],
+      custom?: (PostCSSValueASTNode) => string
+    ): string,
+    walk(
+      ast: PostCSSValueAST,
+      callback: (PostCSSValueASTNode, number, PostCSSValueAST) => ?false,
+      bubble?: boolean
+    ): void
+  };
+
   declare module.exports: PostCSSValueParser;
 }


### PR DESCRIPTION
Don't declare global types in the `flow-typed` libdef for `postcss-value-parser`, this replicates the fbsource Flow error. Add a types file that can be included in the build to avoid errors for missing type definitions. These definitions are required now that `CSSUnparsedValue` doesn't use private fields and the types appear in the build artefacts.

@martinbooth I tried syncing this branch and it resolved the flow errors.