### PR TITLE
Add default "overflow: visible" to Text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -393,6 +393,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -580,6 +581,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -825,6 +827,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -836,6 +839,7 @@
       "version": "19.2.1",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -877,6 +881,7 @@
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.6.tgz",
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -1122,6 +1127,7 @@
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.29.0.tgz",
       "integrity": "sha512-cZ0Iq3OzFUPpgszzDr1G1aJV5UMIZ4VygJ2Az252q4Rdf5cQMhYEIKArWY/oUjMhQmosM8ygOovNq7gvA9CdCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.29.0",
         "@algolia/requester-browser-xhr": "5.29.0",
@@ -1298,6 +1304,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3505,6 +3512,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -3527,6 +3535,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3607,6 +3616,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3970,6 +3980,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4970,6 +4981,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1.tgz",
       "integrity": "sha512-oByRkSZzeGNQByCMaX+kif5Nl2vmtj2IHQI2fWjCfCootsdKZDPFLonhIp5s3IGJO7PLUfe0POyw0Xh/RrGXJA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.8.1",
         "@docusaurus/logger": "3.8.1",
@@ -8313,6 +8325,7 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
       "integrity": "sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -9623,6 +9636,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -9772,7 +9786,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -9793,7 +9806,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9807,7 +9819,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9822,8 +9833,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.0",
@@ -9888,14 +9898,14 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -10242,6 +10252,7 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -11447,6 +11458,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11530,6 +11542,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -11594,6 +11607,7 @@
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.29.0.tgz",
       "integrity": "sha512-E2l6AlTWGznM2e7vEE6T6hzObvEyXukxMOlBmVlMyixZyK1umuO/CiVc6sDBbzVH0oEviCE5IfVY1oZBmccYPQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@algolia/client-abtesting": "5.29.0",
         "@algolia/client-analytics": "5.29.0",
@@ -11766,7 +11780,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -12788,6 +12801,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -14184,6 +14198,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -15233,8 +15248,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -15847,6 +15861,7 @@
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -15961,6 +15976,7 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -16253,6 +16269,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -16944,6 +16961,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.22.tgz",
       "integrity": "sha512-sJ2I4W/e5iiM4u/wYCe3qmW4D7WPCRqByPDD0hJcdYNdjc9HFFFdO4OAudZVyC/MmtoWZEIH5kTJP1cw9FjzYA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "0.24.21",
@@ -17082,6 +17100,7 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.2.tgz",
       "integrity": "sha512-wUlMdpqURmQ/CNKK/+BIHkDA5nGjMqNlYmW0pJFXY/KE/OG80Qcavdu2sHsL4efAIiNGvYdBS10WztuQYU4X0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -19066,6 +19085,7 @@
       "integrity": "sha512-3ljktN2ek+bRRsPAcMeqMEJou6s2MRe6VuLkLsXDXuVrJfRZ7V2VUw41T9uAt9lcA2xaJP4yykYAnMg15nsRPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "hermes-estree": "0.32.1",
@@ -22720,7 +22740,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -27414,6 +27433,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -28329,6 +28349,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -28881,6 +28902,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
       "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -28897,6 +28919,7 @@
       "integrity": "sha512-B5vzcDyTA/T0R7LGMSkLTp3VtRCEe1NItzsM6L/4gDOBGzDDMMMOwxRxogwL9xL07GPBOJrzlggwFaSQOhLVLw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hermes-estree": "0.25.0",
         "hermes-parser": "0.25.0",
@@ -29302,6 +29325,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
       "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29342,6 +29366,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
       "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -29403,6 +29428,7 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -29431,6 +29457,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.5.tgz",
       "integrity": "sha512-jVihwsE4mWEHZ9HkO1J2eUZSwHyDByZOqthwnGrVZCh6kTQBCm4v8dicsyDa6p0fpWNE5KicTcpX/XXl0ASJFg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.79.5",
@@ -29662,6 +29689,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -31082,6 +31110,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -33070,6 +33099,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -33489,6 +33519,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
       "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -33554,6 +33585,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.48.1.tgz",
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -34519,6 +34551,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
       "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -35358,6 +35391,7 @@
       "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "devOptional": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -35446,6 +35480,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
@@ -98,6 +98,13 @@ export function createStrictDOMTextComponent<T, P: StrictProps>(
       disableUserSelect ? { userSelect: 'none' } : null
     );
 
