### PR TITLE
Bugfix: Opacity tokens are making elements invisible on mobile

### DIFF
--- a/packages/react-strict-dom/src/native/css/processStyle.js
+++ b/packages/react-strict-dom/src/native/css/processStyle.js
@@ -110,12 +110,12 @@ export function processStyle(
         result[propName] = 0;
         continue;
       }
+      // Polyfill support for custom property references (do this first)
       if (stringContainsVariables(styleValue)) {
-        // Polyfill support for custom property references (do this first)
         result[propName] = CSSUnparsedValue.parse(propName, styleValue);
         continue;
+      // Polyfill support for string opacity on Android
       } else if (propName === 'opacity') {
-        // Polyfill support for string opacity on Android
         result[propName] = parseFloat(styleValue);
         continue;
       } else if (


### PR DESCRIPTION
# Bug 🐞: Opacity tokens are converted to NaN on mobile
## Description
When using opacity values specified in tokens
```
const tokens = stylex.defineVars({
  disabledOpacity: '0.25',
})
```
the elements on mobile become invisible:
<img width="376" height="68" alt="image" src="https://github.com/user-attachments/assets/0eaa12ec-bd2f-4be2-b51e-a32949349712" />

## Bug cause
During the fix of https://github.com/facebook/react-strict-dom/issues/312 the if statement was added to convert opacity tokens value from string to number by invoking `parseFloat` on the style value.

However this branch does not consider that style value can be an unprocessed variable and fails in cases where styleValue must be parsed with `CSSUnparsedValue.parse` beforehand. It results in `NaN` value set to opacity style and makes element invisible.
<img width="608" height="145" alt="image" src="https://github.com/user-attachments/assets/b4297f49-73e8-4758-9dcc-b2252e5be2ae" />

## Solution
Change the order of checks, to have `if (stringContainsVariables(styleValue))` branch on first place.