### PR TITLE
Go back to using ref callback instead of useImperativeHandle

### DIFF
--- a/packages/react-strict-dom/tests/__snapshots__/compat-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/compat-test.native.js.snap-native
@@ -3,11 +3,7 @@
 exports[`<compat.native> "as" equals "image": as=image 1`] = `
 <Image
   accessibilityLabel="label"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   srcSet="1x.img, 2x.img 2x"
   style={
     {
@@ -23,11 +19,7 @@ exports[`<compat.native> "as" equals "input": as=input 1`] = `
 <TextInput
   accessibilityLabel="label"
   placeholderTextColor="green"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   secureTextEntry={true}
   style={
     {
@@ -42,11 +34,7 @@ exports[`<compat.native> "as" equals "text": as=text 1`] = `
 <Text
   accessibilityLabel="label"
   numberOfLines={3}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -63,11 +51,7 @@ exports[`<compat.native> "as" equals "textarea": as=textarea 1`] = `
   accessibilityLabel="label"
   multiline={true}
   numberOfLines={3}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -80,11 +64,7 @@ exports[`<compat.native> "as" equals "textarea": as=textarea 1`] = `
 exports[`<compat.native> "as" equals "view": as=view 1`] = `
 <View
   accessibilityLabel="label"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -98,11 +78,7 @@ exports[`<compat.native> "as" equals "view": as=view 1`] = `
 exports[`<compat.native> default: default 1`] = `
 <Pressable
   accessibilityLabel="label"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -116,11 +92,7 @@ exports[`<compat.native> default: default 1`] = `
 exports[`<compat.native> nested: nested 1`] = `
 <View
   accessibilityLabel="label"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -129,11 +101,7 @@ exports[`<compat.native> nested: nested 1`] = `
   }
 >
   <Text
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.js.snap-native
@@ -2,11 +2,7 @@
 
 exports[`html "a" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="link"
   style={
     {
@@ -21,11 +17,7 @@ exports[`html "a" default rendering 1`] = `
 
 exports[`html "a" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="link"
   style={
     {
@@ -41,11 +33,7 @@ exports[`html "a" ignores and warns about unsupported attributes 1`] = `
 exports[`html "a" supports additional anchor attributes 1`] = `
 <Text
   onPress={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="link"
   style={
     {
@@ -91,11 +79,7 @@ exports[`html "a" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -141,11 +125,7 @@ exports[`html "a" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="link"
   style={
     {
@@ -160,11 +140,7 @@ exports[`html "a" supports inline event handlers 1`] = `
 
 exports[`html "article" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -176,11 +152,7 @@ exports[`html "article" default rendering 1`] = `
 
 exports[`html "article" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -223,11 +195,7 @@ exports[`html "article" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -278,11 +246,7 @@ exports[`html "article" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -294,11 +258,7 @@ exports[`html "article" supports inline event handlers 1`] = `
 
 exports[`html "aside" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -310,11 +270,7 @@ exports[`html "aside" default rendering 1`] = `
 
 exports[`html "aside" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -357,11 +313,7 @@ exports[`html "aside" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -412,11 +364,7 @@ exports[`html "aside" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -428,11 +376,7 @@ exports[`html "aside" supports inline event handlers 1`] = `
 
 exports[`html "b" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -445,11 +389,7 @@ exports[`html "b" default rendering 1`] = `
 
 exports[`html "b" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -493,11 +433,7 @@ exports[`html "b" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -542,11 +478,7 @@ exports[`html "b" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -559,11 +491,7 @@ exports[`html "b" supports inline event handlers 1`] = `
 
 exports[`html "bdi" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -575,11 +503,7 @@ exports[`html "bdi" default rendering 1`] = `
 
 exports[`html "bdi" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -622,11 +546,7 @@ exports[`html "bdi" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -670,11 +590,7 @@ exports[`html "bdi" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -686,11 +602,7 @@ exports[`html "bdi" supports inline event handlers 1`] = `
 
 exports[`html "bdo" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -702,11 +614,7 @@ exports[`html "bdo" default rendering 1`] = `
 
 exports[`html "bdo" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -749,11 +657,7 @@ exports[`html "bdo" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -797,11 +701,7 @@ exports[`html "bdo" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -813,11 +713,7 @@ exports[`html "bdo" supports inline event handlers 1`] = `
 
 exports[`html "blockquote" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -829,11 +725,7 @@ exports[`html "blockquote" default rendering 1`] = `
 
 exports[`html "blockquote" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -876,11 +768,7 @@ exports[`html "blockquote" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -931,11 +819,7 @@ exports[`html "blockquote" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -947,11 +831,7 @@ exports[`html "blockquote" supports inline event handlers 1`] = `
 
 exports[`html "br" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -966,11 +846,7 @@ exports[`html "br" default rendering 1`] = `
 
 exports[`html "br" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1016,11 +892,7 @@ exports[`html "br" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -1065,11 +937,7 @@ exports[`html "br" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1084,11 +952,7 @@ exports[`html "br" supports inline event handlers 1`] = `
 
 exports[`html "button" default rendering 1`] = `
 <Pressable
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="button"
   style={
     {
@@ -1102,11 +966,7 @@ exports[`html "button" default rendering 1`] = `
 
 exports[`html "button" ignores and warns about unsupported attributes 1`] = `
 <Pressable
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="button"
   style={
     {
@@ -1122,11 +982,7 @@ exports[`html "button" supports additional button attributes 1`] = `
 <Pressable
   disabled={true}
   focusable={false}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="button"
   style={
     {
@@ -1171,11 +1027,7 @@ exports[`html "button" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -1227,11 +1079,7 @@ exports[`html "button" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="button"
   style={
     {
@@ -1245,11 +1093,7 @@ exports[`html "button" supports inline event handlers 1`] = `
 
 exports[`html "code" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1262,11 +1106,7 @@ exports[`html "code" default rendering 1`] = `
 
 exports[`html "code" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1310,11 +1150,7 @@ exports[`html "code" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -1359,11 +1195,7 @@ exports[`html "code" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1376,11 +1208,7 @@ exports[`html "code" supports inline event handlers 1`] = `
 
 exports[`html "del" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1393,11 +1221,7 @@ exports[`html "del" default rendering 1`] = `
 
 exports[`html "del" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1441,11 +1265,7 @@ exports[`html "del" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -1490,11 +1310,7 @@ exports[`html "del" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1507,11 +1323,7 @@ exports[`html "del" supports inline event handlers 1`] = `
 
 exports[`html "div" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1523,11 +1335,7 @@ exports[`html "div" default rendering 1`] = `
 
 exports[`html "div" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1570,11 +1378,7 @@ exports[`html "div" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -1625,11 +1429,7 @@ exports[`html "div" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1641,11 +1441,7 @@ exports[`html "div" supports inline event handlers 1`] = `
 
 exports[`html "em" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1658,11 +1454,7 @@ exports[`html "em" default rendering 1`] = `
 
 exports[`html "em" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1706,11 +1498,7 @@ exports[`html "em" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -1755,11 +1543,7 @@ exports[`html "em" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1772,11 +1556,7 @@ exports[`html "em" supports inline event handlers 1`] = `
 
 exports[`html "fieldset" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1788,11 +1568,7 @@ exports[`html "fieldset" default rendering 1`] = `
 
 exports[`html "fieldset" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1835,11 +1611,7 @@ exports[`html "fieldset" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -1890,11 +1662,7 @@ exports[`html "fieldset" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1906,11 +1674,7 @@ exports[`html "fieldset" supports inline event handlers 1`] = `
 
 exports[`html "footer" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1922,11 +1686,7 @@ exports[`html "footer" default rendering 1`] = `
 
 exports[`html "footer" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1969,11 +1729,7 @@ exports[`html "footer" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -2024,11 +1780,7 @@ exports[`html "footer" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2040,11 +1792,7 @@ exports[`html "footer" supports inline event handlers 1`] = `
 
 exports[`html "form" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2056,11 +1804,7 @@ exports[`html "form" default rendering 1`] = `
 
 exports[`html "form" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2103,11 +1847,7 @@ exports[`html "form" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -2158,11 +1898,7 @@ exports[`html "form" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2174,11 +1910,7 @@ exports[`html "form" supports inline event handlers 1`] = `
 
 exports[`html "h1" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2193,11 +1925,7 @@ exports[`html "h1" default rendering 1`] = `
 
 exports[`html "h1" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2243,11 +1971,7 @@ exports[`html "h1" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -2293,11 +2017,7 @@ exports[`html "h1" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2312,11 +2032,7 @@ exports[`html "h1" supports inline event handlers 1`] = `
 
 exports[`html "h2" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2331,11 +2047,7 @@ exports[`html "h2" default rendering 1`] = `
 
 exports[`html "h2" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2381,11 +2093,7 @@ exports[`html "h2" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -2431,11 +2139,7 @@ exports[`html "h2" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2450,11 +2154,7 @@ exports[`html "h2" supports inline event handlers 1`] = `
 
 exports[`html "h3" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2469,11 +2169,7 @@ exports[`html "h3" default rendering 1`] = `
 
 exports[`html "h3" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2519,11 +2215,7 @@ exports[`html "h3" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -2569,11 +2261,7 @@ exports[`html "h3" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2588,11 +2276,7 @@ exports[`html "h3" supports inline event handlers 1`] = `
 
 exports[`html "h4" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2607,11 +2291,7 @@ exports[`html "h4" default rendering 1`] = `
 
 exports[`html "h4" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2657,11 +2337,7 @@ exports[`html "h4" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -2707,11 +2383,7 @@ exports[`html "h4" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2726,11 +2398,7 @@ exports[`html "h4" supports inline event handlers 1`] = `
 
 exports[`html "h5" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2745,11 +2413,7 @@ exports[`html "h5" default rendering 1`] = `
 
 exports[`html "h5" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2795,11 +2459,7 @@ exports[`html "h5" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -2845,11 +2505,7 @@ exports[`html "h5" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2864,11 +2520,7 @@ exports[`html "h5" supports inline event handlers 1`] = `
 
 exports[`html "h6" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2883,11 +2535,7 @@ exports[`html "h6" default rendering 1`] = `
 
 exports[`html "h6" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -2933,11 +2581,7 @@ exports[`html "h6" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -2983,11 +2627,7 @@ exports[`html "h6" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="heading"
   style={
     {
@@ -3002,11 +2642,7 @@ exports[`html "h6" supports inline event handlers 1`] = `
 
 exports[`html "header" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="header"
   style={
     {
@@ -3019,11 +2655,7 @@ exports[`html "header" default rendering 1`] = `
 
 exports[`html "header" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="header"
   style={
     {
@@ -3067,11 +2699,7 @@ exports[`html "header" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -3122,11 +2750,7 @@ exports[`html "header" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="header"
   style={
     {
@@ -3139,11 +2763,7 @@ exports[`html "header" supports inline event handlers 1`] = `
 
 exports[`html "hr" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": "black",
@@ -3157,11 +2777,7 @@ exports[`html "hr" default rendering 1`] = `
 
 exports[`html "hr" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": "black",
@@ -3206,11 +2822,7 @@ exports[`html "hr" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -3263,11 +2875,7 @@ exports[`html "hr" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": "black",
@@ -3281,11 +2889,7 @@ exports[`html "hr" supports inline event handlers 1`] = `
 
 exports[`html "i" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3298,11 +2902,7 @@ exports[`html "i" default rendering 1`] = `
 
 exports[`html "i" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3346,11 +2946,7 @@ exports[`html "i" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -3395,11 +2991,7 @@ exports[`html "i" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3412,11 +3004,7 @@ exports[`html "i" supports inline event handlers 1`] = `
 
 exports[`html "img" default rendering 1`] = `
 <Image
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3429,11 +3017,7 @@ exports[`html "img" default rendering 1`] = `
 
 exports[`html "img" ignores and warns about unsupported attributes 1`] = `
 <Image
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3451,11 +3035,7 @@ exports[`html "img" supports additional image attributes 1`] = `
   height={100}
   onError={[Function]}
   onLoad={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   referrerPolicy="no-referrer"
   src="https://src.jpg"
   srcSet="https://srcSet-1x.jpg 1x, https://srcSet-2x.jpg 2x"
@@ -3506,11 +3086,7 @@ exports[`html "img" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -3554,11 +3130,7 @@ exports[`html "img" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3571,11 +3143,7 @@ exports[`html "img" supports inline event handlers 1`] = `
 
 exports[`html "input" default rendering 1`] = `
 <TextInput
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -3588,11 +3156,7 @@ exports[`html "input" default rendering 1`] = `
 
 exports[`html "input" ignores and warns about unsupported attributes 1`] = `
 <TextInput
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -3612,11 +3176,7 @@ exports[`html "input" supports additional input attributes 1`] = `
   maxLength="10"
   onChange={[Function]}
   placeholder="Placeholder"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -3663,11 +3223,7 @@ exports[`html "input" supports global attributes 1`] = `
   importantForAccessibility="no-hide-descendants"
   inputMode="numeric"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   spellCheck={true}
   style={
@@ -3716,11 +3272,7 @@ exports[`html "input" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -3733,11 +3285,7 @@ exports[`html "input" supports inline event handlers 1`] = `
 
 exports[`html "ins" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3750,11 +3298,7 @@ exports[`html "ins" default rendering 1`] = `
 
 exports[`html "ins" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3798,11 +3342,7 @@ exports[`html "ins" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -3847,11 +3387,7 @@ exports[`html "ins" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3864,11 +3400,7 @@ exports[`html "ins" supports inline event handlers 1`] = `
 
 exports[`html "kbd" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3881,11 +3413,7 @@ exports[`html "kbd" default rendering 1`] = `
 
 exports[`html "kbd" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3929,11 +3457,7 @@ exports[`html "kbd" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -3978,11 +3502,7 @@ exports[`html "kbd" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3995,11 +3515,7 @@ exports[`html "kbd" supports inline event handlers 1`] = `
 
 exports[`html "label" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4011,11 +3527,7 @@ exports[`html "label" default rendering 1`] = `
 
 exports[`html "label" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4027,11 +3539,7 @@ exports[`html "label" ignores and warns about unsupported attributes 1`] = `
 
 exports[`html "label" supports additional label attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4074,11 +3582,7 @@ exports[`html "label" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -4122,11 +3626,7 @@ exports[`html "label" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4138,11 +3638,7 @@ exports[`html "label" supports inline event handlers 1`] = `
 
 exports[`html "li" supports list item attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="listitem"
   style={
     {
@@ -4155,11 +3651,7 @@ exports[`html "li" supports list item attributes 1`] = `
 
 exports[`html "main" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4171,11 +3663,7 @@ exports[`html "main" default rendering 1`] = `
 
 exports[`html "main" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4218,11 +3706,7 @@ exports[`html "main" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -4273,11 +3757,7 @@ exports[`html "main" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4289,11 +3769,7 @@ exports[`html "main" supports inline event handlers 1`] = `
 
 exports[`html "mark" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": "yellow",
@@ -4307,11 +3783,7 @@ exports[`html "mark" default rendering 1`] = `
 
 exports[`html "mark" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": "yellow",
@@ -4356,11 +3828,7 @@ exports[`html "mark" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -4406,11 +3874,7 @@ exports[`html "mark" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": "yellow",
@@ -4424,11 +3888,7 @@ exports[`html "mark" supports inline event handlers 1`] = `
 
 exports[`html "nav" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4440,11 +3900,7 @@ exports[`html "nav" default rendering 1`] = `
 
 exports[`html "nav" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4487,11 +3943,7 @@ exports[`html "nav" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -4542,11 +3994,7 @@ exports[`html "nav" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4558,11 +4006,7 @@ exports[`html "nav" supports inline event handlers 1`] = `
 
 exports[`html "ol" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="list"
   style={
     {
@@ -4575,11 +4019,7 @@ exports[`html "ol" default rendering 1`] = `
 
 exports[`html "ol" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="list"
   style={
     {
@@ -4623,11 +4063,7 @@ exports[`html "ol" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -4678,11 +4114,7 @@ exports[`html "ol" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="list"
   style={
     {
@@ -4695,11 +4127,7 @@ exports[`html "ol" supports inline event handlers 1`] = `
 
 exports[`html "ol" supports list attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="list"
   style={
     {
@@ -4712,11 +4140,7 @@ exports[`html "ol" supports list attributes 1`] = `
 
 exports[`html "optgroup" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4728,11 +4152,7 @@ exports[`html "optgroup" default rendering 1`] = `
 
 exports[`html "optgroup" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4775,11 +4195,7 @@ exports[`html "optgroup" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -4830,11 +4246,7 @@ exports[`html "optgroup" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4846,11 +4258,7 @@ exports[`html "optgroup" supports inline event handlers 1`] = `
 
 exports[`html "option" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4862,11 +4270,7 @@ exports[`html "option" default rendering 1`] = `
 
 exports[`html "option" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4909,11 +4313,7 @@ exports[`html "option" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -4955,11 +4355,7 @@ exports[`html "option" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4971,11 +4367,7 @@ exports[`html "option" supports inline event handlers 1`] = `
 
 exports[`html "option" supports input attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4989,11 +4381,7 @@ exports[`html "option" supports input attributes 1`] = `
 
 exports[`html "p" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5005,11 +4393,7 @@ exports[`html "p" default rendering 1`] = `
 
 exports[`html "p" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5052,11 +4436,7 @@ exports[`html "p" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -5100,11 +4480,7 @@ exports[`html "p" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5116,11 +4492,7 @@ exports[`html "p" supports inline event handlers 1`] = `
 
 exports[`html "pre" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5133,11 +4505,7 @@ exports[`html "pre" default rendering 1`] = `
 
 exports[`html "pre" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5181,11 +4549,7 @@ exports[`html "pre" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -5230,11 +4594,7 @@ exports[`html "pre" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5247,11 +4607,7 @@ exports[`html "pre" supports inline event handlers 1`] = `
 
 exports[`html "s" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5264,11 +4620,7 @@ exports[`html "s" default rendering 1`] = `
 
 exports[`html "s" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5312,11 +4664,7 @@ exports[`html "s" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -5361,11 +4709,7 @@ exports[`html "s" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5378,11 +4722,7 @@ exports[`html "s" supports inline event handlers 1`] = `
 
 exports[`html "section" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5394,11 +4734,7 @@ exports[`html "section" default rendering 1`] = `
 
 exports[`html "section" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5441,11 +4777,7 @@ exports[`html "section" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -5496,11 +4828,7 @@ exports[`html "section" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5512,11 +4840,7 @@ exports[`html "section" supports inline event handlers 1`] = `
 
 exports[`html "select" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5528,11 +4852,7 @@ exports[`html "select" default rendering 1`] = `
 
 exports[`html "select" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5544,11 +4864,7 @@ exports[`html "select" ignores and warns about unsupported attributes 1`] = `
 
 exports[`html "select" supports additional select attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5591,11 +4907,7 @@ exports[`html "select" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -5646,11 +4958,7 @@ exports[`html "select" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5662,11 +4970,7 @@ exports[`html "select" supports inline event handlers 1`] = `
 
 exports[`html "span" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5678,11 +4982,7 @@ exports[`html "span" default rendering 1`] = `
 
 exports[`html "span" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5725,11 +5025,7 @@ exports[`html "span" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -5773,11 +5069,7 @@ exports[`html "span" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5789,11 +5081,7 @@ exports[`html "span" supports inline event handlers 1`] = `
 
 exports[`html "strong" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5806,11 +5094,7 @@ exports[`html "strong" default rendering 1`] = `
 
 exports[`html "strong" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5854,11 +5138,7 @@ exports[`html "strong" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -5903,11 +5183,7 @@ exports[`html "strong" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5920,11 +5196,7 @@ exports[`html "strong" supports inline event handlers 1`] = `
 
 exports[`html "sub" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5936,11 +5208,7 @@ exports[`html "sub" default rendering 1`] = `
 
 exports[`html "sub" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5983,11 +5251,7 @@ exports[`html "sub" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -6031,11 +5295,7 @@ exports[`html "sub" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -6047,11 +5307,7 @@ exports[`html "sub" supports inline event handlers 1`] = `
 
 exports[`html "sup" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -6063,11 +5319,7 @@ exports[`html "sup" default rendering 1`] = `
 
 exports[`html "sup" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -6110,11 +5362,7 @@ exports[`html "sup" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -6158,11 +5406,7 @@ exports[`html "sup" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -6175,11 +5419,7 @@ exports[`html "sup" supports inline event handlers 1`] = `
 exports[`html "textarea" default rendering 1`] = `
 <TextInput
   multiline={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -6194,11 +5434,7 @@ exports[`html "textarea" default rendering 1`] = `
 exports[`html "textarea" ignores and warns about unsupported attributes 1`] = `
 <TextInput
   multiline={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -6221,11 +5457,7 @@ exports[`html "textarea" supports additional textarea attributes 1`] = `
   numberOfLines={3}
   onChange={[Function]}
   placeholder="Placeholder"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -6273,11 +5505,7 @@ exports[`html "textarea" supports global attributes 1`] = `
   importantForAccessibility="no-hide-descendants"
   multiline={true}
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   spellCheck={true}
   style={
@@ -6328,11 +5556,7 @@ exports[`html "textarea" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -6346,11 +5570,7 @@ exports[`html "textarea" supports inline event handlers 1`] = `
 
 exports[`html "u" default rendering 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -6363,11 +5583,7 @@ exports[`html "u" default rendering 1`] = `
 
 exports[`html "u" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -6411,11 +5627,7 @@ exports[`html "u" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -6460,11 +5672,7 @@ exports[`html "u" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -6477,11 +5685,7 @@ exports[`html "u" supports inline event handlers 1`] = `
 
 exports[`html "ul" default rendering 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="list"
   style={
     {
@@ -6494,11 +5698,7 @@ exports[`html "ul" default rendering 1`] = `
 
 exports[`html "ul" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="list"
   style={
     {
@@ -6542,11 +5742,7 @@ exports[`html "ul" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="article"
   style={
     {
@@ -6597,11 +5793,7 @@ exports[`html "ul" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="list"
   style={
     {
@@ -6614,11 +5806,7 @@ exports[`html "ul" supports inline event handlers 1`] = `
 
 exports[`html "ul" supports list attributes 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   role="list"
   style={
     {
@@ -6631,11 +5819,7 @@ exports[`html "ul" supports list attributes 1`] = `
 
 exports[`html temporary data-* props support 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",

--- a/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/html-test.native.js.snap-native
@@ -2,11 +2,7 @@
 
 exports[`<html.*> auto-wraps raw strings: auto-wrap raw strings 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -28,11 +24,7 @@ exports[`<html.*> auto-wraps raw strings: auto-wrap raw strings 1`] = `
 
 exports[`<html.*> block layout override of flex layout: block layout override of flex 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "alignItems": "stretch",
@@ -48,11 +40,7 @@ exports[`<html.*> block layout override of flex layout: block layout override of
   }
 >
   <ViewNativeComponent
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -65,11 +53,7 @@ exports[`<html.*> block layout override of flex layout: block layout override of
 
 exports[`<html.*> default block layout: block layout 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -81,11 +65,7 @@ exports[`<html.*> default block layout: block layout 1`] = `
 
 exports[`<html.*> default flex layout: flex layout 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "alignContent": "stretch",
@@ -102,11 +82,7 @@ exports[`<html.*> default flex layout: flex layout 1`] = `
   }
 >
   <ViewNativeComponent
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -116,11 +92,7 @@ exports[`<html.*> default flex layout: flex layout 1`] = `
     }
   />
   <ViewNativeComponent
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -137,11 +109,7 @@ exports[`<html.*> opt in to strict layout conformance: strict layout 1`] = `
   mode="strict"
 >
   <ViewNativeComponent
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -155,11 +123,7 @@ exports[`<html.*> opt in to strict layout conformance: strict layout 1`] = `
 exports[`<html.*> prop polyfills <img> "src" prop with loading props 1`] = `
 <Image
   crossOrigin="use-credentials"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   referrerPolicy="no-referrer"
   src="https://src.jpg"
   style={
@@ -175,11 +139,7 @@ exports[`<html.*> prop polyfills <img> "src" prop with loading props 1`] = `
 exports[`<html.*> prop polyfills <img> "srcSet" prop with loading props 1`] = `
 <Image
   crossOrigin="use-credentials"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   referrerPolicy="no-referrer"
   srcSet="https://src.jpg 1x, https://srcx2.jpg 2x"
   style={
@@ -195,11 +155,7 @@ exports[`<html.*> prop polyfills <img> "srcSet" prop with loading props 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "additional-name" 1`] = `
 <TextInput
   autoComplete="additional-name"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -213,11 +169,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "additional-name" 
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "address-line1" 1`] = `
 <TextInput
   autoComplete="address-line1"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -231,11 +183,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "address-line1" 1`
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "address-line2" 1`] = `
 <TextInput
   autoComplete="address-line2"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -249,11 +197,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "address-line2" 1`
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "bday" 1`] = `
 <TextInput
   autoComplete="bday"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -267,11 +211,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "bday" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "bday-day" 1`] = `
 <TextInput
   autoComplete="bday-day"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -285,11 +225,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "bday-day" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "bday-month" 1`] = `
 <TextInput
   autoComplete="bday-month"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -303,11 +239,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "bday-month" 1`] =
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "bday-year" 1`] = `
 <TextInput
   autoComplete="bday-year"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -321,11 +253,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "bday-year" 1`] = 
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-csc" 1`] = `
 <TextInput
   autoComplete="cc-csc"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -339,11 +267,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-csc" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-exp" 1`] = `
 <TextInput
   autoComplete="cc-exp"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -357,11 +281,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-exp" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-exp-month" 1`] = `
 <TextInput
   autoComplete="cc-exp-month"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -375,11 +295,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-exp-month" 1`]
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-exp-year" 1`] = `
 <TextInput
   autoComplete="cc-exp-year"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -393,11 +309,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-exp-year" 1`] 
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-number" 1`] = `
 <TextInput
   autoComplete="cc-number"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -411,11 +323,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "cc-number" 1`] = 
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "country" 1`] = `
 <TextInput
   autoComplete="country"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -429,11 +337,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "country" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "current-password" 1`] = `
 <TextInput
   autoComplete="current-password"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -447,11 +351,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "current-password"
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "email" 1`] = `
 <TextInput
   autoComplete="email"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -465,11 +365,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "email" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "family-name" 1`] = `
 <TextInput
   autoComplete="family-name"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -483,11 +379,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "family-name" 1`] 
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "given-name" 1`] = `
 <TextInput
   autoComplete="given-name"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -501,11 +393,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "given-name" 1`] =
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "honorific-prefix" 1`] = `
 <TextInput
   autoComplete="honorific-prefix"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -519,11 +407,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "honorific-prefix"
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "honorific-suffix" 1`] = `
 <TextInput
   autoComplete="honorific-suffix"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -537,11 +421,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "honorific-suffix"
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "name" 1`] = `
 <TextInput
   autoComplete="name"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -555,11 +435,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "name" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "new-password" 1`] = `
 <TextInput
   autoComplete="new-password"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -573,11 +449,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "new-password" 1`]
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "nickname" 1`] = `
 <TextInput
   autoComplete="nickname"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -591,11 +463,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "nickname" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "off" 1`] = `
 <TextInput
   autoComplete="off"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -609,11 +477,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "off" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "on" 1`] = `
 <TextInput
   autoComplete="on"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -627,11 +491,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "on" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "one-time-code" 1`] = `
 <TextInput
   autoComplete="one-time-code"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -645,11 +505,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "one-time-code" 1`
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "organization" 1`] = `
 <TextInput
   autoComplete="organization"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -663,11 +519,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "organization" 1`]
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "organization-title" 1`] = `
 <TextInput
   autoComplete="organization-title"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -681,11 +533,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "organization-titl
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "postal-code" 1`] = `
 <TextInput
   autoComplete="postal-code"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -699,11 +547,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "postal-code" 1`] 
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "sex" 1`] = `
 <TextInput
   autoComplete="sex"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -717,11 +561,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "sex" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "street-address" 1`] = `
 <TextInput
   autoComplete="street-address"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -735,11 +575,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "street-address" 1
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "tel" 1`] = `
 <TextInput
   autoComplete="tel"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -753,11 +589,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "tel" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "tel-country-code" 1`] = `
 <TextInput
   autoComplete="tel-country-code"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -771,11 +603,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "tel-country-code"
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "tel-national" 1`] = `
 <TextInput
   autoComplete="tel-national"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -789,11 +617,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "tel-national" 1`]
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "url" 1`] = `
 <TextInput
   autoComplete="url"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -807,11 +631,7 @@ exports[`<html.*> prop polyfills <input> "autoComplete" prop: "url" 1`] = `
 exports[`<html.*> prop polyfills <input> "autoComplete" prop: "username" 1`] = `
 <TextInput
   autoComplete="username"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -827,11 +647,7 @@ exports[`<html.*> prop polyfills <input> "disabled" prop 1`] = `
   disabled={true}
   editable={false}
   focusable={false}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -845,11 +661,7 @@ exports[`<html.*> prop polyfills <input> "disabled" prop 1`] = `
 exports[`<html.*> prop polyfills <input> "style" prop 1`] = `
 <TextInput
   placeholderTextColor="pink"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -865,11 +677,7 @@ exports[`<html.*> prop polyfills <input> "style" prop 1`] = `
 exports[`<html.*> prop polyfills <input> "type" prop: "email" 1`] = `
 <TextInput
   inputMode="email"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -883,11 +691,7 @@ exports[`<html.*> prop polyfills <input> "type" prop: "email" 1`] = `
 exports[`<html.*> prop polyfills <input> "type" prop: "number" 1`] = `
 <TextInput
   inputMode="numeric"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -900,11 +704,7 @@ exports[`<html.*> prop polyfills <input> "type" prop: "number" 1`] = `
 
 exports[`<html.*> prop polyfills <input> "type" prop: "password" 1`] = `
 <TextInput
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   secureTextEntry={true}
   style={
     {
@@ -919,11 +719,7 @@ exports[`<html.*> prop polyfills <input> "type" prop: "password" 1`] = `
 exports[`<html.*> prop polyfills <input> "type" prop: "search" 1`] = `
 <TextInput
   inputMode="search"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -937,11 +733,7 @@ exports[`<html.*> prop polyfills <input> "type" prop: "search" 1`] = `
 exports[`<html.*> prop polyfills <input> "type" prop: "tel" 1`] = `
 <TextInput
   inputMode="tel"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -955,11 +747,7 @@ exports[`<html.*> prop polyfills <input> "type" prop: "tel" 1`] = `
 exports[`<html.*> prop polyfills <input> "type" prop: "url" 1`] = `
 <TextInput
   inputMode="url"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -976,11 +764,7 @@ exports[`<html.*> prop polyfills <textarea> "disabled" prop 1`] = `
   editable={false}
   focusable={false}
   multiline={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -996,11 +780,7 @@ exports[`<html.*> prop polyfills <textarea> "rows" prop 1`] = `
 <TextInput
   multiline={true}
   numberOfLines={5}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1014,11 +794,7 @@ exports[`<html.*> prop polyfills <textarea> "rows" prop 1`] = `
 
 exports[`<html.*> prop polyfills global "dir" prop: "auto" block 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1030,11 +806,7 @@ exports[`<html.*> prop polyfills global "dir" prop: "auto" block 1`] = `
 
 exports[`<html.*> prop polyfills global "dir" prop: "auto" text 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1047,11 +819,7 @@ exports[`<html.*> prop polyfills global "dir" prop: "auto" text 1`] = `
 
 exports[`<html.*> prop polyfills global "dir" prop: "ltr" block 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1064,11 +832,7 @@ exports[`<html.*> prop polyfills global "dir" prop: "ltr" block 1`] = `
 
 exports[`<html.*> prop polyfills global "dir" prop: "ltr" text 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1082,11 +846,7 @@ exports[`<html.*> prop polyfills global "dir" prop: "ltr" text 1`] = `
 
 exports[`<html.*> prop polyfills global "dir" prop: "rtl" block 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1099,11 +859,7 @@ exports[`<html.*> prop polyfills global "dir" prop: "rtl" block 1`] = `
 
 exports[`<html.*> prop polyfills global "dir" prop: "rtl" text 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1117,11 +873,7 @@ exports[`<html.*> prop polyfills global "dir" prop: "rtl" text 1`] = `
 
 exports[`<html.*> prop polyfills global "hidden" prop 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1134,11 +886,7 @@ exports[`<html.*> prop polyfills global "hidden" prop 1`] = `
 
 exports[`<html.*> prop polyfills global "hidden" prop: "false" 1`] = `
 <TextInput
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1151,11 +899,7 @@ exports[`<html.*> prop polyfills global "hidden" prop: "false" 1`] = `
 
 exports[`<html.*> prop polyfills global "hidden" prop: "false" 2`] = `
 <TextInput
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1169,11 +913,7 @@ exports[`<html.*> prop polyfills global "hidden" prop: "false" 2`] = `
 
 exports[`<html.*> prop polyfills global "hidden" prop: "hidden" 1`] = `
 <TextInput
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1187,11 +927,7 @@ exports[`<html.*> prop polyfills global "hidden" prop: "hidden" 1`] = `
 
 exports[`<html.*> prop polyfills global "hidden" prop: "true" 1`] = `
 <TextInput
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1205,11 +941,7 @@ exports[`<html.*> prop polyfills global "hidden" prop: "true" 1`] = `
 
 exports[`<html.*> prop polyfills global "hidden" prop: "true" 2`] = `
 <TextInput
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1223,11 +955,7 @@ exports[`<html.*> prop polyfills global "hidden" prop: "true" 2`] = `
 
 exports[`<html.*> prop polyfills global "hidden" prop: "until-found" 1`] = `
 <TextInput
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1240,11 +968,7 @@ exports[`<html.*> prop polyfills global "hidden" prop: "until-found" 1`] = `
 
 exports[`<html.*> prop polyfills global "hidden" prop: display set 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "alignContent": "stretch",
@@ -1265,11 +989,7 @@ exports[`<html.*> prop polyfills global "hidden" prop: display set 1`] = `
 exports[`<html.*> prop polyfills global "inputMode" prop: "decimal" 1`] = `
 <TextInput
   inputMode="decimal"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1283,11 +1003,7 @@ exports[`<html.*> prop polyfills global "inputMode" prop: "decimal" 1`] = `
 exports[`<html.*> prop polyfills global "inputMode" prop: "email" 1`] = `
 <TextInput
   inputMode="email"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1301,11 +1017,7 @@ exports[`<html.*> prop polyfills global "inputMode" prop: "email" 1`] = `
 exports[`<html.*> prop polyfills global "inputMode" prop: "numeric" 1`] = `
 <TextInput
   inputMode="numeric"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1319,11 +1031,7 @@ exports[`<html.*> prop polyfills global "inputMode" prop: "numeric" 1`] = `
 exports[`<html.*> prop polyfills global "inputMode" prop: "search" 1`] = `
 <TextInput
   inputMode="search"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1337,11 +1045,7 @@ exports[`<html.*> prop polyfills global "inputMode" prop: "search" 1`] = `
 exports[`<html.*> prop polyfills global "inputMode" prop: "tel" 1`] = `
 <TextInput
   inputMode="tel"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1355,11 +1059,7 @@ exports[`<html.*> prop polyfills global "inputMode" prop: "tel" 1`] = `
 exports[`<html.*> prop polyfills global "inputMode" prop: "url" 1`] = `
 <TextInput
   inputMode="url"
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1373,11 +1073,7 @@ exports[`<html.*> prop polyfills global "inputMode" prop: "url" 1`] = `
 exports[`<html.*> prop polyfills global "tabIndex" prop 1`] = `
 <TextInput
   focusable={false}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 1,
@@ -1391,11 +1087,7 @@ exports[`<html.*> prop polyfills global "tabIndex" prop 1`] = `
 exports[`<html.*> style polyfills "transition" properties  backgroundColor transition: end 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": {
@@ -1418,11 +1110,7 @@ exports[`<html.*> style polyfills "transition" properties  backgroundColor trans
 exports[`<html.*> style polyfills "transition" properties  backgroundColor transition: start 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": "rgba(0,0,0,0.1)",
@@ -1436,11 +1124,7 @@ exports[`<html.*> style polyfills "transition" properties  backgroundColor trans
 exports[`<html.*> style polyfills "transition" properties  cubic-bezier() timing function: end 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1463,11 +1147,7 @@ exports[`<html.*> style polyfills "transition" properties  cubic-bezier() timing
 exports[`<html.*> style polyfills "transition" properties  cubic-bezier() timing function: start 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1480,11 +1160,7 @@ exports[`<html.*> style polyfills "transition" properties  cubic-bezier() timing
 
 exports[`<html.*> style polyfills "transition" properties  default: default 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": "red",
@@ -1498,11 +1174,7 @@ exports[`<html.*> style polyfills "transition" properties  default: default 1`] 
 exports[`<html.*> style polyfills "transition" properties  opacity transition: end 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1525,11 +1197,7 @@ exports[`<html.*> style polyfills "transition" properties  opacity transition: e
 exports[`<html.*> style polyfills "transition" properties  opacity transition: start 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1545,11 +1213,7 @@ exports[`<html.*> style polyfills "transition" properties  other element types 1
 exports[`<html.*> style polyfills "transition" properties  other transforms: rotate 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1612,11 +1276,7 @@ exports[`<html.*> style polyfills "transition" properties  other transforms: rot
 exports[`<html.*> style polyfills "transition" properties  other transforms: scale 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1679,11 +1339,7 @@ exports[`<html.*> style polyfills "transition" properties  other transforms: sca
 exports[`<html.*> style polyfills "transition" properties  other transforms: skew 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1722,11 +1378,7 @@ exports[`<html.*> style polyfills "transition" properties  other transforms: ske
 exports[`<html.*> style polyfills "transition" properties  other transforms: translate 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1765,11 +1417,7 @@ exports[`<html.*> style polyfills "transition" properties  other transforms: tra
 exports[`<html.*> style polyfills "transition" properties  spring() timing function: end 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1792,11 +1440,7 @@ exports[`<html.*> style polyfills "transition" properties  spring() timing funct
 exports[`<html.*> style polyfills "transition" properties  spring() timing function: start 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1810,11 +1454,7 @@ exports[`<html.*> style polyfills "transition" properties  spring() timing funct
 exports[`<html.*> style polyfills "transition" properties  transform transition: end 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1853,11 +1493,7 @@ exports[`<html.*> style polyfills "transition" properties  transform transition:
 exports[`<html.*> style polyfills "transition" properties  transform transition: start 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1878,11 +1514,7 @@ exports[`<html.*> style polyfills "transition" properties  transform transition:
 exports[`<html.*> style polyfills "transition" properties  transition all properties (opacity and transform): end 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1943,11 +1575,7 @@ exports[`<html.*> style polyfills "transition" properties  transition all proper
 exports[`<html.*> style polyfills "transition" properties  transition all properties (opacity and transform): start 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1972,11 +1600,7 @@ exports[`<html.*> style polyfills "transition" properties  transition all proper
 exports[`<html.*> style polyfills "transition" properties  transition multiple properties: end 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": {
@@ -2014,11 +1638,7 @@ exports[`<html.*> style polyfills "transition" properties  transition multiple p
 exports[`<html.*> style polyfills "transition" properties  transition multiple properties: start 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": "red",
@@ -2038,11 +1658,7 @@ exports[`<html.*> style polyfills "transition" properties  transition multiple p
 exports[`<html.*> style polyfills "transition" properties  transition with missing properties 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2055,11 +1671,7 @@ exports[`<html.*> style polyfills "transition" properties  transition with missi
 exports[`<html.*> style polyfills "transition" properties  transition with missing properties 2`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2080,11 +1692,7 @@ exports[`<html.*> style polyfills "transition" properties  transition with missi
 exports[`<html.*> style polyfills "transition" properties  update triggers transition: green to blue 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": {
@@ -2107,11 +1715,7 @@ exports[`<html.*> style polyfills "transition" properties  update triggers trans
 exports[`<html.*> style polyfills "transition" properties  update triggers transition: red to green 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "backgroundColor": {
@@ -2134,11 +1738,7 @@ exports[`<html.*> style polyfills "transition" properties  update triggers trans
 exports[`<html.*> style polyfills "transition" properties  width transition: end 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2161,11 +1761,7 @@ exports[`<html.*> style polyfills "transition" properties  width transition: end
 exports[`<html.*> style polyfills "transition" properties  width transition: start 1`] = `
 <Animated.View
   animated={true}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2178,11 +1774,7 @@ exports[`<html.*> style polyfills "transition" properties  width transition: sta
 
 exports[`<html.*> style polyfills inherited styles 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderColor": "red",
@@ -2192,11 +1784,7 @@ exports[`<html.*> style polyfills inherited styles 1`] = `
   }
 >
   <ViewNativeComponent
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -2205,11 +1793,7 @@ exports[`<html.*> style polyfills inherited styles 1`] = `
     }
   >
     <Text
-      ref={
-        {
-          "current": null,
-        }
-      }
+      ref={[Function]}
       style={
         {
           "boxSizing": "content-box",
@@ -2235,11 +1819,7 @@ exports[`<html.*> style polyfills inherited styles 1`] = `
     </Text>
     <TextInput
       placeholder="Does not inherit text styles"
-      ref={
-        {
-          "current": null,
-        }
-      }
+      ref={[Function]}
       style={
         {
           "borderWidth": 1,
@@ -2254,11 +1834,7 @@ exports[`<html.*> style polyfills inherited styles 1`] = `
 
 exports[`<html.*> style polyfills inherited styles for auto-fix of raw strings 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2267,11 +1843,7 @@ exports[`<html.*> style polyfills inherited styles for auto-fix of raw strings 1
   }
 >
   <ViewNativeComponent
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -2297,11 +1869,7 @@ exports[`<html.*> style polyfills inherited styles for auto-fix of raw strings 1
 exports[`<html.*> style polyfills inherited themes 1`] = `
 [
   <Text
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "backgroundColor": "pink",
@@ -2314,11 +1882,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
     Expect color:red
   </Text>,
   <Text
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "backgroundColor": "pink",
@@ -2333,11 +1897,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
   <TextInput
     placeholder="Expect placeholderTextColor:green"
     placeholderTextColor="green"
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "borderWidth": 1,
@@ -2347,11 +1907,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
     }
   />,
   <ViewNativeComponent
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -2360,11 +1916,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
     }
   >
     <Text
-      ref={
-        {
-          "current": null,
-        }
-      }
+      ref={[Function]}
       style={
         {
           "backgroundColor": "pink",
@@ -2379,11 +1931,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
     <TextInput
       placeholder="Expect placeholderTextColor:green"
       placeholderTextColor="green"
-      ref={
-        {
-          "current": null,
-        }
-      }
+      ref={[Function]}
       style={
         {
           "borderWidth": 1,
@@ -2393,11 +1941,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
       }
     />
     <ViewNativeComponent
-      ref={
-        {
-          "current": null,
-        }
-      }
+      ref={[Function]}
       style={
         {
           "boxSizing": "content-box",
@@ -2406,11 +1950,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
       }
     >
       <Text
-        ref={
-          {
-            "current": null,
-          }
-        }
+        ref={[Function]}
         style={
           {
             "backgroundColor": "pink",
@@ -2425,11 +1965,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
       <TextInput
         placeholder="Expect placeholderTextColor:blue"
         placeholderTextColor="blue"
-        ref={
-          {
-            "current": null,
-          }
-        }
+        ref={[Function]}
         style={
           {
             "borderWidth": 1,
@@ -2441,11 +1977,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
     </ViewNativeComponent>
   </ViewNativeComponent>,
   <Text
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "backgroundColor": "pink",
@@ -2462,11 +1994,7 @@ exports[`<html.*> style polyfills inherited themes 1`] = `
 
 exports[`<html.*> style polyfills legacy: ThemeProvider 1`] = `
 <Text
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2482,11 +2010,7 @@ exports[`<html.*> style polyfills legacy: ThemeProvider 1`] = `
 exports[`<html.*> style polyfills lineClamp workaround for Android 1`] = `
 <Text
   numberOfLines={3}
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2501,11 +2025,7 @@ exports[`<html.*> style polyfills lineClamp workaround for Android 1`] = `
 
 exports[`<html.*> viewport width lengths are scaled according to viewport width: scaled lengths 1`] = `
 <ViewNativeComponent
-  ref={
-    {
-      "current": null,
-    }
-  }
+  ref={[Function]}
   style={
     {
       "borderWidth": 0.75,
@@ -2527,11 +2047,7 @@ exports[`<html.*> viewport width lengths are scaled according to viewport width:
   }
 >
   <Text
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -2544,11 +2060,7 @@ exports[`<html.*> viewport width lengths are scaled according to viewport width:
     Scaled content
   </Text>
   <Text
-    ref={
-      {
-        "current": null,
-      }
-    }
+    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -1563,6 +1563,20 @@ describe('<html.*>', () => {
     });
     */
 
+    // We shouldn't create a handle if there is no underlying node
+    test('node is null', () => {
+      act(() => {
+        create(
+          <html.input
+            ref={(node) => {
+              expect(() => node.getBoundingClientRect()).toThrow();
+            }}
+          />,
+          { createNodeMock: () => null }
+        );
+      });
+    });
+
     [
       'animate',
       'click',


### PR DESCRIPTION
We shouldn't create an object if the underlying node is null, as this handle is meant to emulate the node but can't proxy methods if none exist.