+    // Native components historically clip text. Opt into web-style default of
+    // visible overflow by default
+    if (nativeProps.style?.overflow == null) {
+      nativeProps.style = nativeProps.style ?? {};
+      nativeProps.style.overflow = 'visible';
+    }
+
     // Use Animated components if necessary
     if (nativeProps.animated === true) {
       NativeComponent = ReactNative.Animated.Text;

--- a/packages/react-strict-dom/tests/compat/__snapshots__/compat-test.native.js.snap
+++ b/packages/react-strict-dom/tests/compat/__snapshots__/compat-test.native.js.snap
@@ -44,6 +44,7 @@ exports[`<compat.native> "as" equals "span": as=span 1`] = `
   style={
     {
       "color": "blue",
+      "overflow": "visible",
       "userSelect": "none",
     }
   }
@@ -85,6 +86,7 @@ exports[`<compat.native> nested: nested 1`] = `
       {
         "boxSizing": "content-box",
         "color": "red",
+        "overflow": "visible",
         "position": "static",
       }
     }

--- a/packages/react-strict-dom/tests/contexts/__snapshots__/contexts-ThemeProvider-test.native.js.snap
+++ b/packages/react-strict-dom/tests/contexts/__snapshots__/contexts-ThemeProvider-test.native.js.snap
@@ -6,6 +6,7 @@ exports[`<contexts.*> <ThemeProvider> css variable declaration inside a media qu
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "width": 42,
     }
@@ -20,6 +21,7 @@ exports[`<contexts.*> <ThemeProvider> defines global custom properties 1`] = `
     style={
       {
         "boxSizing": "content-box",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -33,6 +35,7 @@ exports[`<contexts.*> <ThemeProvider> defines global custom properties 1`] = `
         "backgroundColor": "red",
         "boxSizing": "content-box",
         "color": "red",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -50,6 +53,7 @@ exports[`<contexts.*> <ThemeProvider> kebab case string var to camel case 1`] = 
       {
         "boxSizing": "content-box",
         "color": "red",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -60,6 +64,7 @@ exports[`<contexts.*> <ThemeProvider> kebab case string var to camel case 1`] = 
       {
         "boxSizing": "content-box",
         "color": "red",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -113,6 +118,7 @@ exports[`<contexts.*> <ThemeProvider> rgb(a) function with args applied through 
       {
         "boxSizing": "content-box",
         "color": "rgb(24, 48, 96)",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -123,6 +129,7 @@ exports[`<contexts.*> <ThemeProvider> rgb(a) function with args applied through 
       {
         "boxSizing": "content-box",
         "color": "rgba(24, 48, 96, 0.5)",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -137,6 +144,7 @@ exports[`<contexts.*> <ThemeProvider> rgba function with args applied through mu
     {
       "boxSizing": "content-box",
       "color": "rgba(255, 96, 16, 0.42)",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -151,6 +159,7 @@ exports[`<contexts.*> <ThemeProvider> string var 1`] = `
       "boxSizing": "content-box",
       "color": "red",
       "opacity": 0.25,
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -164,6 +173,7 @@ exports[`<contexts.*> <ThemeProvider> string var and falls back to a default val
     {
       "boxSizing": "content-box",
       "color": "rgb(255,255,255)",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -177,6 +187,7 @@ exports[`<contexts.*> <ThemeProvider> string var and falls back to default value
     {
       "boxSizing": "content-box",
       "color": "red",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -217,6 +228,7 @@ exports[`<contexts.*> <ThemeProvider> string var with a default value 1`] = `
       {
         "boxSizing": "content-box",
         "color": "red",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -227,6 +239,7 @@ exports[`<contexts.*> <ThemeProvider> string var with a default value 1`] = `
       {
         "boxSizing": "content-box",
         "color": "blue",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -242,6 +255,7 @@ exports[`<contexts.*> <ThemeProvider> string var with a default value containing
       {
         "boxSizing": "content-box",
         "color": "rgb(0,0,0)",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -252,6 +266,7 @@ exports[`<contexts.*> <ThemeProvider> string var with a default value containing
       {
         "boxSizing": "content-box",
         "color": "rgb(1 , 1 , 1)",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -265,6 +280,7 @@ exports[`<contexts.*> <ThemeProvider> textShadow with nested/multiple vars 1`] =
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textShadowColor": "red",
       "textShadowOffset": {
@@ -283,6 +299,7 @@ exports[`<contexts.*> <ThemeProvider> transform with nested/multiple vars 1`] = 
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "transform": [
         {

--- a/packages/react-strict-dom/tests/contexts/__snapshots__/contexts-ViewportProvider-test.native.js.snap
+++ b/packages/react-strict-dom/tests/contexts/__snapshots__/contexts-ViewportProvider-test.native.js.snap
@@ -30,6 +30,7 @@ exports[`<contexts.*> <ViewportProvider> all CSS lengths are scaled according to
         "boxSizing": "content-box",
         "fontSize": 24,
         "lineHeight": 24,
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -42,6 +43,7 @@ exports[`<contexts.*> <ViewportProvider> all CSS lengths are scaled according to
       {
         "boxSizing": "content-box",
         "fontSize": 18,
+        "overflow": "visible",
         "position": "static",
       }
     }

--- a/packages/react-strict-dom/tests/css/__snapshots__/css-create-queries-test.native.js.snap
+++ b/packages/react-strict-dom/tests/css/__snapshots__/css-create-queries-test.native.js.snap
@@ -6,6 +6,7 @@ exports[`css.create(): @media query does not match (prefers-color-scheme: dark) 
   "borderColor": "green",
   "boxSizing": "content-box",
   "color": "black",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -16,6 +17,7 @@ exports[`css.create(): @media query does not match (prefers-color-scheme: light)
   "borderColor": "darkgreen",
   "boxSizing": "content-box",
   "color": "white",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -26,6 +28,7 @@ exports[`css.create(): @media query matches (prefers-color-scheme: dark) 1`] = `
   "borderColor": "darkgreen",
   "boxSizing": "content-box",
   "color": "white",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -36,6 +39,7 @@ exports[`css.create(): @media query matches (prefers-color-scheme: light) 1`] = 
   "borderColor": "green",
   "boxSizing": "content-box",
   "color": "black",
+  "overflow": "visible",
   "position": "static",
 }
 `;

--- a/packages/react-strict-dom/tests/css/__snapshots__/css-create-test.native.js.snap
+++ b/packages/react-strict-dom/tests/css/__snapshots__/css-create-test.native.js.snap
@@ -342,6 +342,7 @@ exports[`css.create() properties fontSize 1`] = `
 {
   "boxSizing": "content-box",
   "fontSize": 40,
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -350,6 +351,7 @@ exports[`css.create() properties fontSize scaling fontScale:2 1`] = `
 {
   "boxSizing": "content-box",
   "fontSize": 80,
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -358,6 +360,7 @@ exports[`css.create() properties fontVariant 1`] = `
 {
   "boxSizing": "content-box",
   "fontVariant": "common-ligatures small-caps",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -366,6 +369,7 @@ exports[`css.create() properties fontWeight 1`] = `
 {
   "boxSizing": "content-box",
   "fontWeight": "900",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -374,6 +378,7 @@ exports[`css.create() properties fontWeight 2`] = `
 {
   "boxSizing": "content-box",
   "fontWeight": "bold",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -431,6 +436,7 @@ exports[`css.create() properties inset: inset 1`] = `
   "bottom": 1,
   "boxSizing": "content-box",
   "end": 1,
+  "overflow": "visible",
   "position": "static",
   "start": 1,
   "top": 1,
@@ -443,6 +449,7 @@ exports[`css.create() properties inset: inset vs phys 1`] = `
   "boxSizing": "content-box",
   "end": 1,
   "left": 10,
+  "overflow": "visible",
   "position": "static",
   "right": 10,
   "start": 1,
@@ -454,6 +461,7 @@ exports[`css.create() properties inset: insetBlock 1`] = `
 {
   "bottom": 2,
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "top": 2,
 }
@@ -463,6 +471,7 @@ exports[`css.create() properties inset: insetBlock vs phys 1`] = `
 {
   "bottom": 100,
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "top": 100,
 }
@@ -472,6 +481,7 @@ exports[`css.create() properties inset: insetBlockEnd 1`] = `
 {
   "bottom": 4,
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -480,6 +490,7 @@ exports[`css.create() properties inset: insetBlockEnd vs phys 1`] = `
 {
   "bottom": 4,
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "top": 100,
 }
@@ -488,6 +499,7 @@ exports[`css.create() properties inset: insetBlockEnd vs phys 1`] = `
 exports[`css.create() properties inset: insetBlockStart 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "top": 3,
 }
@@ -497,6 +509,7 @@ exports[`css.create() properties inset: insetBlockStart vs phys 1`] = `
 {
   "bottom": 100,
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "top": 3,
 }
@@ -506,6 +519,7 @@ exports[`css.create() properties inset: insetInline 1`] = `
 {
   "boxSizing": "content-box",
   "end": 5,
+  "overflow": "visible",
   "position": "static",
   "start": 5,
 }
@@ -515,6 +529,7 @@ exports[`css.create() properties inset: insetInlineEnd 1`] = `
 {
   "boxSizing": "content-box",
   "end": 7,
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -522,6 +537,7 @@ exports[`css.create() properties inset: insetInlineEnd 1`] = `
 exports[`css.create() properties inset: insetInlineStart 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "start": 6,
 }
@@ -533,6 +549,7 @@ exports[`css.create() properties isolation 1`] = `
   "style": {
     "boxSizing": "content-box",
     "isolation": "isolate",
+    "overflow": "visible",
     "position": "static",
   },
 }
@@ -545,6 +562,7 @@ exports[`css.create() properties lineClamp 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "userSelect": "none",
     }
@@ -558,6 +576,7 @@ exports[`css.create() properties lineHeight: px 1`] = `
 {
   "boxSizing": "content-box",
   "lineHeight": 24,
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -566,6 +585,7 @@ exports[`css.create() properties lineHeight: rem 1`] = `
 {
   "boxSizing": "content-box",
   "lineHeight": 24,
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -575,6 +595,7 @@ exports[`css.create() properties lineHeight: unitless number 1`] = `
   "boxSizing": "content-box",
   "fontSize": 16,
   "lineHeight": 24,
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -584,6 +605,7 @@ exports[`css.create() properties lineHeight: unitless string 1`] = `
   "boxSizing": "content-box",
   "fontSize": 16,
   "lineHeight": 24,
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -930,6 +952,7 @@ exports[`css.create() properties position: sticky 1`] = `
 exports[`css.create() properties textAlign: center 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "textAlign": "center",
 }
@@ -938,6 +961,7 @@ exports[`css.create() properties textAlign: center 1`] = `
 exports[`css.create() properties textAlign: end 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "textAlign": "right",
 }
@@ -946,6 +970,7 @@ exports[`css.create() properties textAlign: end 1`] = `
 exports[`css.create() properties textAlign: left 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "textAlign": "left",
 }
@@ -954,6 +979,7 @@ exports[`css.create() properties textAlign: left 1`] = `
 exports[`css.create() properties textAlign: right 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "textAlign": "right",
 }
@@ -962,6 +988,7 @@ exports[`css.create() properties textAlign: right 1`] = `
 exports[`css.create() properties textAlign: start 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "textAlign": "left",
 }
@@ -1183,6 +1210,7 @@ exports[`css.create() properties transform: translate 1`] = `
 exports[`css.create() properties userSelect 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "userSelect": "none",
 }
@@ -1191,6 +1219,7 @@ exports[`css.create() properties userSelect 1`] = `
 exports[`css.create() properties verticalAlign: middle 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "verticalAlign": "middle",
 }
@@ -1199,6 +1228,7 @@ exports[`css.create() properties verticalAlign: middle 1`] = `
 exports[`css.create() properties verticalAlign: top 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "verticalAlign": "top",
 }
@@ -1972,6 +2002,7 @@ exports[`css.create() pseudo-elements ::placeholder syntax: placeholderTextColor
   "ref": [Function],
   "style": {
     "boxSizing": "content-box",
+    "overflow": "visible",
     "position": "static",
   },
 }
@@ -1980,6 +2011,7 @@ exports[`css.create() pseudo-elements ::placeholder syntax: placeholderTextColor
 exports[`css.create() values: general calc() 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -1987,6 +2019,7 @@ exports[`css.create() values: general calc() 1`] = `
 exports[`css.create() values: general currentcolor 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -1995,6 +2028,7 @@ exports[`css.create() values: general firstThatWorks 1`] = `
 {
   "boxSizing": "content-box",
   "color": "hsl(0,0,0)",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -2003,6 +2037,7 @@ exports[`css.create() values: general inherit 1`] = `
 {
   "boxSizing": "content-box",
   "fontSize": "inherit",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -2010,6 +2045,7 @@ exports[`css.create() values: general inherit 1`] = `
 exports[`css.create() values: general inherit 2`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -2017,6 +2053,7 @@ exports[`css.create() values: general inherit 2`] = `
 exports[`css.create() values: general initial 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -2025,6 +2062,7 @@ exports[`css.create() values: length units '0' is resolved to the number 0 1`] =
 {
   "borderRadius": 0,
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
   "width": 0,
 }
@@ -2043,6 +2081,7 @@ exports[`css.create() values: length units 10 "em" units based on font-size 1`] 
 {
   "boxSizing": "content-box",
   "fontSize": 10,
+  "overflow": "visible",
   "position": "static",
   "width": 100,
 }

--- a/packages/react-strict-dom/tests/css/__snapshots__/css-themes-test.native.js.snap
+++ b/packages/react-strict-dom/tests/css/__snapshots__/css-themes-test.native.js.snap
@@ -24,6 +24,7 @@ exports[`css.* themes css.defineVars: tokens 1`] = `
 exports[`css.* themes handles undefined variables 1`] = `
 {
   "boxSizing": "content-box",
+  "overflow": "visible",
   "position": "static",
 }
 `;
@@ -37,6 +38,7 @@ exports[`css.* themes inherited themes 1`] = `
         "backgroundColor": "pink",
         "boxSizing": "content-box",
         "color": "red",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -50,6 +52,7 @@ exports[`css.* themes inherited themes 1`] = `
         "backgroundColor": "pink",
         "boxSizing": "content-box",
         "color": "green",
+        "overflow": "visible",
         "position": "static",
       }
     }
@@ -85,6 +88,7 @@ exports[`css.* themes inherited themes 1`] = `
           "backgroundColor": "pink",
           "boxSizing": "content-box",
           "color": "green",
+          "overflow": "visible",
           "position": "static",
         }
       }
@@ -120,6 +124,7 @@ exports[`css.* themes inherited themes 1`] = `
             "backgroundColor": "pink",
             "boxSizing": "content-box",
             "color": "blue",
+            "overflow": "visible",
             "position": "static",
           }
         }
@@ -148,6 +153,7 @@ exports[`css.* themes inherited themes 1`] = `
         "backgroundColor": "pink",
         "boxSizing": "content-box",
         "color": "red",
+        "overflow": "visible",
         "position": "static",
       }
     }

--- a/packages/react-strict-dom/tests/html/__snapshots__/html-test.js.snap-native
+++ b/packages/react-strict-dom/tests/html/__snapshots__/html-test.js.snap-native
@@ -8,6 +8,7 @@ exports[`<html.*> "a" default rendering 1`] = `
     {
       "boxSizing": "content-box",
       "color": "blue",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }
@@ -23,6 +24,7 @@ exports[`<html.*> "a" ignores and warns about unsupported attributes 1`] = `
     {
       "boxSizing": "content-box",
       "color": "blue",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }
@@ -39,6 +41,7 @@ exports[`<html.*> "a" supports additional anchor attributes 1`] = `
     {
       "boxSizing": "content-box",
       "color": "blue",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }
@@ -88,6 +91,7 @@ exports[`<html.*> "a" supports global attributes 1`] = `
       "color": "blue",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
       "writingDirection": "ltr",
@@ -131,6 +135,7 @@ exports[`<html.*> "a" supports inline event handlers 1`] = `
     {
       "boxSizing": "content-box",
       "color": "blue",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }
@@ -381,6 +386,7 @@ exports[`<html.*> "b" default rendering 1`] = `
     {
       "boxSizing": "content-box",
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -394,6 +400,7 @@ exports[`<html.*> "b" ignores and warns about unsupported attributes 1`] = `
     {
       "boxSizing": "content-box",
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -442,6 +449,7 @@ exports[`<html.*> "b" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -483,6 +491,7 @@ exports[`<html.*> "b" supports inline event handlers 1`] = `
     {
       "boxSizing": "content-box",
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -495,6 +504,7 @@ exports[`<html.*> "bdi" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -507,6 +517,7 @@ exports[`<html.*> "bdi" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -554,6 +565,7 @@ exports[`<html.*> "bdi" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -594,6 +606,7 @@ exports[`<html.*> "bdi" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -606,6 +619,7 @@ exports[`<html.*> "bdo" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -618,6 +632,7 @@ exports[`<html.*> "bdo" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -665,6 +680,7 @@ exports[`<html.*> "bdo" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -705,6 +721,7 @@ exports[`<html.*> "bdo" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -832,7 +849,11 @@ exports[`<html.*> "blockquote" supports inline event handlers 1`] = `
 exports[`<html.*> "br" default rendering 1`] = `
 <Text
   ref={[Function]}
-  style={{}}
+  style={
+    {
+      "overflow": "visible",
+    }
+  }
 >
   
 
@@ -842,7 +863,11 @@ exports[`<html.*> "br" default rendering 1`] = `
 exports[`<html.*> "br" ignores and warns about unsupported attributes 1`] = `
 <Text
   ref={[Function]}
-  style={{}}
+  style={
+    {
+      "overflow": "visible",
+    }
+  }
 >
   
 
@@ -889,6 +914,7 @@ exports[`<html.*> "br" supports global attributes 1`] = `
       "--custom-property": "inline",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "writingDirection": "ltr",
     }
   }
@@ -926,7 +952,11 @@ exports[`<html.*> "br" supports inline event handlers 1`] = `
   onTouchMove={[Function]}
   onTouchStart={[Function]}
   ref={[Function]}
-  style={{}}
+  style={
+    {
+      "overflow": "visible",
+    }
+  }
 >
   
 
@@ -1081,6 +1111,7 @@ exports[`<html.*> "code" default rendering 1`] = `
     {
       "boxSizing": "content-box",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -1094,6 +1125,7 @@ exports[`<html.*> "code" ignores and warns about unsupported attributes 1`] = `
     {
       "boxSizing": "content-box",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -1142,6 +1174,7 @@ exports[`<html.*> "code" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -1183,6 +1216,7 @@ exports[`<html.*> "code" supports inline event handlers 1`] = `
     {
       "boxSizing": "content-box",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -1195,6 +1229,7 @@ exports[`<html.*> "del" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "line-through",
     }
@@ -1208,6 +1243,7 @@ exports[`<html.*> "del" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "line-through",
     }
@@ -1256,6 +1292,7 @@ exports[`<html.*> "del" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "line-through",
       "writingDirection": "ltr",
@@ -1297,6 +1334,7 @@ exports[`<html.*> "del" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "line-through",
     }
@@ -1429,6 +1467,7 @@ exports[`<html.*> "em" default rendering 1`] = `
     {
       "boxSizing": "content-box",
       "fontStyle": "italic",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -1442,6 +1481,7 @@ exports[`<html.*> "em" ignores and warns about unsupported attributes 1`] = `
     {
       "boxSizing": "content-box",
       "fontStyle": "italic",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -1490,6 +1530,7 @@ exports[`<html.*> "em" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "fontStyle": "italic",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -1531,6 +1572,7 @@ exports[`<html.*> "em" supports inline event handlers 1`] = `
     {
       "boxSizing": "content-box",
       "fontStyle": "italic",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -1900,6 +1942,7 @@ exports[`<html.*> "h1" default rendering 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -1915,6 +1958,7 @@ exports[`<html.*> "h1" ignores and warns about unsupported attributes 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -1964,6 +2008,7 @@ exports[`<html.*> "h1" supports global attributes 1`] = `
       "display": "none",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -2007,6 +2052,7 @@ exports[`<html.*> "h1" supports inline event handlers 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2022,6 +2068,7 @@ exports[`<html.*> "h2" default rendering 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2037,6 +2084,7 @@ exports[`<html.*> "h2" ignores and warns about unsupported attributes 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2086,6 +2134,7 @@ exports[`<html.*> "h2" supports global attributes 1`] = `
       "display": "none",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -2129,6 +2178,7 @@ exports[`<html.*> "h2" supports inline event handlers 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2144,6 +2194,7 @@ exports[`<html.*> "h3" default rendering 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2159,6 +2210,7 @@ exports[`<html.*> "h3" ignores and warns about unsupported attributes 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2208,6 +2260,7 @@ exports[`<html.*> "h3" supports global attributes 1`] = `
       "display": "none",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -2251,6 +2304,7 @@ exports[`<html.*> "h3" supports inline event handlers 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2266,6 +2320,7 @@ exports[`<html.*> "h4" default rendering 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2281,6 +2336,7 @@ exports[`<html.*> "h4" ignores and warns about unsupported attributes 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2330,6 +2386,7 @@ exports[`<html.*> "h4" supports global attributes 1`] = `
       "display": "none",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -2373,6 +2430,7 @@ exports[`<html.*> "h4" supports inline event handlers 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2388,6 +2446,7 @@ exports[`<html.*> "h5" default rendering 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2403,6 +2462,7 @@ exports[`<html.*> "h5" ignores and warns about unsupported attributes 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2452,6 +2512,7 @@ exports[`<html.*> "h5" supports global attributes 1`] = `
       "display": "none",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -2495,6 +2556,7 @@ exports[`<html.*> "h5" supports inline event handlers 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2510,6 +2572,7 @@ exports[`<html.*> "h6" default rendering 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2525,6 +2588,7 @@ exports[`<html.*> "h6" ignores and warns about unsupported attributes 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2574,6 +2638,7 @@ exports[`<html.*> "h6" supports global attributes 1`] = `
       "display": "none",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -2617,6 +2682,7 @@ exports[`<html.*> "h6" supports inline event handlers 1`] = `
       "boxSizing": "content-box",
       "fontSize": 24,
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2877,6 +2943,7 @@ exports[`<html.*> "i" default rendering 1`] = `
     {
       "boxSizing": "content-box",
       "fontStyle": "italic",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2890,6 +2957,7 @@ exports[`<html.*> "i" ignores and warns about unsupported attributes 1`] = `
     {
       "boxSizing": "content-box",
       "fontStyle": "italic",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -2938,6 +3006,7 @@ exports[`<html.*> "i" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "fontStyle": "italic",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -2979,6 +3048,7 @@ exports[`<html.*> "i" supports inline event handlers 1`] = `
     {
       "boxSizing": "content-box",
       "fontStyle": "italic",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3278,6 +3348,7 @@ exports[`<html.*> "ins" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }
@@ -3291,6 +3362,7 @@ exports[`<html.*> "ins" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }
@@ -3339,6 +3411,7 @@ exports[`<html.*> "ins" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
       "writingDirection": "ltr",
@@ -3380,6 +3453,7 @@ exports[`<html.*> "ins" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }
@@ -3394,6 +3468,7 @@ exports[`<html.*> "kbd" default rendering 1`] = `
     {
       "boxSizing": "content-box",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3407,6 +3482,7 @@ exports[`<html.*> "kbd" ignores and warns about unsupported attributes 1`] = `
     {
       "boxSizing": "content-box",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3455,6 +3531,7 @@ exports[`<html.*> "kbd" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -3496,6 +3573,7 @@ exports[`<html.*> "kbd" supports inline event handlers 1`] = `
     {
       "boxSizing": "content-box",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3508,6 +3586,7 @@ exports[`<html.*> "label" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3520,6 +3599,7 @@ exports[`<html.*> "label" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3532,6 +3612,7 @@ exports[`<html.*> "label" supports additional label attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3579,6 +3660,7 @@ exports[`<html.*> "label" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -3619,6 +3701,7 @@ exports[`<html.*> "label" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3764,6 +3847,7 @@ exports[`<html.*> "mark" default rendering 1`] = `
       "backgroundColor": "yellow",
       "boxSizing": "content-box",
       "color": "black",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3778,6 +3862,7 @@ exports[`<html.*> "mark" ignores and warns about unsupported attributes 1`] = `
       "backgroundColor": "yellow",
       "boxSizing": "content-box",
       "color": "black",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -3827,6 +3912,7 @@ exports[`<html.*> "mark" supports global attributes 1`] = `
       "color": "black",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -3869,6 +3955,7 @@ exports[`<html.*> "mark" supports inline event handlers 1`] = `
       "backgroundColor": "yellow",
       "boxSizing": "content-box",
       "color": "black",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4251,6 +4338,7 @@ exports[`<html.*> "option" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4263,6 +4351,7 @@ exports[`<html.*> "option" ignores and warns about unsupported attributes 1`] = 
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4310,6 +4399,7 @@ exports[`<html.*> "option" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -4348,6 +4438,7 @@ exports[`<html.*> "option" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4360,6 +4451,7 @@ exports[`<html.*> "option" supports input attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4374,6 +4466,7 @@ exports[`<html.*> "p" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4386,6 +4479,7 @@ exports[`<html.*> "p" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4433,6 +4527,7 @@ exports[`<html.*> "p" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -4473,6 +4568,7 @@ exports[`<html.*> "p" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4486,6 +4582,7 @@ exports[`<html.*> "pre" default rendering 1`] = `
     {
       "boxSizing": "content-box",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4499,6 +4596,7 @@ exports[`<html.*> "pre" ignores and warns about unsupported attributes 1`] = `
     {
       "boxSizing": "content-box",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4547,6 +4645,7 @@ exports[`<html.*> "pre" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -4588,6 +4687,7 @@ exports[`<html.*> "pre" supports inline event handlers 1`] = `
     {
       "boxSizing": "content-box",
       "fontFamily": "Menlo",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4600,6 +4700,7 @@ exports[`<html.*> "s" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "line-through",
     }
@@ -4613,6 +4714,7 @@ exports[`<html.*> "s" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "line-through",
     }
@@ -4661,6 +4763,7 @@ exports[`<html.*> "s" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "line-through",
       "writingDirection": "ltr",
@@ -4702,6 +4805,7 @@ exports[`<html.*> "s" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "line-through",
     }
@@ -4963,6 +5067,7 @@ exports[`<html.*> "span" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -4975,6 +5080,7 @@ exports[`<html.*> "span" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5022,6 +5128,7 @@ exports[`<html.*> "span" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -5062,6 +5169,7 @@ exports[`<html.*> "span" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5075,6 +5183,7 @@ exports[`<html.*> "strong" default rendering 1`] = `
     {
       "boxSizing": "content-box",
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5088,6 +5197,7 @@ exports[`<html.*> "strong" ignores and warns about unsupported attributes 1`] = 
     {
       "boxSizing": "content-box",
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5136,6 +5246,7 @@ exports[`<html.*> "strong" supports global attributes 1`] = `
       "direction": "ltr",
       "display": "none",
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -5177,6 +5288,7 @@ exports[`<html.*> "strong" supports inline event handlers 1`] = `
     {
       "boxSizing": "content-box",
       "fontWeight": "bold",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5189,6 +5301,7 @@ exports[`<html.*> "sub" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5201,6 +5314,7 @@ exports[`<html.*> "sub" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5248,6 +5362,7 @@ exports[`<html.*> "sub" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -5288,6 +5403,7 @@ exports[`<html.*> "sub" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5300,6 +5416,7 @@ exports[`<html.*> "sup" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5312,6 +5429,7 @@ exports[`<html.*> "sup" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5359,6 +5477,7 @@ exports[`<html.*> "sup" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -5399,6 +5518,7 @@ exports[`<html.*> "sup" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
     }
   }
@@ -5569,6 +5689,7 @@ exports[`<html.*> "u" default rendering 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }
@@ -5582,6 +5703,7 @@ exports[`<html.*> "u" ignores and warns about unsupported attributes 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }
@@ -5630,6 +5752,7 @@ exports[`<html.*> "u" supports global attributes 1`] = `
       "boxSizing": "content-box",
       "direction": "ltr",
       "display": "none",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
       "writingDirection": "ltr",
@@ -5671,6 +5794,7 @@ exports[`<html.*> "u" supports inline event handlers 1`] = `
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "textDecorationLine": "underline",
     }

--- a/packages/react-strict-dom/tests/html/__snapshots__/html-test.native.js.snap
+++ b/packages/react-strict-dom/tests/html/__snapshots__/html-test.native.js.snap
@@ -72,6 +72,7 @@ exports[`<html.*> (native polyfills) polyfills: inheritence inherited styles 1`]
           "fontWeight": "300",
           "letterSpacing": 10,
           "lineHeight": 192,
+          "overflow": "visible",
           "position": "static",
           "textAlign": "right",
           "textDecorationColor": "red",
@@ -1010,6 +1011,7 @@ exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "auto" 
   style={
     {
       "boxSizing": "content-box",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "auto",
     }
@@ -1037,6 +1039,7 @@ exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "ltr" t
     {
       "boxSizing": "content-box",
       "direction": "ltr",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "ltr",
     }
@@ -1064,6 +1067,7 @@ exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "rtl" t
     {
       "boxSizing": "content-box",
       "direction": "rtl",
+      "overflow": "visible",
       "position": "static",
       "writingDirection": "rtl",
     }


### PR DESCRIPTION
iOS and Android both historically clip everything outside the bounds of the paragraph/top-level text element. This includes clipping content, when `line-height` would set the bounds to be smaller than the text to be drawn. This is equivalent to setting `overflow: 'hidden'` manually on a paragraph.

Changing this default behavior in React Native is scary and breaking and not something we are taking on right now, but with Facsimile/PreparedLayoutTextView on Android, it can be controlled with opt-in `overflow: visible`, for web style clipping.

This change defaults to `overflow: 'visible'` to get that web style behavior by default (e.g. no clipping the bounds of `TextView`/`<p>` when `line-height` makes text larger than the bounds.