### PR TITLE
fix: use centralized cache for `usePrefersReducedMotion` hook

### DIFF
--- a/packages/react-strict-dom/src/native/modules/PrefersReducedMotionStore.js
+++ b/packages/react-strict-dom/src/native/modules/PrefersReducedMotionStore.js
@@ -11,7 +11,7 @@ import type { EventSubscription } from 'react-native/Libraries/vendor/emitter/Ev
 
 import * as ReactNative from '../react-native';
 
-type Listener = (prefersReducedMotion: boolean) => void;
+type Listener = () => void;
 
 const listeners: Set<Listener> = new Set();
 
@@ -24,7 +24,7 @@ function setPrefersReducedMotion(nextValue: boolean) {
     prefersReducedMotion = nextValue;
 
     Array.from(listeners).forEach((listener) => {
-      listener(prefersReducedMotion);
+      listener();
     });
   }
 }

--- a/packages/react-strict-dom/src/native/modules/PrefersReducedMotionStore.js
+++ b/packages/react-strict-dom/src/native/modules/PrefersReducedMotionStore.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import type { EventSubscription } from 'react-native/Libraries/vendor/emitter/EventEmitter';
+
+import * as ReactNative from '../react-native';
+
+type Listener = (prefersReducedMotion: boolean) => void;
+
+const listeners: Set<Listener> = new Set();
+
+let prefersReducedMotion = false;
+let isInitialized = false;
+let reduceMotionChangedSubscription: ?EventSubscription = null;
+
+function setPrefersReducedMotion(nextValue: boolean) {
+  if (prefersReducedMotion !== nextValue) {
+    prefersReducedMotion = nextValue;
+
+    Array.from(listeners).forEach((listener) => {
+      listener(prefersReducedMotion);
+    });
+  }
+}
+
+function ensureInitialized() {
+  if (isInitialized) {
+    return;
+  }
+
+  isInitialized = true;
+
+  if (reduceMotionChangedSubscription == null) {
+    reduceMotionChangedSubscription =
+      ReactNative.AccessibilityInfo.addEventListener(
+        'reduceMotionChanged',
+        (isReduceMotionEnabled) => {
+          setPrefersReducedMotion(isReduceMotionEnabled);
+        }
+      );
+  }
+
+  ReactNative.AccessibilityInfo.isReduceMotionEnabled().then(
+    (isReduceMotionEnabled) => {
+      setPrefersReducedMotion(isReduceMotionEnabled);
+    },
+    () => {
+      // Silently ignore if the native module is not available (e.g., on VR)
+    }
+  );
+}
+
+export function getPrefersReducedMotionSnapshot(): boolean {
+  return prefersReducedMotion;
+}
+
+export function subscribeToPrefersReducedMotion(
+  listener: Listener
+): () => void {
+  listeners.add(listener);
+  ensureInitialized();
+
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/packages/react-strict-dom/src/native/modules/usePrefersReducedMotion.js
+++ b/packages/react-strict-dom/src/native/modules/usePrefersReducedMotion.js
@@ -7,7 +7,7 @@
  * @flow strict-local
  */
 
-import { useEffect, useState } from 'react';
+import * as React from 'react';
 
 import {
   getPrefersReducedMotionSnapshot,
@@ -15,19 +15,9 @@ import {
 } from './PrefersReducedMotionStore';
 
 export function usePrefersReducedMotion(): boolean {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
-    getPrefersReducedMotionSnapshot()
+  return React.useSyncExternalStore(
+    subscribeToPrefersReducedMotion,
+    getPrefersReducedMotionSnapshot,
+    getPrefersReducedMotionSnapshot
   );
-
-  useEffect(() => {
-    const unsubscribe = subscribeToPrefersReducedMotion(
-      (isReduceMotionEnabled) => {
-        setPrefersReducedMotion(isReduceMotionEnabled);
-      }
-    );
-
-    return unsubscribe;
-  }, []);
-
-  return prefersReducedMotion;
 }

--- a/packages/react-strict-dom/src/native/modules/usePrefersReducedMotion.js
+++ b/packages/react-strict-dom/src/native/modules/usePrefersReducedMotion.js
@@ -7,36 +7,26 @@
  * @flow strict-local
  */
 
-import * as ReactNative from '../react-native';
-
 import { useEffect, useState } from 'react';
 
+import {
+  getPrefersReducedMotionSnapshot,
+  subscribeToPrefersReducedMotion
+} from './PrefersReducedMotionStore';
+
 export function usePrefersReducedMotion(): boolean {
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    getPrefersReducedMotionSnapshot()
+  );
 
   useEffect(() => {
-    // 1. Get the initial value of reduce motion
-    ReactNative.AccessibilityInfo.isReduceMotionEnabled().then(
+    const unsubscribe = subscribeToPrefersReducedMotion(
       (isReduceMotionEnabled) => {
         setPrefersReducedMotion(isReduceMotionEnabled);
-      },
-      () => {
-        // Silently ignore if the native module is not available (e.g., on VR)
       }
     );
 
-    // 2. Subscribe to changes in reduce motion
-    const reduceMotionChangedSubscription =
-      ReactNative.AccessibilityInfo.addEventListener(
-        'reduceMotionChanged',
-        (isReduceMotionEnabled) => {
-          setPrefersReducedMotion(isReduceMotionEnabled);
-        }
-      );
-
-    return () => {
-      reduceMotionChangedSubscription.remove();
-    };
+    return unsubscribe;
   }, []);
 
   return prefersReducedMotion;


### PR DESCRIPTION
Fix a performance issue in RN, when each RSD component (div, span, button, etc) calls `AcessibilityInfo.isReduceMotionEnabled` on mount due to `usePrefersReduceMotion` hook called from styles calculation.
This is especially visible on Android, where a single call is relatively cheap (0,1-0,3 ms), but with larger (e.g. 1000) number of components, this operation alone could take ~300ms in our app during screen load.

<img width="1196" height="396" alt="CleanShot 2026-04-01 at 10 19 21@2x" src="https://github.com/user-attachments/assets/0e17dab9-2420-4982-a857-d199f8ed8246" />



The fix is to keep a reactive JS cache for this value, so that only single `AcessibilityInfo.isReduceMotionEnabled` is ever made, all other components would use the cached value. The cache itself subscribes to `reduceMotionChanged` event, hence the value stays up to date.

Additionally, having up-to-date value, prevents effect triggered re-renders when default value would switch to true.