### PR TITLE
Fix useCSSLayers option plugin for @stylexjs/babel-plugin@0.14

### DIFF
--- a/packages/postcss-react-strict-dom/src/bundler.js
+++ b/packages/postcss-react-strict-dom/src/bundler.js
@@ -58,9 +58,7 @@ module.exports = function createBundler() {
   function bundle({ useCSSLayers }) {
     const rules = Array.from(styleXRulesMap.values()).flat();
 
-    const css = stylexBabelPlugin.processStylexRules(rules, {
-      useLayers: useCSSLayers
-    });
+    const css = stylexBabelPlugin.processStylexRules(rules, useCSSLayers);
 
     return css;
   }


### PR DESCRIPTION
The version currently depended upon doesn't support an options object.

See #401