### PR TITLE
Fallback to unstable_getBoundingClientRect if available

### DIFF
--- a/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
+++ b/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
@@ -67,7 +67,8 @@ function getOrCreateStrictRef(
       const scale = (number: number) => number / viewportScale;
 
       // Override getBoundingClientRect for viewport-scaling
-      const getBoundingClientRect = node?.getBoundingClientRect;
+      const getBoundingClientRect = 
+        node?.getBoundingClientRect ?? node?.unstable_getBoundingClientRect;
       if (getBoundingClientRect) {
         // $FlowFixMe[prop-missing]
         Object.defineProperty(strictRef, 'getBoundingClientRect', {


### PR DESCRIPTION
This was recently changed as part of the refactoring of https://github.com/facebook/react-strict-dom/commit/74562f4ac4553bac3c185410aae4c43ff16a0c06#diff-bcc5857af5fe29c6679b5afaf39db7eed5fc74a15ab118691ee8c13c5954b70eL75

this implicitly binds react-strict-dom to require at least react-native 0.82.

Is that intentional?

Is there a place where the minimum required version is explicitly listed?

In that case, then maybe was just forgotten to update the peer dependency here: https://github.com/facebook/react-strict-dom/blob/main/packages/react-strict-dom/package.json#L62

Feel free to close in case, and treat this PR as a small question with a code snippet