### PR TITLE
Export StrictClickEvent type from StrictReactDOMProps

### DIFF
--- a/packages/react-strict-dom/src/types/StrictReactDOMProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMProps.js
@@ -173,7 +173,7 @@ type SyntheticEvent<+T> = $ReadOnly<{|
 |}>;
 */
 
-type StrictClickEvent = $ReadOnly<{|
+export type StrictClickEvent = $ReadOnly<{|
   altKey: boolean,
   button: number,
   ctrlKey: boolean,


### PR DESCRIPTION
This is useful when defining a callback, at least for typescript (otherwise, you need to redefined explicitly the type that match what a onClick could expect).