### PR TITLE
Add onPointerLeave handler to active state polyfill

### DIFF
--- a/packages/react-strict-dom/src/native/modules/usePseudoStates.js
+++ b/packages/react-strict-dom/src/native/modules/usePseudoStates.js
@@ -79,6 +79,7 @@ export function usePseudoStates(style: Style): Interaction {
         value.onPointerCancel = () => setActive(false);
         value.onPointerDown = () => setActive(true);
         value.onPointerUp = () => setActive(false);
+        value.onPointerLeave = () => setActive(false);
       }
     }
     return value;

--- a/packages/react-strict-dom/src/native/modules/usePseudoStates.js
+++ b/packages/react-strict-dom/src/native/modules/usePseudoStates.js
@@ -69,7 +69,6 @@ export function usePseudoStates(style: Style): Interaction {
         value.onMouseEnter = () => setMouseHover(true);
         value.onMouseLeave = () => setMouseHover(false);
         value.onPointerEnter = () => setPointerHover(true);
-        value.onPointerLeave = () => setPointerHover(false);
       }
       if (isFocusStyledElement) {
         value.onBlur = () => setFocus(false);
@@ -79,7 +78,16 @@ export function usePseudoStates(style: Style): Interaction {
         value.onPointerCancel = () => setActive(false);
         value.onPointerDown = () => setActive(true);
         value.onPointerUp = () => setActive(false);
-        value.onPointerLeave = () => setActive(false);
+      }
+      if (isHoverStyledElement || isActiveStyledElement) {
+        value.onPointerLeave = () => {
+          if (isHoverStyledElement) {
+            setPointerHover(false);
+          }
+          if (isActiveStyledElement) {
+            setActive(false);
+          }
+        }
       }
     }
     return value;


### PR DESCRIPTION
### Current state
on native devices when an interactive element is styled with `:active`, if the finger is pressed and then dragged out of the element without lifting, the element keep showing the active state.

### Expected behavior
The active state should not be applied when moving out of the element

### Why?
while on a desktop environment using a mouse or other fine pointing device the active state is actually preserved when moving out until the pointer is lifted; on mobile browsers (and the expectations on native apps) the active state is removed as soon as the element is not hovered anymore.

### What do the specs say?
It's not too clear to me: https://html.spec.whatwg.org/multipage/semantics-other.html#concept-selector-active

"An element is said to be being actively pointed at while the user indicates the element using a pointing device while that pointing device is in the "down" state (e.g. for a mouse, between the time the mouse button is pressed and the time it is released; for a finger in a multitouch environment, while the finger is touching the display surface)."

This can be interpreted in different ways, but I assume the "being actively pointed at" can be interpreded in a way that justifies the observed behavior on mobile browsers, and in the proposed approach I'm opting to be closer to that behavior, considering that the persistence of active states when dragging out on native apps is often perceived as a bug as well.
That being said, I'm not sure why on desktop using a mouse the state is actually preserved when moving the pointer out, as in theory it would not be "actively pointed at" anymore...

**Question:** do we also need to include `onMouseLeave`? In theory pointer events should cover that as well, but I noticed mouse enter/leave are used on top of theme for the hover use case, what was the reason for that?