### PR TITLE
fix: remove fontScale from CSS relative units to prevent double scaling

### DIFF
--- a/packages/react-strict-dom/src/native/css/CSSLengthUnitValue.js
+++ b/packages/react-strict-dom/src/native/css/CSSLengthUnitValue.js
@@ -14,7 +14,6 @@ const LENGTH_REGEX = /^(-?[0-9]*[.]?[0-9]+)(em|px|rem|vh|vmax|vmin|vw)$/;
 type CSSLengthUnitType = 'em' | 'px' | 'rem' | 'vh' | 'vmax' | 'vmin' | 'vw';
 
 type ResolvePixelValueOptions = $ReadOnly<{
-  fontScale: number | void,
   inheritedFontSize: ?number,
   viewportHeight: number,
   viewportScale: number,
@@ -54,7 +53,6 @@ export class CSSLengthUnitValue {
 
   resolvePixelValue(options: ResolvePixelValueOptions): number {
     const {
-      fontScale = 1,
       inheritedFontSize,
       viewportHeight,
       viewportScale = 1,
@@ -66,7 +64,7 @@ export class CSSLengthUnitValue {
     switch (unit) {
       case 'em': {
         if (inheritedFontSize == null) {
-          return fontScale * 16 * value * viewportScale;
+          return 16 * value * viewportScale;
         } else {
           return inheritedFontSize * value;
         }
@@ -75,7 +73,7 @@ export class CSSLengthUnitValue {
         return value * viewportScale;
       }
       case 'rem': {
-        return fontScale * 16 * value * viewportScale;
+        return 16 * value * viewportScale;
       }
       case 'vh': {
         return viewportHeight * valuePercent;

--- a/packages/react-strict-dom/src/native/css/index.js
+++ b/packages/react-strict-dom/src/native/css/index.js
@@ -119,7 +119,6 @@ type ResolveStyleOptions = $ReadOnly<{
   colorScheme: ?('light' | 'dark'),
   customProperties: CustomProperties,
   focus?: ?boolean,
-  fontScale: number | void,
   fontSize?: ?number,
   hover?: ?boolean,
   inheritedFontSize: ?number,
@@ -142,7 +141,6 @@ function resolveStyle(
   const {
     active,
     focus,
-    fontScale,
     fontSize: _fontSize,
     hover,
     inheritedFontSize,
@@ -183,7 +181,6 @@ function resolveStyle(
       // we use the inherited fontSize.
       if (propName === 'fontSize' || fontSize == null) {
         result[propName] = styleValue.resolvePixelValue({
-          fontScale,
           inheritedFontSize: inheritedFontSize,
           viewportHeight,
           viewportScale,
@@ -196,7 +193,6 @@ function resolveStyle(
         // used as the "inherited" value to resolve other lengths correctly.
         if (typeof fontSize === 'number') {
           result[propName] = styleValue.resolvePixelValue({
-            fontScale,
             inheritedFontSize: fontSize,
             viewportHeight,
             viewportScale,

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -95,7 +95,7 @@ export function useStyleProps(
     writingDirection: dir
   } = options;
 
-  const { fontScale, height, width } = ReactNative.useWindowDimensions();
+  const { height, width } = ReactNative.useWindowDimensions();
   const colorScheme = ReactNative.useColorScheme();
   const { scale: viewportScale } = useViewportScale();
 
@@ -130,7 +130,6 @@ export function useStyleProps(
       colorScheme: colorScheme === 'unspecified' ? 'light' : colorScheme,
       customProperties: customProperties ?? emptyObject,
       focus,
-      fontScale,
       hover,
       inheritedFontSize:
         typeof inheritedFontSize === 'number' ? inheritedFontSize : undefined,

--- a/packages/react-strict-dom/tests/css/__snapshots__/css-create-test.native.js.snap
+++ b/packages/react-strict-dom/tests/css/__snapshots__/css-create-test.native.js.snap
@@ -346,13 +346,6 @@ exports[`css.create() properties fontSize 1`] = `
 }
 `;
 
-exports[`css.create() properties fontSize scaling fontScale:2 1`] = `
-{
-  "boxSizing": "content-box",
-  "fontSize": 80,
-  "position": "static",
-}
-`;
 
 exports[`css.create() properties fontVariant 1`] = `
 {
@@ -2077,35 +2070,35 @@ exports[`css.create() values: length units 10 "rem" units are resolved to pixels
 exports[`css.create() values: length units 10 "vh" units are resolved to pixels: vh 1`] = `
 {
   "boxSizing": "content-box",
-  "height": NaN,
+  "height": -100,
   "position": "static",
-  "width": NaN,
+  "width": 100,
 }
 `;
 
 exports[`css.create() values: length units 10 "vmax" units are resolved to pixels: vmax 1`] = `
 {
   "boxSizing": "content-box",
-  "height": NaN,
+  "height": -200,
   "position": "static",
-  "width": NaN,
+  "width": 200,
 }
 `;
 
 exports[`css.create() values: length units 10 "vmin" units are resolved to pixels: vmin 1`] = `
 {
   "boxSizing": "content-box",
-  "height": NaN,
+  "height": -100,
   "position": "static",
-  "width": NaN,
+  "width": 100,
 }
 `;
 
 exports[`css.create() values: length units 10 "vw" units are resolved to pixels: vw 1`] = `
 {
   "boxSizing": "content-box",
-  "height": NaN,
+  "height": -200,
   "position": "static",
-  "width": NaN,
+  "width": 200,
 }
 `;

--- a/packages/react-strict-dom/tests/css/css-create-test.native.js
+++ b/packages/react-strict-dom/tests/css/css-create-test.native.js
@@ -497,29 +497,6 @@ describe('css.create()', () => {
       expect(root.toJSON().props.style).toMatchSnapshot();
     });
 
-    describe('fontSize scaling', () => {
-      const ReactNative = require('../../src/native/react-native');
-      beforeEach(() => {
-        ReactNative.useWindowDimensions.mockReturnValue({ fontScale: 2 });
-      });
-      afterEach(() => {
-        ReactNative.useWindowDimensions.mockReturnValue({ fontScale: 1 });
-      });
-
-      test('fontScale:2', () => {
-        const styles = css.create({
-          root: {
-            fontSize: '2.5rem'
-          }
-        });
-        let root;
-        act(() => {
-          root = create(<html.span style={styles.root} />);
-        });
-        expect(root.toJSON().props.style).toMatchSnapshot();
-      });
-    });
-
     test('fontVariant', () => {
       const styles = css.create({
         root: {


### PR DESCRIPTION
By default react-native textual elements have the `allowFontScaling` prop set to true, effectively making `px` values to behave like `rem`/`em` values. The existing polyfill, though, scales the px values using the detected `fontScale`. This leads to a double amount of scaling on the native app.

This PR remove the fontScale multiplier, leaving the scaling to the native capability, while keeping the polyfill logic to translate em/rem to appropriate px values.