### PR TITLE
Remove experimental_ prefix from backgroundImage on native

### DIFF
--- a/packages/react-strict-dom/src/native/css/processStyle.js
+++ b/packages/react-strict-dom/src/native/css/processStyle.js
@@ -115,9 +115,9 @@ export function processStyle(
         result[propName] = CSSUnparsedValue.parse(propName, styleValue);
         continue;
       }
-      // Polyfill support for backgroundImage using experimental API
+      // Polyfill support for backgroundImage
       else if (propName === 'backgroundImage') {
-        result.experimental_backgroundImage = styleValue;
+        result.backgroundImage = styleValue;
         continue;
       }
       // Warn for unsupported caretColor values

--- a/packages/react-strict-dom/tests/css/__snapshots__/css-create-test.native.js.snap
+++ b/packages/react-strict-dom/tests/css/__snapshots__/css-create-test.native.js.snap
@@ -19,7 +19,7 @@ exports[`css.create() properties animationDuration 1`] = `
 exports[`css.create() properties backgroundImage 1`] = `
 {
   "boxSizing": "content-box",
-  "experimental_backgroundImage": "linear-gradient(to bottom right, yellow, green)",
+  "backgroundImage": "linear-gradient(to bottom right, yellow, green)",
   "position": "static",
 }
 `;


### PR DESCRIPTION
We are removing the experimental_ prefix from the prop in React Native. Removing it here as well so this doesn't break