### PR TITLE
Add native polyfill for willChange

### DIFF
--- a/packages/react-strict-dom/src/native/css/index.js
+++ b/packages/react-strict-dom/src/native/css/index.js
@@ -469,6 +469,12 @@ export function props(
       nextStyle.alignContent ??= styleValue;
       nextStyle.justifyContent ??= styleValue;
     }
+    // willChange polyfill
+    else if (styleProp === 'willChange') {
+      if (typeof styleValue === 'string' && styleValue !== 'auto') {
+        nativeProps.renderToHardwareTextureAndroid = true;
+      }
+    }
     // Everything else
     else {
       nextStyle[styleProp] = styleValue;

--- a/packages/react-strict-dom/src/native/css/isAllowedStyleKey.js
+++ b/packages/react-strict-dom/src/native/css/isAllowedStyleKey.js
@@ -156,6 +156,7 @@ const allowedStyleKeySet = new Set<string>([
   'verticalAlign', // Android Only
   'visibility',
   'width',
+  'willChange', // Android Only
   'zIndex',
   // Object-value keys
   'default',

--- a/packages/react-strict-dom/src/types/renderer.native.js
+++ b/packages/react-strict-dom/src/types/renderer.native.js
@@ -110,6 +110,7 @@ type ReactNativeProps = {
   ref?: $FlowFixMe,
   referrerPolicy?: ImageProps['referrerPolicy'],
   role?: ?string,
+  renderToHardwareTextureAndroid?: ViewProps['renderToHardwareTextureAndroid'],
   secureTextEntry?: TextInputProps['secureTextEntry'],
   spellCheck?: TextInputProps['spellCheck'],
   src?: ImageProps['src'],

--- a/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
+++ b/packages/react-strict-dom/tests/__snapshots__/css-test.native.js.snap-native
@@ -773,6 +773,13 @@ exports[`properties: general visibility: visible 1`] = `
 }
 `;
 
+exports[`properties: general willChange 1`] = `
+{
+  "renderToHardwareTextureAndroid": true,
+  "style": {},
+}
+`;
+
 exports[`properties: logical direction blockSize: blockSize 1`] = `
 {
   "style": {

--- a/packages/react-strict-dom/tests/css-test.native.js
+++ b/packages/react-strict-dom/tests/css-test.native.js
@@ -775,6 +775,15 @@ describe('properties: general', () => {
       'visible'
     );
   });
+
+  test('willChange', () => {
+    const styles = css.create({
+      root: {
+        willChange: 'transform'
+      }
+    });
+    expect(css.props.call(mockOptions, styles.root)).toMatchSnapshot();
+  });
 });
 
 /**


### PR DESCRIPTION
Add native polyfill for willChange

At least on RN Android there's a specific prop, `renderToHardwareTextureAndroid`, that promotes an RN view to a GPU layer which is almost exactly the same responsibility of the web's `will-change` CSS property so this diff maps the two properties together.
