### PR TITLE
Change the accepted values of `<compat.native>` prop `as`

### DIFF
--- a/packages/react-strict-dom/src/native/compat.js
+++ b/packages/react-strict-dom/src/native/compat.js
@@ -40,7 +40,7 @@ const defaultProps = {};
 
 type StrictPropsOnlyCompat<T> = {
   ...StrictProps,
-  as?: 'image' | 'input' | 'text' | 'textarea' | 'view',
+  as?: 'div' | 'img' | 'input' | 'span' | 'textarea',
   children: (nativeProps: T) => React.Node
 };
 
@@ -58,15 +58,15 @@ component Native<T>(...htmlProps: StrictPropsOnlyCompat<T>) {
     );
   }
   let Component = Strict;
-  if (as === 'image') {
+  if (as === 'img') {
     Component = StrictImage;
   } else if (as === 'input') {
     Component = StrictInput;
-  } else if (as === 'text') {
+  } else if (as === 'span') {
     Component = StrictText;
   } else if (as === 'textarea') {
     Component = StrictTextArea;
-  } else if (as === 'view') {
+  } else if (as === 'div') {
     Component = Strict;
   }
 

--- a/packages/react-strict-dom/tests/__snapshots__/compat-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/compat-test.native.js.snap-native
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<compat.native> "as" equals "image": as=image 1`] = `
+exports[`<compat.native> "as" equals "div": as=div 1`] = `
+<View
+  accessibilityLabel="label"
+  ref={[Function]}
+  style={
+    {
+      "boxSizing": "content-box",
+      "paddingHorizontal": 32,
+      "position": "static",
+    }
+  }
+/>
+`;
+
+exports[`<compat.native> "as" equals "img": as=img 1`] = `
 <Image
   accessibilityLabel="label"
   ref={[Function]}
@@ -30,7 +44,7 @@ exports[`<compat.native> "as" equals "input": as=input 1`] = `
 />
 `;
 
-exports[`<compat.native> "as" equals "text": as=text 1`] = `
+exports[`<compat.native> "as" equals "span": as=span 1`] = `
 <Text
   accessibilityLabel="label"
   numberOfLines={3}
@@ -55,20 +69,6 @@ exports[`<compat.native> "as" equals "textarea": as=textarea 1`] = `
   style={
     {
       "boxSizing": "content-box",
-      "position": "static",
-    }
-  }
-/>
-`;
-
-exports[`<compat.native> "as" equals "view": as=view 1`] = `
-<View
-  accessibilityLabel="label"
-  ref={[Function]}
-  style={
-    {
-      "boxSizing": "content-box",
-      "paddingHorizontal": 32,
       "position": "static",
     }
   }

--- a/packages/react-strict-dom/tests/compat-test.native.js
+++ b/packages/react-strict-dom/tests/compat-test.native.js
@@ -57,7 +57,27 @@ describe('<compat.native>', () => {
     expect(root.toJSON()).toMatchSnapshot('default');
   });
 
-  test('"as" equals "image"', () => {
+  test('"as" equals "div"', () => {
+    const styles = css.create({
+      view: {
+        paddingInline: '2rem'
+      }
+    });
+
+    let root;
+    act(() => {
+      root = create(
+        <compat.native as="div" style={styles.view}>
+          {(nativeProps) => (
+            <View {...nativeProps} accessibilityLabel="label" />
+          )}
+        </compat.native>
+      );
+    });
+    expect(root.toJSON()).toMatchSnapshot('as=div');
+  });
+
+  test('"as" equals "img"', () => {
     const styles = css.create({
       image: {
         aspectRatio: '16/9'
@@ -67,18 +87,14 @@ describe('<compat.native>', () => {
     let root;
     act(() => {
       root = create(
-        <compat.native
-          as="image"
-          srcSet="1x.img, 2x.img 2x"
-          style={styles.image}
-        >
+        <compat.native as="img" srcSet="1x.img, 2x.img 2x" style={styles.image}>
           {(nativeProps) => (
             <Image {...nativeProps} accessibilityLabel="label" />
           )}
         </compat.native>
       );
     });
-    expect(root.toJSON()).toMatchSnapshot('as=image');
+    expect(root.toJSON()).toMatchSnapshot('as=img');
   });
 
   test('"as" equals "input"', () => {
@@ -103,7 +119,7 @@ describe('<compat.native>', () => {
     expect(root.toJSON()).toMatchSnapshot('as=input');
   });
 
-  test('"as" equals "text"', () => {
+  test('"as" equals "span"', () => {
     const styles = css.create({
       text: {
         color: 'blue',
@@ -114,14 +130,14 @@ describe('<compat.native>', () => {
     let root;
     act(() => {
       root = create(
-        <compat.native as="text" style={styles.text}>
+        <compat.native as="span" style={styles.text}>
           {(nativeProps) => (
             <Text {...nativeProps} accessibilityLabel="label" />
           )}
         </compat.native>
       );
     });
-    expect(root.toJSON()).toMatchSnapshot('as=text');
+    expect(root.toJSON()).toMatchSnapshot('as=span');
   });
 
   test('"as" equals "textarea"', () => {
@@ -140,26 +156,6 @@ describe('<compat.native>', () => {
       );
     });
     expect(root.toJSON()).toMatchSnapshot('as=textarea');
-  });
-
-  test('"as" equals "view"', () => {
-    const styles = css.create({
-      view: {
-        paddingInline: '2rem'
-      }
-    });
-
-    let root;
-    act(() => {
-      root = create(
-        <compat.native as="view" style={styles.view}>
-          {(nativeProps) => (
-            <View {...nativeProps} accessibilityLabel="label" />
-          )}
-        </compat.native>
-      );
-    });
-    expect(root.toJSON()).toMatchSnapshot('as=view');
   });
 
   test('nested', () => {


### PR DESCRIPTION
This prop previously mixed the semantics of web and native in the accepted values. Now the values match the tag names on web, and indicate the equivalent `html.*` functional role that the compat.native component performs. LLMs have a better success rate using this API after this change. So it was likely somewhat confusing for people too.