### PR TITLE
Add native support for `css.types.*` functions

### DIFF
--- a/apps/examples/src/components/App.js
+++ b/apps/examples/src/components/App.js
@@ -665,14 +665,14 @@ const animateSequence = css.keyframes({
 });
 
 const themedTokens = css.createTheme(tokens, {
-  squareColor: 'purple',
+  squareColor: css.types.color<string>('purple'),
   textColor: 'purple',
   inputColor: 'purple',
   inputPlaceholderColor: 'mediumpurple'
 });
 
 const themedTokensAlt = css.createTheme(tokens, {
-  squareColor: 'darkorange',
+  squareColor: css.types.color<string>('darkorange'),
   textColor: 'darkorange',
   inputColor: 'orangered',
   inputPlaceholderColor: 'orange'

--- a/apps/examples/src/components/tokens.stylex.js
+++ b/apps/examples/src/components/tokens.stylex.js
@@ -7,19 +7,19 @@
  * @flow strict-local
  */
 
-import type { StyleVars } from 'react-strict-dom';
+import type { StyleVars, StyleTypes } from 'react-strict-dom';
 
 import { css } from 'react-strict-dom';
 
 export const tokens: StyleVars<
   $ReadOnly<{
-    squareColor: string,
+    squareColor: StyleTypes.Color<string>,
     textColor: string,
     inputColor: string,
     inputPlaceholderColor: string
   }>
 > = css.defineVars({
-  squareColor: 'red',
+  squareColor: css.types.color<string>('red'),
   textColor: {
     default: 'darkred',
     '@media (prefers-color-scheme: dark)': 'lightred'

--- a/packages/react-strict-dom/src/native/css/index.js
+++ b/packages/react-strict-dom/src/native/css/index.js
@@ -512,3 +512,78 @@ export function props(
 
   return nativeProps;
 }
+
+type ValueWithDefault<+T> =
+  | T
+  | $ReadOnly<{
+      default: ValueWithDefault<T>,
+      [string]: ValueWithDefault<T>
+    }>;
+
+export const types = {
+  angle: <T: string | 0 = string | 0>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  color: <T: string = string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  image: <T: string = string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  integer: <T: number | string = number | string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  length: <T: number | string = number | string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  lengthPercentage: <T: number | string = number | string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  number: <T: number | string = number | string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  percentage: <T: number | string = number | string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  resolution: <T: string = string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  time: <T: string | 0 = string | 0>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  transformFunction: <T: string = string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  transformList: <T: string = string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  },
+  url: <T: string = string>(
+    value: ValueWithDefault<T>
+  ): ValueWithDefault<T> => {
+    return value;
+  }
+};

--- a/packages/react-strict-dom/src/native/index.js
+++ b/packages/react-strict-dom/src/native/index.js
@@ -12,6 +12,7 @@ import type {
   StyleXStylesWithout,
   StaticStyles,
   Theme,
+  Types,
   VarGroup
 } from '@stylexjs/stylex';
 
@@ -24,19 +25,12 @@ import * as _css from './css';
 import { ProvideCustomProperties } from './modules/ContextCustomProperties';
 import { ProvideViewportScale } from './modules/ContextViewportScale';
 
-type StyleTheme<V, T> = Theme<V, T>;
-type StyleVars<T> = VarGroup<T>;
-type Styles<T> = StyleXStyles<T>;
-type StylesWithout<T> = StyleXStylesWithout<T>;
-
 type ProviderValue = $ReadOnly<{ [string]: string | number }>;
 
 type ProviderProps = $ReadOnly<{
   children: React.Node,
   customProperties: ProviderValue
 }>;
-
-export type { StaticStyles, StyleTheme, StyleVars, Styles, StylesWithout };
 
 function ThemeProvider(props: ProviderProps): React.Node {
   const { children, customProperties } = props;
@@ -55,5 +49,12 @@ const contexts = {
 
 // Export using StyleX types as the shim has divergent types internally.
 const css: TStyleX = _css as $FlowFixMe;
+
+export type { StaticStyles };
+export type { StyleXStyles as Styles };
+export type { StyleXStylesWithout as StylesWithout };
+export type { Theme as StyleTheme };
+export type { Types as StyleTypes };
+export type { VarGroup as StyleVars };
 
 export { compat, contexts, css, html };

--- a/packages/react-strict-dom/src/types/styles.js
+++ b/packages/react-strict-dom/src/types/styles.js
@@ -12,7 +12,8 @@ import type {
   StyleXArray,
   StyleXStyles,
   Theme,
-  VarGroup
+  VarGroup,
+  Types
 } from '@stylexjs/stylex';
 
 import typeof * as TStyleX from '@stylexjs/stylex';
@@ -37,3 +38,4 @@ export type IStyleX = $ReadOnly<{
 
 export type MutableCustomProperties = { [string]: mixed };
 export type CustomProperties = $ReadOnly<MutableCustomProperties>;
+export type { Types };

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -1,5 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`css.types.* types.angle: tokens 1`] = `
+{
+  "angle": "var(--angle__id__6)",
+}
+`;
+
+exports[`css.types.* types.color: tokens 1`] = `
+{
+  "color": "var(--color__id__7)",
+}
+`;
+
+exports[`css.types.* types.image: tokens 1`] = `
+{
+  "image": "var(--image__id__8)",
+}
+`;
+
+exports[`css.types.* types.integer: tokens 1`] = `
+{
+  "integer": "var(--integer__id__9)",
+}
+`;
+
+exports[`css.types.* types.length: tokens 1`] = `
+{
+  "length": "var(--length__id__10)",
+}
+`;
+
+exports[`css.types.* types.lengthPercentage: tokens 1`] = `
+{
+  "lengthPercentage": "var(--lengthPercentage__id__11)",
+}
+`;
+
+exports[`css.types.* types.number: tokens 1`] = `
+{
+  "number": "var(--number__id__12)",
+}
+`;
+
+exports[`css.types.* types.percentage: tokens 1`] = `
+{
+  "percentage": "var(--percentage__id__13)",
+}
+`;
+
+exports[`css.types.* types.resolution: tokens 1`] = `
+{
+  "resolution": "var(--resolution__id__14)",
+}
+`;
+
+exports[`css.types.* types.time: tokens 1`] = `
+{
+  "time": "var(--time__id__15)",
+}
+`;
+
+exports[`css.types.* types.transformFunction: tokens 1`] = `
+{
+  "transformFunction": "var(--transformFunction__id__16)",
+}
+`;
+
+exports[`css.types.* types.url: tokens 1`] = `
+{
+  "url": "var(--url__id__17)",
+}
+`;
+
 exports[`properties: custom property css.createTheme: css.__customProperties 1`] = `
 {
   "rootColor__id__1": "red",

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -1841,3 +1841,92 @@ describe('queries: @media', () => {
     expect(props.style.color).toBe('white');
   });
 });
+
+describe('css.types.*', () => {
+  test('types.angle', () => {
+    const tokens = css.defineVars({
+      angle: css.types.angle('40deg')
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.color', () => {
+    const tokens = css.defineVars({
+      color: css.types.color({
+        default: 'blue',
+        '@media (prefers-color-scheme: dark)': 'lightblue'
+      })
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.image', () => {
+    const tokens = css.defineVars({
+      image: css.types.image('./jpg')
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.integer', () => {
+    const tokens = css.defineVars({
+      integer: css.types.integer(4)
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.length', () => {
+    const tokens = css.defineVars({
+      length: css.types.length('4px')
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.lengthPercentage', () => {
+    const tokens = css.defineVars({
+      lengthPercentage: css.types.lengthPercentage('100%')
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.number', () => {
+    const tokens = css.defineVars({
+      number: css.types.number(4.4)
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.percentage', () => {
+    const tokens = css.defineVars({
+      percentage: css.types.percentage('100%')
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.resolution', () => {
+    const tokens = css.defineVars({
+      resolution: css.types.resolution('96dpi')
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.time', () => {
+    const tokens = css.defineVars({
+      time: css.types.time('1s')
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.transformFunction', () => {
+    const tokens = css.defineVars({
+      transformFunction: css.types.transformFunction('translateX(10px)')
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+
+  test('types.url', () => {
+    const tokens = css.defineVars({
+      url: css.types.url('https://foobar.com')
+    });
+    expect(tokens).toMatchSnapshot('tokens');
+  });
+});


### PR DESCRIPTION
These functions pass the value straight through on native.

Fix #331
Ref #337