### PR TITLE
Allow implicit js or ts extensions

### DIFF
--- a/packages/react-strict-dom/babel/preset.js
+++ b/packages/react-strict-dom/babel/preset.js
@@ -34,7 +34,7 @@ function reactStrictPreset(_, options = {}) {
         styleResolution: 'property-specificity',
         unstable_moduleResolution: {
           rootDir: process.cwd(),
-          themeFileExtension: '.css.js',
+          themeFileExtension: '.css',
           type: 'commonJS'
         }
       }


### PR DESCRIPTION
Allows `.js` or `.ts` extensions implicitly in the way it did before `.stylex.js`/`.stylex.ts` was changed to `.css.js`/`.css.ts`.

Issue #405