### PR TITLE
Update StyleX packages to 0.15.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8555,32 +8555,6 @@
         "micromark-util-symbol": "^1.0.1"
       }
     },
-    "node_modules/@stylexjs/babel-plugin": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@stylexjs/babel-plugin/-/babel-plugin-0.14.1.tgz",
-      "integrity": "sha512-K7KzSfdFaWKJqZztR0haXowu3lmc0RXDTWIAKBADOChEEw0Z08e8FD3C97NHAHCktgsSc/bCe85g+wmu9a4xuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.26.8",
-        "@babel/helper-module-imports": "^7.25.9",
-        "@babel/traverse": "^7.26.8",
-        "@babel/types": "^7.26.8",
-        "@dual-bundle/import-meta-resolve": "^4.1.0",
-        "@stylexjs/stylex": "0.14.1",
-        "postcss-value-parser": "^4.1.0"
-      }
-    },
-    "node_modules/@stylexjs/stylex": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@stylexjs/stylex/-/stylex-0.14.1.tgz",
-      "integrity": "sha512-UlAGhGUHTqZoMThHdpLUFhO0fjWxJ3VDFRsGK0mNwCD4IEe2EPkIjtZTjHZepidDAbUcNoXlTQoK/y1fcd5f/w==",
-      "license": "MIT",
-      "dependencies": {
-        "css-mediaquery": "^0.1.2",
-        "invariant": "^2.2.4",
-        "styleq": "0.2.1"
-      }
-    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -34248,13 +34222,39 @@
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.26.8",
-        "@stylexjs/babel-plugin": "^0.14.1",
+        "@stylexjs/babel-plugin": "^0.15.4",
         "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3"
       },
       "peerDependencies": {
         "postcss": "^8.4.49"
+      }
+    },
+    "packages/postcss-react-strict-dom/node_modules/@stylexjs/babel-plugin": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@stylexjs/babel-plugin/-/babel-plugin-0.15.4.tgz",
+      "integrity": "sha512-QfL2j3VCU+KTyIEoPBhdwq8KW1Gv0FVvwSzfjjdQ0J2Ei/DJBx2AXVsDYzBcVw0WI+KsEfQUHFZ1Fk2t1U/9Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.26.8",
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/traverse": "^7.26.8",
+        "@babel/types": "^7.26.8",
+        "@dual-bundle/import-meta-resolve": "^4.1.0",
+        "@stylexjs/stylex": "0.15.4",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "packages/postcss-react-strict-dom/node_modules/@stylexjs/stylex": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@stylexjs/stylex/-/stylex-0.15.4.tgz",
+      "integrity": "sha512-UQT75p3qxwCIsVpH87YfgHvzWGDyMbQcFKhguj4noBZCc+npEh5h7J4BIHMgrxpyJa9mislLfXv+M5TmP2YH5A==",
+      "license": "MIT",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2",
+        "invariant": "^2.2.4",
+        "styleq": "0.2.1"
       }
     },
     "packages/postcss-react-strict-dom/node_modules/glob-parent": {
@@ -34274,8 +34274,8 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.24.7",
-        "@stylexjs/babel-plugin": "^0.14.1",
-        "@stylexjs/stylex": "^0.14.1",
+        "@stylexjs/babel-plugin": "^0.15.4",
+        "@stylexjs/stylex": "^0.15.4",
         "postcss-react-strict-dom": "0.0.53",
         "postcss-value-parser": "^4.1.0",
         "styleq": "^0.2.1"
@@ -34299,6 +34299,32 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-native": ">=0.79.5"
+      }
+    },
+    "packages/react-strict-dom/node_modules/@stylexjs/babel-plugin": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@stylexjs/babel-plugin/-/babel-plugin-0.15.4.tgz",
+      "integrity": "sha512-QfL2j3VCU+KTyIEoPBhdwq8KW1Gv0FVvwSzfjjdQ0J2Ei/DJBx2AXVsDYzBcVw0WI+KsEfQUHFZ1Fk2t1U/9Iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.26.8",
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/traverse": "^7.26.8",
+        "@babel/types": "^7.26.8",
+        "@dual-bundle/import-meta-resolve": "^4.1.0",
+        "@stylexjs/stylex": "0.15.4",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "packages/react-strict-dom/node_modules/@stylexjs/stylex": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/@stylexjs/stylex/-/stylex-0.15.4.tgz",
+      "integrity": "sha512-UQT75p3qxwCIsVpH87YfgHvzWGDyMbQcFKhguj4noBZCc+npEh5h7J4BIHMgrxpyJa9mislLfXv+M5TmP2YH5A==",
+      "license": "MIT",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2",
+        "invariant": "^2.2.4",
+        "styleq": "0.2.1"
       }
     },
     "packages/scripts": {

--- a/packages/postcss-react-strict-dom/package.json
+++ b/packages/postcss-react-strict-dom/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.26.8",
-    "@stylexjs/babel-plugin": "^0.14.1",
+    "@stylexjs/babel-plugin": "^0.15.4",
     "fast-glob": "^3.3.2",
     "glob-parent": "^6.0.2",
     "is-glob": "^4.0.3"

--- a/packages/react-strict-dom/package.json
+++ b/packages/react-strict-dom/package.json
@@ -38,8 +38,8 @@
   },
   "dependencies": {
     "@babel/helper-module-imports": "^7.24.7",
-    "@stylexjs/babel-plugin": "^0.14.1",
-    "@stylexjs/stylex": "^0.14.1",
+    "@stylexjs/babel-plugin": "^0.15.4",
+    "@stylexjs/stylex": "^0.15.4",
     "postcss-value-parser": "^4.1.0",
     "postcss-react-strict-dom": "0.0.53",
     "styleq": "^0.2.1"


### PR DESCRIPTION
Update StyleX packages to 0.15.4.

Resolves an issue with the postcss plugin expecting a newer function signature: #401