### PR TITLE
docs: Remove cacheDirectory from babelLoader config in Next.js instructions

### DIFF
--- a/packages/website/docs/learn/environment-setup/02-next.md
+++ b/packages/website/docs/learn/environment-setup/02-next.md
@@ -26,7 +26,6 @@ Babel is not the default compiler when using Next.js App Router, but it can stil
 const dev = process.env.NODE_ENV !== 'production'
 
 const config = {
-  cacheDirectory: true,
   parserOpts: {
     plugins: ['typescript', 'jsx'],
   },


### PR DESCRIPTION
I removed that in #383 but it was skipped somehow.  We discussed about this and this option doesn't seems to work with current babel-loader version (cf https://github.com/facebook/react-strict-dom/pull/383#issuecomment-3246341833)

Ref https://github.com/facebook/react-strict-dom/issues/382#issuecomment-3360648342