### PR TITLE
Add error messages for styles that only work on flex children

### DIFF
--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -17,7 +17,7 @@ import { ProvideCustomProperties } from './ContextCustomProperties';
 import { ProvideDisplayInside, useDisplayInside } from './ContextDisplayInside';
 import { ProvideInheritedStyles } from './ContextInheritedStyles';
 import { TextString } from './TextString';
-import { warnMsg } from '../../shared/logUtils';
+import { errorMsg } from '../../shared/logUtils';
 import { useNativeProps } from './useNativeProps';
 import { useStrictDOMElement } from './useStrictDOMElement';
 
@@ -99,14 +99,18 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       const displayValue = nativeProps.style.display;
 
       if (__DEV__) {
-        if (
-          displayValue != null &&
-          displayValue !== 'flex' &&
-          displayValue !== 'none' &&
-          displayValue !== 'block'
-        ) {
-          warnMsg(
-            `unsupported style value in "display:${String(displayValue)}"`
+        const nativeStyle = nativeProps.style;
+        if (displayInsideValue !== 'flex') {
+          // Error message if the element is not a flex child but tries to use flex
+          ['flex', 'flexBasis', 'flexGrow', 'flexShrink'].forEach(
+            (styleProp) => {
+              const value = nativeStyle[styleProp];
+              if (value != null) {
+                errorMsg(
+                  `"display:flex" is required on the parent for "${styleProp}" to have an effect.`
+                );
+              }
+            }
           );
         }
       }
@@ -133,7 +137,7 @@ export function createStrictDOMComponent<T, P: StrictProps>(
       }
 
       if (displayInsideValue === 'flex') {
-        // flex child should not shrink
+        // flex child should not shrink by default
         nativeProps.style.flexShrink ??= 1;
       }
 

--- a/packages/react-strict-dom/src/native/modules/useNativeProps.js
+++ b/packages/react-strict-dom/src/native/modules/useNativeProps.js
@@ -167,16 +167,6 @@ export function useNativeProps(
   });
 
   const displayValue = nativeProps.style.display;
-  if (__DEV__) {
-    if (
-      displayValue != null &&
-      displayValue !== 'flex' &&
-      displayValue !== 'none' &&
-      displayValue !== 'block'
-    ) {
-      warnMsg(`unsupported style value in "display:${String(displayValue)}"`);
-    }
-  }
   // 'hidden' polyfill (only if "display" is not set)
   if (displayValue == null && hidden && hidden !== 'until-found') {
     nativeProps.style.display = 'none';

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -266,15 +266,11 @@ describe('properties: general', () => {
     });
     css.props.call(mockOptions, [styles.flex, styles.align]);
     expect(console.error).not.toHaveBeenCalledWith(
-      expect.stringContaining(
-        '"display:flex" is required to use flexbox properties'
-      )
+      expect.stringContaining('"display:flex" is required')
     );
     css.props.call(mockOptions, [styles.align, styles.row]);
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(
-        '"display:flex" is required to use flexbox properties'
-      )
+      expect.stringContaining('"display:flex" is required')
     );
   });
 

--- a/packages/react-strict-dom/tests/html-test.native.js
+++ b/packages/react-strict-dom/tests/html-test.native.js
@@ -89,6 +89,55 @@ describe('<html.*>', () => {
     expect(root.toJSON()).toMatchSnapshot('block layout override of flex');
   });
 
+  [
+    'alignContent',
+    'alignItems',
+    'columnGap',
+    'flexDirection',
+    'flexWrap',
+    'gap',
+    'justifyContent',
+    'rowGap'
+  ].forEach((styleProp) => {
+    test(`block layout error: "${styleProp}"`, () => {
+      const styles = css.create({
+        root: {
+          [styleProp]: 'center'
+        }
+      });
+      act(() => {
+        create(<html.div style={styles.root} />);
+      });
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `"display:flex" is required for "${styleProp}" to have an effect.`
+        )
+      );
+    });
+  });
+
+  ['flex', 'flexBasis', 'flexGrow', 'flexShrink'].forEach((styleProp) => {
+    test(`block layout error for flex child: "${styleProp}"`, () => {
+      const styles = css.create({
+        root: {
+          [styleProp]: 1
+        }
+      });
+      act(() => {
+        create(
+          <html.div>
+            <html.div style={styles.root} />
+          </html.div>
+        );
+      });
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `"display:flex" is required on the parent for "${styleProp}" to have an effect.`
+        )
+      );
+    });
+  });
+
   test('auto-wraps raw strings', () => {
     const styles = css.create({
       root: {


### PR DESCRIPTION
These messages will help developers on native to know when styles will have no effect on web because they only work on flex children, but the parent is not a flex container. On native, the styles will work because all elements are `display:flex`, but this is not the case on web.

The messages are based on those provided by Chrome DevTools