### PR TITLE
Include useCSSLayers in react-strict-dom/postcss-plugin

### DIFF
--- a/packages/react-strict-dom/postcss/plugin.js
+++ b/packages/react-strict-dom/postcss/plugin.js
@@ -13,13 +13,15 @@ const plugin = ({
   // Use `babelrc: false` to disable this behavior.
   babelConfig = {},
   include,
-  exclude
+  exclude,
+  useCSSLayers = true
 }) => {
   return postcssPlugin({
     cwd,
     babelConfig,
     include,
-    exclude
+    exclude,
+    useCSSLayers
   });
 };
 


### PR DESCRIPTION
Allows setting `useCSSLayers` from `react-strict-dom/postcss-plugin`

See #403