### PR TITLE
Adopt React Native 0.82 DOM Node APIs

### DIFF
--- a/apps/expo-app/app.json
+++ b/apps/expo-app/app.json
@@ -12,7 +12,9 @@
       "resizeMode": "contain",
       "backgroundColor": "#ffffff"
     },
-    "assetBundlePatterns": ["**/*"],
+    "assetBundlePatterns": [
+      "**/*"
+    ],
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
@@ -25,6 +27,9 @@
     "web": {
       "bundler": "metro",
       "favicon": "./assets/favicon.png"
-    }
+    },
+    "plugins": [
+      "expo-build-properties"
+    ]
   }
 }

--- a/apps/expo-app/package.json
+++ b/apps/expo-app/package.json
@@ -10,15 +10,15 @@
     "dev:web": "expo start --web --clear"
   },
   "dependencies": {
-    "@expo/metro-runtime": "~5.0.4",
+    "@expo/metro-runtime": "~55.0.11",
     "example-ui": "0.0.55",
-    "expo": "^53.0.11",
-    "expo-build-properties": "~0.14.6",
-    "expo-status-bar": "~2.2.3",
-    "react": "~19.0.0",
-    "react-dom": "~19.0.0",
-    "react-native": "~0.79.5",
-    "react-native-web": "~0.20.0",
+    "expo": "^55.0.0",
+    "expo-build-properties": "~55.0.13",
+    "expo-status-bar": "~55.0.6",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "react-native": "0.83.6",
+    "react-native-web": "^0.21.0",
     "react-strict-dom": "0.0.55"
   },
   "devDependencies": {

--- a/apps/platform-tests/package.json
+++ b/apps/platform-tests/package.json
@@ -10,14 +10,14 @@
     "dev:web": "expo start --web --clear"
   },
   "dependencies": {
-    "@expo/metro-runtime": "~5.0.4",
-    "expo": "^53.0.11",
-    "expo-build-properties": "~0.14.6",
-    "expo-status-bar": "~2.2.3",
-    "react": "~19.0.0",
-    "react-dom": "~19.0.0",
-    "react-native": "~0.79.5",
-    "react-native-web": "~0.20.0",
+    "@expo/metro-runtime": "~55.0.11",
+    "expo": "^55.0.0",
+    "expo-build-properties": "~55.0.13",
+    "expo-status-bar": "~55.0.6",
+    "react": "19.2.0",
+    "react-dom": "19.2.0",
+    "react-native": "0.83.6",
+    "react-native-web": "^0.21.0",
     "react-strict-dom": "0.0.55"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,9 +44,9 @@
         "patch-package": "^8.0.0",
         "prettier": "^3.3.3",
         "prettier-plugin-hermes-parser": "0.36.1",
-        "react": "~19.2.0",
-        "react-dom": "~19.2.0",
-        "react-test-renderer": "~19.2.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-test-renderer": "^19.0.0",
         "yargs": "17.7.2"
       },
       "engines": {
@@ -35159,7 +35159,7 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-native": ">=0.79.5"
+        "react-native": ">=0.82.0"
       }
     },
     "packages/benchmarks": {
@@ -35232,14 +35232,14 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@testing-library/react": "^16.3.0",
-        "react": "~19.2.0",
-        "react-dom": "~19.2.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
         "rollup": "^4.22.4"
       },
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-native": ">=0.79.5"
+        "react-native": ">=0.82.0"
       }
     },
     "packages/react-strict-dom": {
@@ -35260,9 +35260,9 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.7",
         "@testing-library/react": "^16.3.0",
-        "react": "~19.2.0",
-        "react-dom": "~19.2.0",
-        "react-test-renderer": "~19.2.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-test-renderer": "^19.0.0",
         "rollup": "^4.22.4"
       },
       "engines": {
@@ -35271,7 +35271,7 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-native": ">=0.79.5"
+        "react-native": ">=0.82.0"
       }
     },
     "packages/scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,9 @@
         "patch-package": "^8.0.0",
         "prettier": "^3.3.3",
         "prettier-plugin-hermes-parser": "0.36.1",
+        "react": "~19.2.0",
+        "react-dom": "~19.2.0",
+        "react-test-renderer": "~19.2.0",
         "yargs": "17.7.2"
       },
       "engines": {
@@ -57,19 +60,40 @@
     "apps/expo-app": {
       "version": "0.0.55",
       "dependencies": {
-        "@expo/metro-runtime": "~5.0.4",
+        "@expo/metro-runtime": "~55.0.11",
         "example-ui": "0.0.55",
-        "expo": "^53.0.11",
-        "expo-build-properties": "~0.14.6",
-        "expo-status-bar": "~2.2.3",
-        "react": "~19.0.0",
-        "react-dom": "~19.0.0",
-        "react-native": "~0.79.5",
-        "react-native-web": "~0.20.0",
+        "expo": "^55.0.0",
+        "expo-build-properties": "~55.0.13",
+        "expo-status-bar": "~55.0.6",
+        "react": "19.2.0",
+        "react-dom": "19.2.0",
+        "react-native": "0.83.6",
+        "react-native-web": "^0.21.0",
         "react-strict-dom": "0.0.55"
       },
       "devDependencies": {
         "@babel/core": "^7.27.3"
+      }
+    },
+    "apps/expo-app/node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "apps/expo-app/node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
       }
     },
     "apps/nextjs-app": {
@@ -425,18 +449,39 @@
     "apps/platform-tests": {
       "version": "0.0.55",
       "dependencies": {
-        "@expo/metro-runtime": "~5.0.4",
-        "expo": "^53.0.11",
-        "expo-build-properties": "~0.14.6",
-        "expo-status-bar": "~2.2.3",
-        "react": "~19.0.0",
-        "react-dom": "~19.0.0",
-        "react-native": "~0.79.5",
-        "react-native-web": "~0.20.0",
+        "@expo/metro-runtime": "~55.0.11",
+        "expo": "^55.0.0",
+        "expo-build-properties": "~55.0.13",
+        "expo-status-bar": "~55.0.6",
+        "react": "19.2.0",
+        "react-dom": "19.2.0",
+        "react-native": "0.83.6",
+        "react-native-web": "^0.21.0",
         "react-strict-dom": "0.0.55"
       },
       "devDependencies": {
         "@babel/core": "^7.27.3"
+      }
+    },
+    "apps/platform-tests/node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "apps/platform-tests/node_modules/react-dom": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
+      "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
       }
     },
     "apps/vite-app": {
@@ -832,25 +877,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "apps/vite-app/node_modules/react": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
-      "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/vite-app/node_modules/react-dom": {
-      "version": "19.2.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
-      "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.1"
-      }
-    },
     "apps/vite-app/node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -970,20 +996,6 @@
       },
       "peerDependenciesMeta": {
         "vite": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@0no-co/graphql.web": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
-      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
-      },
-      "peerDependenciesMeta": {
-        "graphql": {
           "optional": true
         }
       }
@@ -1272,12 +1284,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -1343,12 +1355,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -1386,17 +1399,17 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-      "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+      "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.27.1",
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
         "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/helper-replace-supers": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-        "@babel/traverse": "^7.27.1",
+        "@babel/traverse": "^7.29.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1449,13 +1462,13 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-      "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1503,9 +1516,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1529,14 +1542,14 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-      "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.27.1",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
         "@babel/helper-optimise-call-expression": "^7.27.1",
-        "@babel/traverse": "^7.27.1"
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1610,98 +1623,13 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/highlight": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.9.tgz",
-      "integrity": "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1790,14 +1718,14 @@
       }
     },
     "node_modules/@babel/plugin-proposal-decorators": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.28.0.tgz",
-      "integrity": "sha512-zOiZqvANjWDUaUS9xMxbMcK/Zccztbe/6ikvUXaG9nsPH3w6qh5UaPGAnirI/WhIbZ8m3OHU0ReyPrknG+ZKeg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.0.tgz",
+      "integrity": "sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.27.1",
-        "@babel/helper-plugin-utils": "^7.27.1",
-        "@babel/plugin-syntax-decorators": "^7.27.1"
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/plugin-syntax-decorators": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1885,12 +1813,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-decorators": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.27.1.tgz",
-      "integrity": "sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.28.6.tgz",
+      "integrity": "sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1912,12 +1840,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-export-default-from": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.27.1.tgz",
-      "integrity": "sha512-eBC/3KSekshx19+N40MzjWqJd7KTEdOoLesAfa4IDFI8eRz5a47i5Oszus6zG/cwIXN63YhgLOMSSNJx49sENg==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.28.6.tgz",
+      "integrity": "sha512-Svlx1fjJFnNz0LZeUaybRukSxZI3KkpApUmIRzEdXC5k8ErTOz0OD0kNrICi5Vc3GlpP5ZCeRyRO+mfWTSz+iQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
+        "@babel/helper-plugin-utils": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -3320,49 +3248,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
-      "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse--for-generate-function-map": {
-      "name": "@babel/traverse",
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-      "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.0",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.0",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -3370,9 +3280,10 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
@@ -6219,32 +6130,32 @@
       }
     },
     "node_modules/@expo/cli": {
-      "version": "0.24.21",
-      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-0.24.21.tgz",
-      "integrity": "sha512-DT6K9vgFHqqWL/19mU1ofRcPoO1pn4qmgi76GtuiNU4tbBe/02mRHwFsQw7qRfFAT28If5e/wiwVozgSuZVL8g==",
+      "version": "55.0.32",
+      "resolved": "https://registry.npmjs.org/@expo/cli/-/cli-55.0.32.tgz",
+      "integrity": "sha512-fq+/yUYBVw5ZudT4igNyJ3WaF17R39iS7EZlrkfHkLI7Y1kmUlivabwKviLoAfepJOKjKODKpViti9EPfmG3SQ==",
       "license": "MIT",
       "dependencies": {
-        "@0no-co/graphql.web": "^1.0.8",
-        "@babel/runtime": "^7.20.0",
-        "@expo/code-signing-certificates": "^0.0.5",
-        "@expo/config": "~11.0.13",
-        "@expo/config-plugins": "~10.1.2",
-        "@expo/devcert": "^1.1.2",
-        "@expo/env": "~1.0.7",
-        "@expo/image-utils": "^0.7.6",
-        "@expo/json-file": "^9.1.5",
-        "@expo/metro-config": "~0.20.17",
-        "@expo/osascript": "^2.2.5",
-        "@expo/package-manager": "^1.8.6",
-        "@expo/plist": "^0.3.5",
-        "@expo/prebuild-config": "^9.0.11",
-        "@expo/schema-utils": "^0.1.0",
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/config": "~55.0.17",
+        "@expo/config-plugins": "~55.0.10",
+        "@expo/devcert": "^1.2.1",
+        "@expo/env": "~2.1.2",
+        "@expo/image-utils": "^0.8.14",
+        "@expo/json-file": "^10.0.15",
+        "@expo/log-box": "55.0.12",
+        "@expo/metro": "~55.1.1",
+        "@expo/metro-config": "~55.0.23",
+        "@expo/osascript": "^2.4.4",
+        "@expo/package-manager": "^1.10.5",
+        "@expo/plist": "^0.5.4",
+        "@expo/prebuild-config": "^55.0.18",
+        "@expo/require-utils": "^55.0.5",
+        "@expo/router-server": "^55.0.18",
+        "@expo/schema-utils": "^55.0.4",
         "@expo/spawn-async": "^1.7.2",
         "@expo/ws-tunnel": "^1.0.1",
-        "@expo/xcpretty": "^4.3.0",
-        "@react-native/dev-middleware": "0.79.6",
-        "@urql/core": "^5.0.6",
-        "@urql/exchange-retry": "^1.3.0",
+        "@expo/xcpretty": "^4.4.0",
+        "@react-native/dev-middleware": "0.83.6",
         "accepts": "^1.3.8",
         "arg": "^5.0.2",
         "better-opn": "~3.0.2",
@@ -6255,49 +6166,69 @@
         "compression": "^1.7.4",
         "connect": "^3.7.0",
         "debug": "^4.3.4",
-        "env-editor": "^0.4.1",
-        "freeport-async": "^2.0.0",
+        "dnssd-advertise": "^1.1.4",
+        "expo-server": "^55.0.11",
+        "fetch-nodeshim": "^0.4.10",
         "getenv": "^2.0.0",
-        "glob": "^10.4.2",
-        "lan-network": "^0.1.6",
-        "minimatch": "^9.0.0",
-        "node-forge": "^1.3.1",
+        "glob": "^13.0.0",
+        "lan-network": "^0.2.1",
+        "multitars": "^1.0.0",
+        "node-forge": "^1.3.3",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
-        "picomatch": "^3.0.1",
-        "pretty-bytes": "^5.6.0",
+        "picomatch": "^4.0.3",
         "pretty-format": "^29.7.0",
         "progress": "^2.0.3",
         "prompts": "^2.3.2",
-        "qrcode-terminal": "0.11.0",
-        "require-from-string": "^2.0.2",
-        "requireg": "^0.2.2",
-        "resolve": "^1.22.2",
         "resolve-from": "^5.0.0",
-        "resolve.exports": "^2.0.3",
         "semver": "^7.6.0",
         "send": "^0.19.0",
         "slugify": "^1.3.4",
         "source-map-support": "~0.5.21",
         "stacktrace-parser": "^0.1.10",
         "structured-headers": "^0.4.1",
-        "tar": "^7.4.3",
         "terminal-link": "^2.1.1",
-        "undici": "^6.18.2",
+        "toqr": "^0.1.1",
         "wrap-ansi": "^7.0.0",
-        "ws": "^8.12.1"
+        "ws": "^8.12.1",
+        "zod": "^3.25.76"
       },
       "bin": {
         "expo-internal": "build/bin/cli"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "expo-router": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo-router": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/cli/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@expo/cli/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@expo/cli/node_modules/emoji-regex": {
@@ -6307,20 +6238,17 @@
       "license": "MIT"
     },
     "node_modules/@expo/cli/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6335,37 +6263,62 @@
         "node": ">=8"
       }
     },
+    "node_modules/@expo/cli/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@expo/cli/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/cli/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@expo/cli/node_modules/picomatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-      "integrity": "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@expo/cli/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6416,106 +6369,145 @@
       }
     },
     "node_modules/@expo/code-signing-certificates": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.5.tgz",
-      "integrity": "sha512-BNhXkY1bblxKZpltzAx98G2Egj9g1Q+JRcvR7E99DOj862FTCX+ZPsAUtPTr7aHxwtrL7+fL3r0JSmM9kBm+Bw==",
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
+      "integrity": "sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==",
       "license": "MIT",
       "dependencies": {
-        "node-forge": "^1.2.1",
-        "nullthrows": "^1.1.1"
+        "node-forge": "^1.3.3"
       }
     },
     "node_modules/@expo/config": {
-      "version": "11.0.13",
-      "resolved": "https://registry.npmjs.org/@expo/config/-/config-11.0.13.tgz",
-      "integrity": "sha512-TnGb4u/zUZetpav9sx/3fWK71oCPaOjZHoVED9NaEncktAd0Eonhq5NUghiJmkUGt3gGSjRAEBXiBbbY9/B1LA==",
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-55.0.17.tgz",
+      "integrity": "sha512-Y3VaRg7Jllg3MhlUOTQqHm6/dttsqcjYlnS9enhAllZvPUpTHnRA4YPETtUZlxkdMJy6y3UZe986pd/KfJ6OTg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "@expo/config-plugins": "~10.1.2",
-        "@expo/config-types": "^53.0.5",
-        "@expo/json-file": "^9.1.5",
+        "@expo/config-plugins": "~55.0.9",
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "^10.0.14",
+        "@expo/require-utils": "^55.0.5",
         "deepmerge": "^4.3.1",
         "getenv": "^2.0.0",
-        "glob": "^10.4.2",
-        "require-from-string": "^2.0.2",
-        "resolve-from": "^5.0.0",
+        "glob": "^13.0.0",
         "resolve-workspace-root": "^2.0.0",
         "semver": "^7.6.0",
-        "slugify": "^1.3.4",
-        "sucrase": "3.35.0"
+        "slugify": "^1.3.4"
       }
     },
     "node_modules/@expo/config-plugins": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-10.1.2.tgz",
-      "integrity": "sha512-IMYCxBOcnuFStuK0Ay+FzEIBKrwW8OVUMc65+v0+i7YFIIe8aL342l7T4F8lR4oCfhXn7d6M5QPgXvjtc/gAcw==",
+      "version": "55.0.10",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-55.0.10.tgz",
+      "integrity": "sha512-1txnRnMLIO5lM/Of/VyvDkCwZap0YFvCyfSTIlUQamhwhx6Rh7r8TXfcIstaDYUQ7X6GTMkNxLXWbcYS6ZAFDw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config-types": "^53.0.5",
-        "@expo/json-file": "~9.1.5",
-        "@expo/plist": "^0.3.5",
+        "@expo/config-types": "^55.0.5",
+        "@expo/json-file": "~10.0.15",
+        "@expo/plist": "^0.5.4",
         "@expo/sdk-runtime-versions": "^1.0.0",
         "chalk": "^4.1.2",
         "debug": "^4.3.5",
         "getenv": "^2.0.0",
-        "glob": "^10.4.2",
+        "glob": "^13.0.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.4",
-        "slash": "^3.0.0",
         "slugify": "^1.6.6",
         "xcode": "^3.0.1",
         "xml2js": "0.6.0"
       }
     },
-    "node_modules/@expo/config-plugins/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+    "node_modules/@expo/config-plugins/node_modules/@expo/json-file": {
+      "version": "10.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.15.tgz",
+      "integrity": "sha512-xLtsy1820Rf2myhhIc7WmfoUg5cWEJB9tEylhgGhRF/acYGuUXUVkKHYoHY31GbYf6CIZNvipTFxuvWRpVlXTw==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "@babel/code-frame": "^7.20.0",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@expo/config-plugins/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@expo/config-plugins/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/config-plugins/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@expo/config-plugins/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6524,78 +6516,94 @@
         "node": ">=10"
       }
     },
-    "node_modules/@expo/config-plugins/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@expo/config-types": {
-      "version": "53.0.5",
-      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-53.0.5.tgz",
-      "integrity": "sha512-kqZ0w44E+HEGBjy+Lpyn0BVL5UANg/tmNixxaRMLS6nf37YsDrLk2VMAmeKMMk5CKG0NmOdVv3ngeUjRQMsy9g==",
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-55.0.5.tgz",
+      "integrity": "sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==",
       "license": "MIT"
     },
-    "node_modules/@expo/config/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+    "node_modules/@expo/config/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@expo/config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@expo/config/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@expo/config/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/@expo/config/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/config/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@expo/config/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6605,23 +6613,13 @@
       }
     },
     "node_modules/@expo/devcert": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@expo/devcert/-/devcert-1.2.0.tgz",
-      "integrity": "sha512-Uilcv3xGELD5t/b0eM4cxBFEKQRIivB3v7i+VhWLV/gL98aw810unLKKJbGAxAIhY6Ipyz8ChWibFsKFXYwstA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@expo/devcert/-/devcert-1.2.1.tgz",
+      "integrity": "sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==",
       "license": "MIT",
       "dependencies": {
         "@expo/sudo-prompt": "^9.3.1",
-        "debug": "^3.1.0",
-        "glob": "^10.4.2"
-      }
-    },
-    "node_modules/@expo/devcert/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
+        "debug": "^3.1.0"
       }
     },
     "node_modules/@expo/devcert/node_modules/debug": {
@@ -6633,70 +6631,67 @@
         "ms": "^2.1.1"
       }
     },
-    "node_modules/@expo/devcert/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
+    "node_modules/@expo/devtools": {
+      "version": "55.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/devtools/-/devtools-55.0.3.tgz",
+      "integrity": "sha512-KoIDgo0NoXeWLsIcOdZqtAG/1LlsM+JL0DA3bo0vCYaOYTBLXi/ZvRBqa20Ub8D2vKLNa+FgRQW0gRg04Ps1Pg==",
+      "license": "MIT",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "chalk": "^4.1.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@expo/devcert/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+    "node_modules/@expo/dom-webview": {
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-55.0.6.tgz",
+      "integrity": "sha512-ZNm8tiNEZysxrr36J0x4mOCGyJDcaIvL/3tMxBz0VJIJDcV19xjuJAhJQxHovu+jKx6s9tRyEAINa1mdrzV39g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@expo/env": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/env/-/env-1.0.7.tgz",
-      "integrity": "sha512-qSTEnwvuYJ3umapO9XJtrb1fAqiPlmUUg78N0IZXXGwQRt+bkp0OBls+Y5Mxw/Owj8waAM0Z3huKKskRADR5ow==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.1.2.tgz",
+      "integrity": "sha512-RJtGFfj/ygO/6zcVbV3cckHf4THcEkv5IZft1GjCB3dfT6axvzvIwXE9EiQqQYmGHcQ+ZrvC8xZcIhiHba0pYg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "debug": "^4.3.4",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
         "getenv": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.12.0"
       }
     },
     "node_modules/@expo/fingerprint": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.13.4.tgz",
-      "integrity": "sha512-MYfPYBTMfrrNr07DALuLhG6EaLVNVrY/PXjEzsjWdWE4ZFn0yqI0IdHNkJG7t1gePT8iztHc7qnsx+oo/rDo6w==",
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.16.7.tgz",
+      "integrity": "sha512-BH8sicYOqZ1iBMwCVEGIz6uTTfylosjc49FoMmCYIzKOiYdiVehsfoYBwyfxwWIiya1VMhm1gv0cgOP8fxHpDw==",
       "license": "MIT",
       "dependencies": {
+        "@expo/env": "^2.1.2",
         "@expo/spawn-async": "^1.7.2",
         "arg": "^5.0.2",
         "chalk": "^4.1.2",
         "debug": "^4.3.4",
-        "find-up": "^5.0.0",
         "getenv": "^2.0.0",
-        "glob": "^10.4.2",
+        "glob": "^13.0.0",
         "ignore": "^5.3.1",
-        "minimatch": "^9.0.0",
-        "p-limit": "^3.1.0",
+        "minimatch": "^10.2.2",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       },
@@ -6704,100 +6699,88 @@
         "fingerprint": "bin/cli.js"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+    "node_modules/@expo/fingerprint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+    "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@expo/fingerprint/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
+    "node_modules/@expo/fingerprint/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@expo/fingerprint/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@expo/fingerprint/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
+    "node_modules/@expo/fingerprint/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "p-limit": "^3.0.2"
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@expo/fingerprint/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6807,26 +6790,24 @@
       }
     },
     "node_modules/@expo/image-utils": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.7.6.tgz",
-      "integrity": "sha512-GKnMqC79+mo/1AFrmAcUcGfbsXXTRqOMNS1umebuevl3aaw+ztsYEFEiuNhHZW7PQ3Xs3URNT513ZxKhznDscw==",
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.14.tgz",
+      "integrity": "sha512-5Sn+jG4Cw+shC2wDMXoqSAJnvERbiwzHn05FpWtD5IBflfTIs5gUmjzwiGVyjOdlMSQhgRrw/AymPbmO9h9mpQ==",
       "license": "MIT",
       "dependencies": {
+        "@expo/require-utils": "^55.0.5",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.0.0",
         "getenv": "^2.0.0",
         "jimp-compact": "0.16.1",
         "parse-png": "^2.1.0",
-        "resolve-from": "^5.0.0",
-        "semver": "^7.6.0",
-        "temp-dir": "~2.0.0",
-        "unique-string": "~2.0.0"
+        "semver": "^7.6.0"
       }
     },
     "node_modules/@expo/image-utils/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6836,211 +6817,306 @@
       }
     },
     "node_modules/@expo/json-file": {
-      "version": "9.1.5",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-9.1.5.tgz",
-      "integrity": "sha512-prWBhLUlmcQtvN6Y7BpW2k9zXGd3ySa3R6rAguMJkp1z22nunLN64KYTUWfijFlprFoxm9r2VNnGkcbndAlgKA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
+      "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "~7.10.4",
+        "@babel/code-frame": "^7.20.0",
         "json5": "^2.2.3"
       }
     },
-    "node_modules/@expo/json-file/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+    "node_modules/@expo/local-build-cache-provider": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/@expo/local-build-cache-provider/-/local-build-cache-provider-55.0.13.tgz",
+      "integrity": "sha512-Vg5BE10UL+0yg3BVtIeiSoeHU31Qe1m3UxhBPS478ACY1zzKuxZE30x2sym/B2OIWypjmPzXDRt8J9TOGFuFNw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/highlight": "^7.10.4"
+        "@expo/config": "~55.0.17",
+        "chalk": "^4.1.2"
       }
     },
-    "node_modules/@expo/metro-config": {
-      "version": "0.20.17",
-      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-0.20.17.tgz",
-      "integrity": "sha512-lpntF2UZn5bTwrPK6guUv00Xv3X9mkN3YYla+IhEHiYXWyG7WKOtDU0U4KR8h3ubkZ6SPH3snDyRyAzMsWtZFA==",
+    "node_modules/@expo/log-box": {
+      "version": "55.0.12",
+      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-55.0.12.tgz",
+      "integrity": "sha512-f9ARS8J60cq3LLNdIqmUjYwyerBzVS5Ecp7KjIf3GOIPjW0571rkcwLz4/U18l/1DeSkSzIkYsNl2TC9oTdWaQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.20.0",
-        "@babel/generator": "^7.20.5",
-        "@babel/parser": "^7.20.0",
-        "@babel/types": "^7.20.0",
-        "@expo/config": "~11.0.12",
-        "@expo/env": "~1.0.7",
-        "@expo/json-file": "~9.1.5",
-        "@expo/spawn-async": "^1.7.2",
-        "chalk": "^4.1.0",
-        "debug": "^4.3.2",
-        "dotenv": "~16.4.5",
-        "dotenv-expand": "~11.0.6",
-        "getenv": "^2.0.0",
-        "glob": "^10.4.2",
-        "jsc-safe-url": "^0.2.4",
-        "lightningcss": "~1.27.0",
-        "minimatch": "^9.0.0",
-        "postcss": "~8.4.32",
-        "resolve-from": "^5.0.0"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
+        "@expo/dom-webview": "^55.0.6",
+        "anser": "^1.4.9",
+        "stacktrace-parser": "^0.1.10"
       },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/@expo/metro-runtime": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-5.0.4.tgz",
-      "integrity": "sha512-r694MeO+7Vi8IwOsDIDzH/Q5RPMt1kUDYbiTJwnO15nIqiDwlE8HU55UlRhffKZy6s5FmxQsZ8HA+T8DqUW8cQ==",
-      "license": "MIT",
       "peerDependencies": {
+        "@expo/dom-webview": "^55.0.6",
+        "expo": "*",
+        "react": "*",
         "react-native": "*"
       }
     },
-    "node_modules/@expo/osascript": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.3.7.tgz",
-      "integrity": "sha512-IClSOXxR0YUFxIriUJVqyYki7lLMIHrrzOaP01yxAL1G8pj2DWV5eW1y5jSzIcIfSCNhtGsshGd1tU/AYup5iQ==",
+    "node_modules/@expo/metro": {
+      "version": "55.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/metro/-/metro-55.1.1.tgz",
+      "integrity": "sha512-/wfXo5hTuAVpVLG/4hzlmD9NBGJkzkmBEMm/4VICajYRbj7y8OmqqPWbbymzHiBiHB6tI9BnsyXpQM6zVZEECg==",
       "license": "MIT",
       "dependencies": {
+        "metro": "0.83.7",
+        "metro-babel-transformer": "0.83.7",
+        "metro-cache": "0.83.7",
+        "metro-cache-key": "0.83.7",
+        "metro-config": "0.83.7",
+        "metro-core": "0.83.7",
+        "metro-file-map": "0.83.7",
+        "metro-minify-terser": "0.83.7",
+        "metro-resolver": "0.83.7",
+        "metro-runtime": "0.83.7",
+        "metro-source-map": "0.83.7",
+        "metro-symbolicate": "0.83.7",
+        "metro-transform-plugins": "0.83.7",
+        "metro-transform-worker": "0.83.7"
+      }
+    },
+    "node_modules/@expo/metro-config": {
+      "version": "55.0.23",
+      "resolved": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-55.0.23.tgz",
+      "integrity": "sha512-Mkw3Ss/1LFlafH3iie3r9E13yKMyJgZqGTEkGviGf6LYp51eY5fR8ATbXrNsH69wVc2z+ty4lT/8lEA18YJv7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.20.0",
+        "@babel/generator": "^7.20.5",
+        "@expo/config": "~55.0.17",
+        "@expo/env": "~2.1.2",
+        "@expo/json-file": "~10.0.15",
+        "@expo/metro": "~55.1.1",
         "@expo/spawn-async": "^1.7.2",
-        "exec-async": "^2.2.0"
+        "browserslist": "^4.25.0",
+        "chalk": "^4.1.0",
+        "debug": "^4.3.2",
+        "getenv": "^2.0.0",
+        "glob": "^13.0.0",
+        "hermes-parser": "^0.32.0",
+        "jsc-safe-url": "^0.2.4",
+        "lightningcss": "^1.30.1",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.14",
+        "resolve-from": "^5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/@expo/json-file": {
+      "version": "10.0.15",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.15.tgz",
+      "integrity": "sha512-xLtsy1820Rf2myhhIc7WmfoUg5cWEJB9tEylhgGhRF/acYGuUXUVkKHYoHY31GbYf6CIZNvipTFxuvWRpVlXTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-estree": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.1.tgz",
+      "integrity": "sha512-ne5hkuDxheNBAikDjqvCZCwihnz0vVu9YsBzAEO1puiyFR4F1+PAz/SiPHSsNTuOveCYGRMX8Xbx4LOubeC0Qg==",
+      "license": "MIT"
+    },
+    "node_modules/@expo/metro-config/node_modules/hermes-parser": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.1.tgz",
+      "integrity": "sha512-175dz634X/W5AiwrpLdoMl/MOb17poLHyIqgyExlE8D9zQ1OPnoORnGMB5ltRKnpvQzBjMYvT2rN/sHeIfZW5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.32.1"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/lru-cache": {
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@expo/metro-config/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@expo/metro-runtime": {
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-55.0.11.tgz",
+      "integrity": "sha512-4KKi/jGrIEXi2YGu0hYTVr0CEeRJy5SXbCrz9+KDZkuD3ROwKNpM1DBawni5rhPVovFnR323HBck9GaxhnfrRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/log-box": "55.0.12",
+        "anser": "^1.4.9",
+        "pretty-format": "^29.7.0",
+        "stacktrace-parser": "^0.1.10",
+        "whatwg-fetch": "^3.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-dom": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/osascript": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@expo/osascript/-/osascript-2.6.0.tgz",
+      "integrity": "sha512-QvqDBlJXa8CS2vRORJ4wEflY1m0vVI07uSJdIRgBrLxRPBcsrXxrtU7+wXRXMqfq9zLwNP9XbvRsXF2omoDylg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/spawn-async": "^1.8.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@expo/package-manager": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.9.7.tgz",
-      "integrity": "sha512-k3uky8Qzlv21rxuPvP2KUTAy8NI0b/LP7BSXcwJpS/rH7RmiAqUXgzPar3I1OmKGgxpod78Y9Mae//F8d3aiOQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@expo/package-manager/-/package-manager-1.12.0.tgz",
+      "integrity": "sha512-SWr6093nwBjn94cvElsYZNUnhvs+XtUatUz3h0vAn0IbaWG0B6l/V5ZfOBptX/xq6rMpFG5ibIf/eckLSXw8Gg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/json-file": "^10.0.7",
-        "@expo/spawn-async": "^1.7.2",
+        "@expo/json-file": "^10.2.0",
+        "@expo/spawn-async": "^1.8.0",
         "chalk": "^4.0.0",
         "npm-package-arg": "^11.0.0",
         "ora": "^3.4.0",
         "resolve-workspace-root": "^2.0.0"
       }
     },
-    "node_modules/@expo/package-manager/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
-      }
-    },
-    "node_modules/@expo/package-manager/node_modules/@expo/json-file": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
-      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "~7.10.4",
-        "json5": "^2.2.3"
-      }
-    },
     "node_modules/@expo/plist": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.3.5.tgz",
-      "integrity": "sha512-9RYVU1iGyCJ7vWfg3e7c/NVyMFs8wbl+dMWZphtFtsqyN9zppGREU3ctlD3i8KUE0sCUTVnLjCWr+VeUIDep2g==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.5.4.tgz",
+      "integrity": "sha512-Jqppj0FULNq6Zp5JtQrFICl8TtpMjwwUbxEcEC2T3z7m+TOrTQEHZXz3D3Ay7vhbmvD+VMgfWJ4ARclJXeN8Eg==",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.8",
-        "base64-js": "^1.2.3",
+        "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       }
     },
     "node_modules/@expo/prebuild-config": {
-      "version": "9.0.12",
-      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-9.0.12.tgz",
-      "integrity": "sha512-AKH5Scf+gEMgGxZZaimrJI2wlUJlRoqzDNn7/rkhZa5gUTnO4l6slKak2YdaH+nXlOWCNfAQWa76NnpQIfmv6Q==",
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-55.0.18.tgz",
+      "integrity": "sha512-2oKXyy5pyM87DJqXW5Z+Sakle6rApFFtpPhWOiNsOdoh6rOAD+EqVgyrs2OEEic8CE0tTt27w3SRfSZe/PZrxg==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~11.0.13",
-        "@expo/config-plugins": "~10.1.2",
-        "@expo/config-types": "^53.0.5",
-        "@expo/image-utils": "^0.7.6",
-        "@expo/json-file": "^9.1.5",
-        "@react-native/normalize-colors": "0.79.6",
+        "@expo/config": "~55.0.17",
+        "@expo/config-plugins": "~55.0.9",
+        "@expo/config-types": "^55.0.5",
+        "@expo/image-utils": "^0.8.14",
+        "@expo/json-file": "^10.0.14",
+        "@react-native/normalize-colors": "0.83.6",
         "debug": "^4.3.1",
         "resolve-from": "^5.0.0",
         "semver": "^7.6.0",
         "xml2js": "0.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
+    "node_modules/@expo/prebuild-config/node_modules/@react-native/normalize-colors": {
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.83.6.tgz",
+      "integrity": "sha512-bTM24b5v4qN3h52oflnv+OujFORn/kVi06WaWhnQQw14/ycilPqIsqsa+DpIBqdBrXxvLa9fXtCRrQtGATZCEw==",
+      "license": "MIT"
+    },
     "node_modules/@expo/prebuild-config/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7049,10 +7125,63 @@
         "node": ">=10"
       }
     },
+    "node_modules/@expo/require-utils": {
+      "version": "55.0.5",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.5.tgz",
+      "integrity": "sha512-U4K/CQ2VpXuwfNGsN+daKmYOt15hCP8v/pXaYH6eut7kdYZo6SfJ1yr67BIcJ+1Gzzs+QzTxswAZChKpXmceyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@expo/router-server": {
+      "version": "55.0.18",
+      "resolved": "https://registry.npmjs.org/@expo/router-server/-/router-server-55.0.18.tgz",
+      "integrity": "sha512-W0VsvIiR48OvdlAOUlag4qspGYT/DV4srfYowlbYxwZh5Qw0MjiZAID4Zt7F0qynGZZxx8OZPpFhIX7XsqtRmg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "@expo/metro-runtime": "^55.0.11",
+        "expo": "*",
+        "expo-constants": "^55.0.16",
+        "expo-font": "^55.0.8",
+        "expo-router": "*",
+        "expo-server": "^55.0.11",
+        "react": "*",
+        "react-dom": "*",
+        "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@expo/metro-runtime": {
+          "optional": true
+        },
+        "expo-router": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-server-dom-webpack": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@expo/schema-utils": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-0.1.7.tgz",
-      "integrity": "sha512-jWHoSuwRb5ZczjahrychMJ3GWZu54jK9ulNdh1d4OzAEq672K9E5yOlnlBsfIHWHGzUAT+0CL7Yt1INiXTz68g==",
+      "version": "55.0.4",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.4.tgz",
+      "integrity": "sha512-65IdeeE8dAZR3n3J5Eq7LYiQ8BFGeEYCWPBCzycvafL7PkskbCyIclTQarRwf/HXFoRvezKCjaLwy/8v9Prk6g==",
       "license": "MIT"
     },
     "node_modules/@expo/sdk-runtime-versions": {
@@ -7062,12 +7191,12 @@
       "license": "MIT"
     },
     "node_modules/@expo/spawn-async": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.7.2.tgz",
-      "integrity": "sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@expo/spawn-async/-/spawn-async-1.8.0.tgz",
+      "integrity": "sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==",
       "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.3"
+        "cross-spawn": "^7.0.6"
       },
       "engines": {
         "node": ">=12"
@@ -7080,12 +7209,12 @@
       "license": "MIT"
     },
     "node_modules/@expo/vector-icons": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-14.1.0.tgz",
-      "integrity": "sha512-7T09UE9h8QDTsUeMGymB4i+iqvtEeaO5VvUjryFB4tugDTG/bkzViWA74hm5pfjjDEhYMXWaX112mcvhccmIwQ==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@expo/vector-icons/-/vector-icons-15.1.1.tgz",
+      "integrity": "sha512-Iu2VkcoI5vygbtYngm7jb4ifxElNVXQYdDrYkT7UCEIiKLeWnQY0wf2ZhHZ+Wro6Sc5TaumpKUOqDRpLi5rkvw==",
       "license": "MIT",
       "peerDependencies": {
-        "expo-font": "*",
+        "expo-font": ">=14.0.4",
         "react": "*",
         "react-native": "*"
       }
@@ -7097,27 +7226,17 @@
       "license": "MIT"
     },
     "node_modules/@expo/xcpretty": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.3.2.tgz",
-      "integrity": "sha512-ReZxZ8pdnoI3tP/dNnJdnmAk7uLT4FjsKDGW7YeDdvdOMz2XCQSmSCM9IWlrXuWtMF9zeSB6WJtEhCQ41gQOfw==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@expo/xcpretty/-/xcpretty-4.4.4.tgz",
+      "integrity": "sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@babel/code-frame": "7.10.4",
+        "@babel/code-frame": "^7.20.0",
         "chalk": "^4.1.0",
-        "find-up": "^5.0.0",
         "js-yaml": "^4.1.0"
       },
       "bin": {
         "excpretty": "build/cli.js"
-      }
-    },
-    "node_modules/@expo/xcpretty/node_modules/@babel/code-frame": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@expo/xcpretty/node_modules/argparse": {
@@ -7126,62 +7245,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/@expo/xcpretty/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@expo/xcpretty/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@expo/xcpretty/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@expo/xcpretty/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@hapi/hoek": {
@@ -7717,6 +7790,7 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -7734,6 +7808,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7746,6 +7821,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -7755,18 +7831,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@isaacs/ttlcache": {
@@ -8558,6 +8622,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8612,31 +8677,31 @@
       "license": "MIT"
     },
     "node_modules/@react-native/assets-registry": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.5.tgz",
-      "integrity": "sha512-N4Kt1cKxO5zgM/BLiyzuuDNquZPiIgfktEQ6TqJ/4nKA8zr4e8KJgU6Tb2eleihDO4E24HmkvGc73naybKRz/w==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.83.6.tgz",
+      "integrity": "sha512-iljb4ue1yWJ3EhySz7EjV6CzSVrI2uNtR8BI2jzP5+QS5E4Cl3fdIJRmVwDEx1pu8uE97PGEusGRHnoaZ9Q3jg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.79.6.tgz",
-      "integrity": "sha512-CS5OrgcMPixOyUJ/Sk/HSsKsKgyKT5P7y3CojimOQzWqRZBmoQfxdST4ugj7n1H+ebM2IKqbgovApFbqXsoX0g==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.83.6.tgz",
+      "integrity": "sha512-qfRXsHGeucT5c6mK+8Q7v4Ly3zmygfVmFlEtkiq7q07W1OTreld6nib4rJ/DBEeNiKBoBTuHjWliYGNuDjLFQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.3",
-        "@react-native/codegen": "0.79.6"
+        "@react-native/codegen": "0.83.6"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/babel-preset": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.79.6.tgz",
-      "integrity": "sha512-H+FRO+r2Ql6b5IwfE0E7D52JhkxjeGSBSUpCXAI5zQ60zSBJ54Hwh2bBJOohXWl4J+C7gKYSAd2JHMUETu+c/A==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.83.6.tgz",
+      "integrity": "sha512-4/fXFDUvGOObETZq4+SUFkafld6OGgQWut5cQiqVghlhCB5z/p2lVhPgEUr/aTxTzeS3AmN+ztC+GpYPQ7tsTw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -8680,43 +8745,58 @@
         "@babel/plugin-transform-typescript": "^7.25.2",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
         "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.79.6",
-        "babel-plugin-syntax-hermes-parser": "0.25.1",
+        "@react-native/babel-plugin-codegen": "0.83.6",
+        "babel-plugin-syntax-hermes-parser": "0.32.0",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "react-refresh": "^0.14.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
         "@babel/core": "*"
       }
     },
     "node_modules/@react-native/babel-preset/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
       "license": "MIT",
       "dependencies": {
-        "hermes-parser": "0.25.1"
+        "hermes-parser": "0.32.0"
+      }
+    },
+    "node_modules/@react-native/babel-preset/node_modules/hermes-estree": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-native/babel-preset/node_modules/hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.32.0"
       }
     },
     "node_modules/@react-native/codegen": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.6.tgz",
-      "integrity": "sha512-iRBX8Lgbqypwnfba7s6opeUwVyaR23mowh9ILw7EcT2oLz3RqMmjJdrbVpWhGSMGq2qkPfqAH7bhO8C7O+xfjQ==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.83.6.tgz",
+      "integrity": "sha512-doB/Pq6Cf6IjF3wlQXTIiZOnsX9X8mEEk+CdGfyuCwZjWrf7IB8KaZEXXckJmfUcIwvJ9u/a72ZoTTCIoxAc9A==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "@babel/parser": "^7.25.3",
         "glob": "^7.1.1",
-        "hermes-parser": "0.25.1",
+        "hermes-parser": "0.32.0",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "yargs": "^17.6.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
         "@babel/core": "*"
@@ -8726,7 +8806,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -8743,83 +8823,55 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.5.tgz",
-      "integrity": "sha512-ApLO1ARS8JnQglqS3JAHk0jrvB+zNW3dvNJyXPZPoygBpZVbf8sjvqeBiaEYpn8ETbFWddebC4HoQelDndnrrA==",
+    "node_modules/@react-native/codegen/node_modules/hermes-estree": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-native/codegen/node_modules/hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
       "license": "MIT",
       "dependencies": {
-        "@react-native/dev-middleware": "0.79.5",
-        "chalk": "^4.0.0",
-        "debug": "^2.2.0",
+        "hermes-estree": "0.32.0"
+      }
+    },
+    "node_modules/@react-native/community-cli-plugin": {
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.6.tgz",
+      "integrity": "sha512-Mko6mywoHYJmpBnjwAC95vQWaUUh//71knFadH0BrhHDq2m7i/IrpLwcQsPAy8855ucXflBs5zQyGTpNbPBAaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/dev-middleware": "0.83.6",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
-        "metro": "^0.82.0",
-        "metro-config": "^0.82.0",
-        "metro-core": "^0.82.0",
+        "metro": "^0.83.6",
+        "metro-config": "^0.83.6",
+        "metro-core": "^0.83.6",
         "semver": "^7.1.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@react-native-community/cli": "*"
+        "@react-native-community/cli": "*",
+        "@react-native/metro-config": "*"
       },
       "peerDependenciesMeta": {
         "@react-native-community/cli": {
           "optional": true
+        },
+        "@react-native/metro-config": {
+          "optional": true
         }
       }
     },
-    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.5.tgz",
-      "integrity": "sha512-WQ49TRpCwhgUYo5/n+6GGykXmnumpOkl4Lr2l2o2buWU9qPOwoiBqJAtmWEXsAug4ciw3eLiVfthn5ufs0VB0A==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/@react-native/dev-middleware": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.5.tgz",
-      "integrity": "sha512-U7r9M/SEktOCP/0uS6jXMHmYjj4ESfYCkNAenBjFjjsRWekiHE+U/vRMeO+fG9gq4UCcBAUISClkQCowlftYBw==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.5",
-        "chrome-launcher": "^0.15.2",
-        "chromium-edge-launcher": "^0.2.0",
-        "connect": "^3.6.5",
-        "debug": "^2.2.0",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "open": "^7.0.3",
-        "serve-static": "^1.16.2",
-        "ws": "^6.2.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
-    },
     "node_modules/@react-native/community-cli-plugin/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8828,86 +8880,88 @@
         "node": ">=10"
       }
     },
-    "node_modules/@react-native/community-cli-plugin/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
-      "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
-      }
-    },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.6.tgz",
-      "integrity": "sha512-lIK/KkaH7ueM22bLO0YNaQwZbT/oeqhaghOvmZacaNVbJR1Cdh/XAqjT8FgCS+7PUnbxA8B55NYNKGZG3O2pYw==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.83.6.tgz",
+      "integrity": "sha512-TyWXEpAjVundrc87fPWg91piOUg75+X9iutcfDe7cO3NrAEYCsl7Z09rKHuiAGkxfG9/rFD13dPsYIixUFkSFA==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
+      }
+    },
+    "node_modules/@react-native/debugger-shell": {
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.83.6.tgz",
+      "integrity": "sha512-684TJMBCU0l0ZjJWzrnK0HH+ERaM9KLyxyArE1k7BrP+gVl4X9GO0Pi94RoInOxvW/nyV65sOU6Ip1F3ygS0cg==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "fb-dotslash": "0.5.8"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.79.6",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.6.tgz",
-      "integrity": "sha512-BK3GZBa9c7XSNR27EDRtxrgyyA3/mf1j3/y+mPk7Ac0Myu85YNrXnC9g3mL5Ytwo0g58TKrAIgs1fF2Q5Mn6mQ==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.83.6.tgz",
+      "integrity": "sha512-22xoddLTelpcVnF385SNH2hdP7X2av5pu7yRl/WnM5jBznbcl0+M9Ce94cj+WVeomsoUF/vlfuB0Ooy+RMlRiA==",
       "license": "MIT",
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.79.6",
+        "@react-native/debugger-frontend": "0.83.6",
+        "@react-native/debugger-shell": "0.83.6",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
-        "debug": "^2.2.0",
+        "debug": "^4.4.0",
         "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "open": "^7.0.3",
         "serve-static": "^1.16.2",
-        "ws": "^6.2.3"
+        "ws": "^7.5.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@react-native/dev-middleware/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.5.tgz",
-      "integrity": "sha512-K3QhfFNKiWKF3HsCZCEoWwJPSMcPJQaeqOmzFP4RL8L3nkpgUwn74PfSCcKHxooVpS6bMvJFQOz7ggUZtNVT+A==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.83.6.tgz",
+      "integrity": "sha512-5prXv7WWR1RgZ/kWGZP+mi7/y/IE2ymfOHIZO5Pv14tMOmRAcQSgSYogcRmOiWw5mJs2K0UFeMiQD49ZO9oCug==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.5.tgz",
-      "integrity": "sha512-a2wsFlIhvd9ZqCD5KPRsbCQmbZi6KxhRN++jrqG0FUTEV5vY7MvjjUqDILwJd2ZBZsf7uiDuClCcKqA+EEdbvw==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.83.6.tgz",
+      "integrity": "sha512-VSev0LV2i5X0ibduHBSLqKj0YU2F+waCgjl2uvaGHMGCSV1ZRKNFX/vJFqvLwjvdzLbkAZoFT1Rg7k7jDv44UA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       }
     },
     "node_modules/@react-native/normalize-colors": {
@@ -8915,6 +8969,29 @@
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.6.tgz",
       "integrity": "sha512-0v2/ruY7eeKun4BeKu+GcfO+SHBdl0LJn4ZFzTzjHdWES0Cn+ONqKljYaIv8p9MV2Hx/kcdEvbY4lWI34jC/mQ==",
       "license": "MIT"
+    },
+    "node_modules/@react-native/virtualized-lists": {
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.83.6.tgz",
+      "integrity": "sha512-gNSFXeb4P7qHtauLvl+zESroULIyX6Ltpvau3dhwy/QmfanBv0KUcrIU/7aVXxtWcXgp+54oWJyu2LIrsZ9+LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "@types/react": "^19.2.0",
+        "react": "*",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.47",
@@ -11234,29 +11311,6 @@
         "win32"
       ]
     },
-    "node_modules/@urql/core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@urql/core/-/core-5.2.0.tgz",
-      "integrity": "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A==",
-      "license": "MIT",
-      "dependencies": {
-        "@0no-co/graphql.web": "^1.0.13",
-        "wonka": "^6.3.2"
-      }
-    },
-    "node_modules/@urql/exchange-retry": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@urql/exchange-retry/-/exchange-retry-1.3.2.tgz",
-      "integrity": "sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg==",
-      "license": "MIT",
-      "dependencies": {
-        "@urql/core": "^5.1.2",
-        "wonka": "^6.3.2"
-      },
-      "peerDependencies": {
-        "@urql/core": "^5.0.0"
-      }
-    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -11404,9 +11458,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -11748,12 +11802,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -12028,12 +12076,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
-      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -12382,10 +12424,19 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      }
+    },
     "node_modules/babel-plugin-react-native-web": {
-      "version": "0.19.13",
-      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.19.13.tgz",
-      "integrity": "sha512-4hHoto6xaN23LCyZgL9LJZc3olmAxd7b6jDzlZnKXAh4rRAbZRKNBJoOOdp46OBqgy+K0t0guTj5/mhA8inymQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-native-web/-/babel-plugin-react-native-web-0.21.2.tgz",
+      "integrity": "sha512-SPD0J6qjJn8231i0HZhlAGH6NORe+QvRSQM2mwQEzJ2Fb3E4ruWTiiicPlHjmeWShDXLcvoorOCXjeR7k/lyWA==",
       "license": "MIT"
     },
     "node_modules/babel-plugin-syntax-hermes-parser": {
@@ -12451,15 +12502,17 @@
       }
     },
     "node_modules/babel-preset-expo": {
-      "version": "13.2.4",
-      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-13.2.4.tgz",
-      "integrity": "sha512-3IKORo3KR+4qtLdCkZNDj8KeA43oBn7RRQejFGWfiZgu/NeaRUSri8YwYjZqybm7hn3nmMv9OLahlvXBX23o5Q==",
+      "version": "55.0.22",
+      "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-55.0.22.tgz",
+      "integrity": "sha512-Se6kPnvCNN13jJVIa6JJvlmImVoVRzu9stagAbivCPcfrq2VNrsEiYpJZ1+H32kXinKW/y797/wctGuxPy0APw==",
       "license": "MIT",
       "dependencies": {
+        "@babel/generator": "^7.20.5",
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/plugin-proposal-decorators": "^7.12.9",
         "@babel/plugin-proposal-export-default-from": "^7.24.7",
         "@babel/plugin-syntax-export-default-from": "^7.24.7",
+        "@babel/plugin-transform-class-static-block": "^7.27.1",
         "@babel/plugin-transform-export-namespace-from": "^7.25.9",
         "@babel/plugin-transform-flow-strip-types": "^7.25.2",
         "@babel/plugin-transform-modules-commonjs": "^7.24.8",
@@ -12470,30 +12523,54 @@
         "@babel/plugin-transform-runtime": "^7.24.7",
         "@babel/preset-react": "^7.22.15",
         "@babel/preset-typescript": "^7.23.0",
-        "@react-native/babel-preset": "0.79.6",
-        "babel-plugin-react-native-web": "~0.19.13",
-        "babel-plugin-syntax-hermes-parser": "^0.25.1",
+        "@react-native/babel-preset": "0.83.6",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "babel-plugin-react-native-web": "~0.21.0",
+        "babel-plugin-syntax-hermes-parser": "^0.32.0",
         "babel-plugin-transform-flow-enums": "^0.0.2",
         "debug": "^4.3.4",
-        "react-refresh": "^0.14.2",
         "resolve-from": "^5.0.0"
       },
       "peerDependencies": {
-        "babel-plugin-react-compiler": "^19.0.0-beta-e993439-20250405"
+        "@babel/runtime": "^7.20.0",
+        "expo": "*",
+        "expo-widgets": "^55.0.19",
+        "react-refresh": ">=0.14.0 <1.0.0"
       },
       "peerDependenciesMeta": {
-        "babel-plugin-react-compiler": {
+        "@babel/runtime": {
+          "optional": true
+        },
+        "expo": {
+          "optional": true
+        },
+        "expo-widgets": {
           "optional": true
         }
       }
     },
     "node_modules/babel-preset-expo/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.1.tgz",
+      "integrity": "sha512-HgErPZTghW76Rkq9uqn5ESeiD97FbqpZ1V170T1RG2RDp+7pJVQV2pQJs7y5YzN0/gcT6GM5ci9apRnIwuyPdQ==",
       "license": "MIT",
       "dependencies": {
-        "hermes-parser": "0.25.1"
+        "hermes-parser": "0.32.1"
+      }
+    },
+    "node_modules/babel-preset-expo/node_modules/hermes-estree": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.1.tgz",
+      "integrity": "sha512-ne5hkuDxheNBAikDjqvCZCwihnz0vVu9YsBzAEO1puiyFR4F1+PAz/SiPHSsNTuOveCYGRMX8Xbx4LOubeC0Qg==",
+      "license": "MIT"
+    },
+    "node_modules/babel-preset-expo/node_modules/hermes-parser": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.1.tgz",
+      "integrity": "sha512-175dz634X/W5AiwrpLdoMl/MOb17poLHyIqgyExlE8D9zQ1OPnoORnGMB5ltRKnpvQzBjMYvT2rN/sHeIfZW5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.32.1"
       }
     },
     "node_modules/babel-preset-jest": {
@@ -12866,30 +12943,6 @@
         "node-int64": "^0.4.0"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -12977,39 +13030,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/caller-callsite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caller-callsite/node_modules/callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
-      "license": "MIT",
-      "dependencies": {
-        "caller-callsite": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/callsites": {
@@ -13251,15 +13271,6 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/chrome-launcher": {
@@ -14124,15 +14135,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypto-random-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
-      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/css-blank-pseudo": {
@@ -15030,15 +15032,12 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "bin": {
-        "detect-libc": "bin/detect-libc.js"
-      },
       "engines": {
-        "node": ">=0.10"
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -15133,6 +15132,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/dnssd-advertise": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/dnssd-advertise/-/dnssd-advertise-1.1.4.tgz",
+      "integrity": "sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -15414,33 +15419,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dotenv-expand": {
-      "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
-      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dotenv": "^16.4.5"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -15553,15 +15531,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/env-editor": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/env-editor/-/env-editor-0.4.2.tgz",
-      "integrity": "sha512-ObFo8v4rQJAE59M69QzwloxPZtd33TpYEIjtKD1rrFDcM1Gd7IkDxEBU+HriziN6HSHQnBJi8Dmy+JWkav5HKA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/error-ex": {
@@ -16938,12 +16907,6 @@
       "resolved": "apps/example-ui",
       "link": true
     },
-    "node_modules/exec-async": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/exec-async/-/exec-async-2.2.0.tgz",
-      "integrity": "sha512-87OpwcEiMia/DeiKFzaQNBNFeN3XkkpYIh9FyOqq5mS2oKv3CBE67PXoEKcr6nodWdXNogTiQ0jE2NGuoffXPw==",
-      "license": "MIT"
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -16994,28 +16957,34 @@
       }
     },
     "node_modules/expo": {
-      "version": "53.0.22",
-      "resolved": "https://registry.npmjs.org/expo/-/expo-53.0.22.tgz",
-      "integrity": "sha512-sJ2I4W/e5iiM4u/wYCe3qmW4D7WPCRqByPDD0hJcdYNdjc9HFFFdO4OAudZVyC/MmtoWZEIH5kTJP1cw9FjzYA==",
+      "version": "55.0.26",
+      "resolved": "https://registry.npmjs.org/expo/-/expo-55.0.26.tgz",
+      "integrity": "sha512-MuVW6Uzd/Jh6E37ICOYAiTOm9nflNMUNzf6wH5ld/IXFyuF2Lo86a8fCSMgHcvTGsSjRsJ5Uxhf+WHZcvGPfrg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
-        "@expo/cli": "0.24.21",
-        "@expo/config": "~11.0.13",
-        "@expo/config-plugins": "~10.1.2",
-        "@expo/fingerprint": "0.13.4",
-        "@expo/metro-config": "0.20.17",
-        "@expo/vector-icons": "^14.0.0",
-        "babel-preset-expo": "~13.2.4",
-        "expo-asset": "~11.1.7",
-        "expo-constants": "~17.1.7",
-        "expo-file-system": "~18.1.11",
-        "expo-font": "~13.3.2",
-        "expo-keep-awake": "~14.1.4",
-        "expo-modules-autolinking": "2.1.14",
-        "expo-modules-core": "2.5.0",
-        "react-native-edge-to-edge": "1.6.0",
-        "whatwg-url-without-unicode": "8.0.0-3"
+        "@expo/cli": "55.0.32",
+        "@expo/config": "~55.0.17",
+        "@expo/config-plugins": "~55.0.10",
+        "@expo/devtools": "55.0.3",
+        "@expo/fingerprint": "0.16.7",
+        "@expo/local-build-cache-provider": "55.0.13",
+        "@expo/log-box": "55.0.12",
+        "@expo/metro": "~55.1.1",
+        "@expo/metro-config": "55.0.23",
+        "@expo/vector-icons": "^15.0.2",
+        "@ungap/structured-clone": "^1.3.0",
+        "babel-preset-expo": "~55.0.22",
+        "expo-asset": "~55.0.17",
+        "expo-constants": "~55.0.16",
+        "expo-file-system": "~55.0.22",
+        "expo-font": "~55.0.8",
+        "expo-keep-awake": "~55.0.8",
+        "expo-modules-autolinking": "55.0.24",
+        "expo-modules-core": "55.0.25",
+        "pretty-format": "^29.7.0",
+        "react-refresh": "^0.14.2",
+        "whatwg-url-minimum": "^0.1.2"
       },
       "bin": {
         "expo": "bin/cli",
@@ -17046,13 +17015,13 @@
       "link": true
     },
     "node_modules/expo-asset": {
-      "version": "11.1.7",
-      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-11.1.7.tgz",
-      "integrity": "sha512-b5P8GpjUh08fRCf6m5XPVAh7ra42cQrHBIMgH2UXP+xsj4Wufl6pLy6jRF5w6U7DranUMbsXm8TOyq4EHy7ADg==",
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-55.0.17.tgz",
+      "integrity": "sha512-pK9HHJuFqjE8kDUcbMFsZj3Cz8WdXpvZHZmYl7ouFQp59P83BvHln6VnqPDGlO+/4929G0Lm8ZUzbONuNRhi9w==",
       "license": "MIT",
       "dependencies": {
-        "@expo/image-utils": "^0.7.6",
-        "expo-constants": "~17.1.7"
+        "@expo/image-utils": "^0.8.14",
+        "expo-constants": "~55.0.16"
       },
       "peerDependencies": {
         "expo": "*",
@@ -17061,39 +17030,18 @@
       }
     },
     "node_modules/expo-build-properties": {
-      "version": "0.14.8",
-      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.14.8.tgz",
-      "integrity": "sha512-GTFNZc5HaCS9RmCi6HspCe2+isleuOWt2jh7UEKHTDQ9tdvzkIoWc7U6bQO9lH3Mefk4/BcCUZD/utl7b1wdqw==",
+      "version": "55.0.14",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.14.tgz",
+      "integrity": "sha512-5wopuLXlzFpDnCfsIjgAcj4yKnVTYg3XYGnYV5Hqi7u6jJipLG4fwtUqxVIFqBj7vEHXjd4zYCyXjp39AtAD7w==",
       "license": "MIT",
       "dependencies": {
-        "ajv": "^8.11.0",
+        "@expo/schema-utils": "^55.0.4",
+        "resolve-from": "^5.0.0",
         "semver": "^7.6.0"
       },
       "peerDependencies": {
         "expo": "*"
       }
-    },
-    "node_modules/expo-build-properties/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/expo-build-properties/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/expo-build-properties/node_modules/semver": {
       "version": "7.7.2",
@@ -17108,13 +17056,12 @@
       }
     },
     "node_modules/expo-constants": {
-      "version": "17.1.7",
-      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.7.tgz",
-      "integrity": "sha512-byBjGsJ6T6FrLlhOBxw4EaiMXrZEn/MlUYIj/JAd+FS7ll5X/S4qVRbIimSJtdW47hXMq0zxPfJX6njtA56hHA==",
+      "version": "55.0.16",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.16.tgz",
+      "integrity": "sha512-Z15/No94UHoogD+pulxjudGAeOHTEIWZgb/vnX48Wx5D+apWTeCbnKxQZZtGQlosvduYL5kaic2/W8U+NHfBQQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/config": "~11.0.12",
-        "@expo/env": "~1.0.7"
+        "@expo/env": "~2.1.2"
       },
       "peerDependencies": {
         "expo": "*",
@@ -17122,9 +17069,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "18.1.11",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
-      "integrity": "sha512-HJw/m0nVOKeqeRjPjGdvm+zBi5/NxcdPf8M8P3G2JFvH5Z8vBWqVDic2O58jnT1OFEy0XXzoH9UqFu7cHg9DTQ==",
+      "version": "55.0.22",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-55.0.22.tgz",
+      "integrity": "sha512-T5Rfv3vqcFyhVrl/tEEeglc/J8LJbcZQgC3TMT5jxzIgUgWmIgJEgncGYqB/YNXFgUTL2LiuCvqrU51Dzp83NQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -17132,22 +17079,23 @@
       }
     },
     "node_modules/expo-font": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-13.3.2.tgz",
-      "integrity": "sha512-wUlMdpqURmQ/CNKK/+BIHkDA5nGjMqNlYmW0pJFXY/KE/OG80Qcavdu2sHsL4efAIiNGvYdBS10WztuQYU4X0A==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-55.0.8.tgz",
+      "integrity": "sha512-WyP75pnKqhLNktYwDn3xKAUNt5rLihRDv8XWGhhz6VEhVqypixpT86NA3uGtiDTlM3gGjhrYCY7o7ypXgCUOZg==",
       "license": "MIT",
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
       "peerDependencies": {
         "expo": "*",
-        "react": "*"
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-keep-awake": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.1.4.tgz",
-      "integrity": "sha512-wU9qOnosy4+U4z/o4h8W9PjPvcFMfZXrlUoKTMBW7F4pLqhkkP/5G4EviPZixv4XWFMjn1ExQ5rV6BX8GwJsWA==",
+      "version": "55.0.8",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-55.0.8.tgz",
+      "integrity": "sha512-PfIpMfM+STOBwkR5XOE+yVtER86c44MD+W8QD8JxuO0sT9pF7Y1SJYakWlpvX8xsGA+bjKLxftm9403s9kQhKA==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -17155,30 +17103,18 @@
       }
     },
     "node_modules/expo-modules-autolinking": {
-      "version": "2.1.14",
-      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.1.14.tgz",
-      "integrity": "sha512-nT5ERXwc+0ZT/pozDoJjYZyUQu5RnXMk9jDGm5lg+PiKvsrCTSA/2/eftJGMxLkTjVI2MXp5WjSz3JRjbA7UXA==",
+      "version": "55.0.24",
+      "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-55.0.24.tgz",
+      "integrity": "sha512-A0OyMbTPZqibYrwqj98HFYTNSvl4NSS4Zt+R5A8qiAx3nM0mc81e6Iqw7Wl4J8M/t36lJ+cT3WuVTz5Oszj6Hw==",
       "license": "MIT",
       "dependencies": {
+        "@expo/require-utils": "^55.0.5",
         "@expo/spawn-async": "^1.7.2",
         "chalk": "^4.1.0",
-        "commander": "^7.2.0",
-        "find-up": "^5.0.0",
-        "glob": "^10.4.2",
-        "require-from-string": "^2.0.2",
-        "resolve-from": "^5.0.0"
+        "commander": "^7.2.0"
       },
       "bin": {
         "expo-modules-autolinking": "bin/expo-modules-autolinking.js"
-      }
-    },
-    "node_modules/expo-modules-autolinking/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/expo-modules-autolinking/node_modules/commander": {
@@ -17190,104 +17126,41 @@
         "node": ">= 10"
       }
     },
-    "node_modules/expo-modules-autolinking/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/expo-modules-autolinking/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo-modules-autolinking/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/expo-modules-autolinking/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo-modules-autolinking/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/expo-modules-core": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-2.5.0.tgz",
-      "integrity": "sha512-aIbQxZE2vdCKsolQUl6Q9Farlf8tjh/ROR4hfN1qT7QBGPl1XrJGnaOKkcgYaGrlzCPg/7IBe0Np67GzKMZKKQ==",
+      "version": "55.0.25",
+      "resolved": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-55.0.25.tgz",
+      "integrity": "sha512-yXpfg7aHLbuqoXocK34Vua6Aey5SCyqLygAsXAMbul9P8vfBjLpaOPiTJ5cLVF7Drfq8ownqVJO6qpGEtZ6GOw==",
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": "^0.7.4 || ^0.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-worklets": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-server": {
+      "version": "55.0.11",
+      "resolved": "https://registry.npmjs.org/expo-server/-/expo-server-55.0.11.tgz",
+      "integrity": "sha512-AxRdHqcv0H1g4s923vu+5n1Nrhne23bjXbP+Vl7+Lwfpe7MG9PuU1IS95IJK6a+7BVV1mRN6QlZvs8Yv7EEXNQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.16.0"
       }
     },
     "node_modules/expo-status-bar": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-2.2.3.tgz",
-      "integrity": "sha512-+c8R3AESBoduunxTJ8353SqKAKpxL6DvcD8VKBuh81zzJyUUbfB4CVjr1GufSJEKsMzNPXZU+HJwXx7Xh7lx8Q==",
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-55.0.6.tgz",
+      "integrity": "sha512-ijOUptfdiqYt7rObZ6jrPQ8sE5YN/8MxKCIJx0b7TY4nGkSJxhPIxeoW4GXcXCA8mTQ9PiOHH/ThLZgRVZvUlQ==",
       "license": "MIT",
       "dependencies": {
-        "react-native-edge-to-edge": "1.6.0",
-        "react-native-is-edge-to-edge": "^1.1.6"
+        "react-native-is-edge-to-edge": "^1.2.1"
       },
       "peerDependencies": {
         "react": "*",
@@ -17295,9 +17168,9 @@
       }
     },
     "node_modules/exponential-backoff": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
-      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
       "license": "Apache-2.0"
     },
     "node_modules/express": {
@@ -17562,6 +17435,18 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fb-dotslash": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/fb-dotslash/-/fb-dotslash-0.5.8.tgz",
+      "integrity": "sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "dotslash": "bin/dotslash"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -17612,6 +17497,12 @@
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/fetch-nodeshim": {
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/fetch-nodeshim/-/fetch-nodeshim-0.4.10.tgz",
+      "integrity": "sha512-m6I8ALe4L4XpdETy7MJZWs6L1IVMbjs99bwbpIKphxX+0CTns4IKDWJY0LWfr4YsFjfg+z1TjzTMU8lKl8rG0w==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -17988,6 +17879,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -18004,6 +17896,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -18065,15 +17958,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
-      }
-    },
-    "node_modules/freeport-async": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/freeport-async/-/freeport-async-2.0.0.tgz",
-      "integrity": "sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/fresh": {
@@ -19111,6 +18995,12 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hermes-compiler": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-0.14.1.tgz",
+      "integrity": "sha512-+RPPQlayoZ9n6/KXKt5SFILWXCGJ/LV5d24L5smXrvTDrPS4L6dSctPczXauuvzFP3QEJbD1YO7Z3Ra4a+4IhA==",
+      "license": "MIT"
+    },
     "node_modules/hermes-eslint": {
       "version": "0.36.1",
       "resolved": "https://registry.npmjs.org/hermes-eslint/-/hermes-eslint-0.36.1.tgz",
@@ -19141,12 +19031,14 @@
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
       "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
       "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
@@ -19741,26 +19633,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -20186,15 +20058,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-docker": {
@@ -20814,6 +20677,7 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -21704,6 +21568,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
@@ -21832,9 +21697,9 @@
       }
     },
     "node_modules/lan-network": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.1.7.tgz",
-      "integrity": "sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/lan-network/-/lan-network-0.2.1.tgz",
+      "integrity": "sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==",
       "license": "MIT",
       "bin": {
         "lan-network": "dist/lan-network-cli.js"
@@ -21933,12 +21798,12 @@
       "license": "MIT"
     },
     "node_modules/lightningcss": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.27.0.tgz",
-      "integrity": "sha512-8f7aNmS1+etYSLHht0fQApPc2kNO8qGRutifN5rVIc6Xo6ABsEbqOr758UwI7ALVbTt4x1fllKt0PYgzD9S3yQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "detect-libc": "^1.0.3"
+        "detect-libc": "^2.0.3"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -21948,22 +21813,43 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-darwin-arm64": "1.27.0",
-        "lightningcss-darwin-x64": "1.27.0",
-        "lightningcss-freebsd-x64": "1.27.0",
-        "lightningcss-linux-arm-gnueabihf": "1.27.0",
-        "lightningcss-linux-arm64-gnu": "1.27.0",
-        "lightningcss-linux-arm64-musl": "1.27.0",
-        "lightningcss-linux-x64-gnu": "1.27.0",
-        "lightningcss-linux-x64-musl": "1.27.0",
-        "lightningcss-win32-arm64-msvc": "1.27.0",
-        "lightningcss-win32-x64-msvc": "1.27.0"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.27.0.tgz",
-      "integrity": "sha512-Gl/lqIXY+d+ySmMbgDf0pgaWSqrWYxVHoc88q+Vhf2YNzZ8DwoRzGt5NZDVqqIW5ScpSnmmjcgXP87Dn2ylSSQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
@@ -21981,9 +21867,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.27.0.tgz",
-      "integrity": "sha512-0+mZa54IlcNAoQS9E0+niovhyjjQWEMrwW0p2sSdLRhLDc8LMQ/b67z7+B5q4VmjYCMSfnFi3djAAQFIDuj/Tg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -22001,9 +21887,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.27.0.tgz",
-      "integrity": "sha512-n1sEf85fePoU2aDN2PzYjoI8gbBqnmLGEhKq7q0DKLj0UTVmOTwDC7PtLcy/zFxzASTSBlVQYJUhwIStQMIpRA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -22021,9 +21907,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.27.0.tgz",
-      "integrity": "sha512-MUMRmtdRkOkd5z3h986HOuNBD1c2lq2BSQA1Jg88d9I7bmPGx08bwGcnB75dvr17CwxjxD6XPi3Qh8ArmKFqCA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -22041,11 +21927,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.27.0.tgz",
-      "integrity": "sha512-cPsxo1QEWq2sfKkSq2Bq5feQDHdUEwgtA9KaB27J5AX22+l4l0ptgjMZZtYtUnteBofjee+0oW1wQ1guv04a7A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -22061,11 +21950,14 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.27.0.tgz",
-      "integrity": "sha512-rCGBm2ax7kQ9pBSeITfCW9XSVF69VX+fm5DIpvDZQl4NnQoMQyRwhZQm9pd59m8leZ1IesRqWk2v/DntMo26lg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -22081,11 +21973,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.27.0.tgz",
-      "integrity": "sha512-Dk/jovSI7qqhJDiUibvaikNKI2x6kWPN79AQiD/E/KeQWMjdGe9kw51RAgoWFDi0coP4jinaH14Nrt/J8z3U4A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -22101,11 +21996,14 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.27.0.tgz",
-      "integrity": "sha512-QKjTxXm8A9s6v9Tg3Fk0gscCQA1t/HMoF7Woy1u68wCk5kS4fR+q3vXa1p3++REW784cRAtkYKrPy6JKibrEZA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -22121,9 +22019,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.27.0.tgz",
-      "integrity": "sha512-/wXegPS1hnhkeG4OXQKEMQeJd48RDC3qdh+OA8pCuOPCyvnm/yEayrJdJVqzBsqpy1aJklRCVxscpFur80o6iQ==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -22141,9 +22039,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.27.0.tgz",
-      "integrity": "sha512-/OJLj94Zm/waZShL8nB5jsNj3CfNATLCTyFxZyouilfTmSoLDX7VlVAmhPHoZWVFp4vdmoiEbPEYC8HID3m6yw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -23383,45 +23281,44 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.4.tgz",
-      "integrity": "sha512-/gFmw3ux9CPG5WUmygY35hpyno28zi/7OUn6+OFfbweA8l0B+PPqXXLr0/T6cf5nclCcH0d22o+02fICaShVxw==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.7.tgz",
+      "integrity": "sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.24.7",
+        "@babel/code-frame": "^7.29.0",
         "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.3",
-        "@babel/types": "^7.25.2",
-        "accepts": "^1.3.7",
-        "chalk": "^4.0.0",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "accepts": "^2.0.0",
         "ci-info": "^2.0.0",
         "connect": "^3.6.5",
         "debug": "^4.4.0",
         "error-stack-parser": "^2.0.6",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.28.1",
+        "hermes-parser": "0.35.0",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
         "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.82.4",
-        "metro-cache": "0.82.4",
-        "metro-cache-key": "0.82.4",
-        "metro-config": "0.82.4",
-        "metro-core": "0.82.4",
-        "metro-file-map": "0.82.4",
-        "metro-resolver": "0.82.4",
-        "metro-runtime": "0.82.4",
-        "metro-source-map": "0.82.4",
-        "metro-symbolicate": "0.82.4",
-        "metro-transform-plugins": "0.82.4",
-        "metro-transform-worker": "0.82.4",
-        "mime-types": "^2.1.27",
+        "metro-babel-transformer": "0.83.7",
+        "metro-cache": "0.83.7",
+        "metro-cache-key": "0.83.7",
+        "metro-config": "0.83.7",
+        "metro-core": "0.83.7",
+        "metro-file-map": "0.83.7",
+        "metro-resolver": "0.83.7",
+        "metro-runtime": "0.83.7",
+        "metro-source-map": "0.83.7",
+        "metro-symbolicate": "0.83.7",
+        "metro-transform-plugins": "0.83.7",
+        "metro-transform-worker": "0.83.7",
+        "mime-types": "^3.0.1",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
         "source-map": "^0.5.6",
@@ -23433,70 +23330,71 @@
         "metro": "src/cli.js"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.4.tgz",
-      "integrity": "sha512-4juJahGRb1gmNbQq48lNinB6WFNfb6m0BQqi/RQibEltNiqTCxew/dBspI2EWA4xVCd3mQWGfw0TML4KurQZnQ==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.7.tgz",
+      "integrity": "sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.28.1",
+        "hermes-parser": "0.35.0",
+        "metro-cache-key": "0.83.7",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
-      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
       "license": "MIT"
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
-      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.28.1"
+        "hermes-estree": "0.35.0"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.4.tgz",
-      "integrity": "sha512-vX0ylSMGtORKiZ4G8uP6fgfPdDiCWvLZUGZ5zIblSGylOX6JYhvExl0Zg4UA9pix/SSQu5Pnp9vdODMFsNIxhw==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.7.tgz",
+      "integrity": "sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==",
       "license": "MIT",
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
         "https-proxy-agent": "^7.0.5",
-        "metro-core": "0.82.4"
+        "metro-core": "0.83.7"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.4.tgz",
-      "integrity": "sha512-2JCTqcpF+f2OghOpe/+x+JywfzDkrHdAqinPFWmK2ezNAU/qX0jBFaTETogPibFivxZJil37w9Yp6syX8rFUng==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.7.tgz",
+      "integrity": "sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-cache/node_modules/agent-base": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -23516,92 +23414,57 @@
       }
     },
     "node_modules/metro-config": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.4.tgz",
-      "integrity": "sha512-Ki3Wumr3hKHGDS7RrHsygmmRNc/PCJrvkLn0+BWWxmbOmOcMMJDSmSI+WRlT8jd5VPZFxIi4wg+sAt5yBXAK0g==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.7.tgz",
+      "integrity": "sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==",
       "license": "MIT",
       "dependencies": {
         "connect": "^3.6.5",
-        "cosmiconfig": "^5.0.5",
         "flow-enums-runtime": "^0.0.6",
         "jest-validate": "^29.7.0",
-        "metro": "0.82.4",
-        "metro-cache": "0.82.4",
-        "metro-core": "0.82.4",
-        "metro-runtime": "0.82.4"
+        "metro": "0.83.7",
+        "metro-cache": "0.83.7",
+        "metro-core": "0.83.7",
+        "metro-runtime": "0.83.7",
+        "yaml": "^2.6.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
-    "node_modules/metro-config/node_modules/cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
-      "license": "MIT",
-      "dependencies": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
+    "node_modules/metro-config/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/metro-config/node_modules/import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
-      "license": "MIT",
-      "dependencies": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
+        "node": ">= 14.6"
       },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/metro-config/node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "license": "MIT",
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/metro-config/node_modules/resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.4.tgz",
-      "integrity": "sha512-Xo4ozbxPg2vfgJGCgXZ8sVhC2M0lhTqD+tsKO2q9aelq/dCjnnSb26xZKcQO80CQOQUL7e3QWB7pLFGPjZm31A==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.7.tgz",
+      "integrity": "sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.82.4"
+        "metro-resolver": "0.83.7"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.4.tgz",
-      "integrity": "sha512-eO7HD1O3aeNsbEe6NBZvx1lLJUrxgyATjnDmb7bm4eyF6yWOQot9XVtxTDLNifECuvsZ4jzRiTInrbmIHkTdGA==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.7.tgz",
+      "integrity": "sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -23615,66 +23478,65 @@
         "walker": "^1.0.7"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.4.tgz",
-      "integrity": "sha512-W79Mi6BUwWVaM8Mc5XepcqkG+TSsCyyo//dmTsgYfJcsmReQorRFodil3bbJInETvjzdnS1mCsUo9pllNjT1Hg==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.7.tgz",
+      "integrity": "sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "terser": "^5.15.0"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.4.tgz",
-      "integrity": "sha512-uWoHzOBGQTPT5PjippB8rRT3iI9CTgFA9tRiLMzrseA5o7YAlgvfTdY9vFk2qyk3lW3aQfFKWkmqENryPRpu+Q==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.7.tgz",
+      "integrity": "sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.4.tgz",
-      "integrity": "sha512-vVyFO7H+eLXRV2E7YAUYA7aMGBECGagqxmFvC2hmErS7oq90BbPVENfAHbUWq1vWH+MRiivoRxdxlN8gBoF/dw==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.7.tgz",
+      "integrity": "sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.4.tgz",
-      "integrity": "sha512-9jzDQJ0FPas1FuQFtwmBHsez2BfhFNufMowbOMeG3ZaFvzeziE8A0aJwILDS3U+V5039ssCQFiQeqDgENWvquA==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.7.tgz",
+      "integrity": "sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.25.3",
-        "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3",
-        "@babel/types": "^7.25.2",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.82.4",
+        "metro-symbolicate": "0.83.7",
         "nullthrows": "^1.1.1",
-        "ob1": "0.82.4",
+        "ob1": "0.83.7",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-source-map/node_modules/source-map": {
@@ -23687,14 +23549,14 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.4.tgz",
-      "integrity": "sha512-LwEwAtdsx7z8rYjxjpLWxuFa2U0J6TS6ljlQM4WAATKa4uzV8unmnRuN2iNBWTmRqgNR77mzmI2vhwD4QSCo+w==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.7.tgz",
+      "integrity": "sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.82.4",
+        "metro-source-map": "0.83.7",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
@@ -23703,7 +23565,7 @@
         "metro-symbolicate": "src/index.js"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-symbolicate/node_modules/source-map": {
@@ -23716,44 +23578,57 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.4.tgz",
-      "integrity": "sha512-NoWQRPHupVpnDgYguiEcm7YwDhnqW02iWWQjO2O8NsNP09rEMSq99nPjARWfukN7+KDh6YjLvTIN20mj3dk9kw==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz",
+      "integrity": "sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.25.0",
-        "@babel/template": "^7.25.0",
-        "@babel/traverse": "^7.25.3",
+        "@babel/generator": "^7.29.1",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.4.tgz",
-      "integrity": "sha512-kPI7Ad/tdAnI9PY4T+2H0cdgGeSWWdiPRKuytI806UcN4VhFL6OmYa19/4abYVYF+Cd2jo57CDuwbaxRfmXDhw==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.7.tgz",
+      "integrity": "sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.2",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
-        "@babel/types": "^7.25.2",
+        "@babel/generator": "^7.29.1",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.82.4",
-        "metro-babel-transformer": "0.82.4",
-        "metro-cache": "0.82.4",
-        "metro-cache-key": "0.82.4",
-        "metro-minify-terser": "0.82.4",
-        "metro-source-map": "0.82.4",
-        "metro-transform-plugins": "0.82.4",
+        "metro": "0.83.7",
+        "metro-babel-transformer": "0.83.7",
+        "metro-cache": "0.83.7",
+        "metro-cache-key": "0.83.7",
+        "metro-minify-terser": "0.83.7",
+        "metro-source-map": "0.83.7",
+        "metro-transform-plugins": "0.83.7",
         "nullthrows": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
+      }
+    },
+    "node_modules/metro/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/metro/node_modules/ci-info": {
@@ -23763,18 +23638,18 @@
       "license": "MIT"
     },
     "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
-      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+      "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
       "license": "MIT"
     },
     "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
-      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+      "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
       "license": "MIT",
       "dependencies": {
-        "hermes-estree": "0.28.1"
+        "hermes-estree": "0.35.0"
       }
     },
     "node_modules/metro/node_modules/image-size": {
@@ -23792,6 +23667,40 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/metro/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/metro/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/metro/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/metro/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -23802,9 +23711,9 @@
       }
     },
     "node_modules/metro/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -25746,24 +25655,12 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
-      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mkdirp": {
@@ -25806,21 +25703,16 @@
         "multicast-dns": "cli.js"
       }
     },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
-      }
+    "node_modules/multitars": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/multitars/-/multitars-1.0.0.tgz",
+      "integrity": "sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -25870,12 +25762,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "license": "MIT"
-    },
-    "node_modules/nested-error-stacks": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
-      "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
       "license": "MIT"
     },
     "node_modules/next": {
@@ -26050,9 +25936,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -26182,9 +26068,9 @@
       "license": "ISC"
     },
     "node_modules/npm-package-arg/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -26465,15 +26351,15 @@
       "license": "MIT"
     },
     "node_modules/ob1": {
-      "version": "0.82.4",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.4.tgz",
-      "integrity": "sha512-n9S8e4l5TvkrequEAMDidl4yXesruWTNTzVkeaHSGywoTOIwTzZzKw7Z670H3eaXDZui5MJXjWGNzYowVZIxCA==",
+      "version": "0.83.7",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.7.tgz",
+      "integrity": "sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==",
       "license": "MIT",
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
       },
       "engines": {
-        "node": ">=18.18"
+        "node": ">=20.19.4"
       }
     },
     "node_modules/object-assign": {
@@ -27025,6 +26911,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-json/node_modules/semver": {
@@ -27289,6 +27176,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -27305,6 +27193,7 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
@@ -27405,17 +27294,26 @@
       "link": true
     },
     "node_modules/plist": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
-      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.8",
+        "@xmldom/xmldom": "^0.9.10",
         "base64-js": "^1.5.1",
         "xmlbuilder": "^15.1.1"
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/pngjs": {
@@ -27438,9 +27336,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -27457,7 +27355,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -28943,18 +28841,6 @@
         "prettier": "^3.0.0"
       }
     },
-    "node_modules/pretty-bytes": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
-      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/pretty-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -29177,14 +29063,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/qrcode-terminal": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.11.0.tgz",
-      "integrity": "sha512-Uu7ii+FQy4Qf82G4xu7ShHhjhGahEpCWc3x8UavY3CTcWV+ufmmCtwkr7ZKsX42jdL0kr1B5FKUeqJvAn51jzQ==",
-      "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
-      }
-    },
     "node_modules/qs": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
@@ -29318,18 +29196,18 @@
       }
     },
     "node_modules/react": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.2.tgz",
-      "integrity": "sha512-ldFwzufLletzCikNJVYaxlxMLu7swJ3T2VrGfzXlMsVhZhPDKXA38DEROidaYZVgMAmQnIjymrmqto5pyfrwPA==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.5.tgz",
+      "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "license": "MIT",
       "dependencies": {
         "shell-quote": "^1.6.1",
@@ -29337,9 +29215,9 @@
       }
     },
     "node_modules/react-devtools-core/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -29358,22 +29236,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.25.0"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.2.6"
       }
-    },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
-      "license": "MIT"
     },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
@@ -29447,72 +29319,61 @@
       }
     },
     "node_modules/react-native": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.5.tgz",
-      "integrity": "sha512-jVihwsE4mWEHZ9HkO1J2eUZSwHyDByZOqthwnGrVZCh6kTQBCm4v8dicsyDa6p0fpWNE5KicTcpX/XXl0ASJFg==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.6.tgz",
+      "integrity": "sha512-H513+8VzviNFXOdPnStRzX9S3/jiJGg++QZ1zd+ROyAvBEKqFqKUPHH0d82y3QyRPct5qKjdOa7J6vNehCvXYA==",
       "license": "MIT",
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
-        "@react-native/assets-registry": "0.79.5",
-        "@react-native/codegen": "0.79.5",
-        "@react-native/community-cli-plugin": "0.79.5",
-        "@react-native/gradle-plugin": "0.79.5",
-        "@react-native/js-polyfills": "0.79.5",
-        "@react-native/normalize-colors": "0.79.5",
-        "@react-native/virtualized-lists": "0.79.5",
+        "@react-native/assets-registry": "0.83.6",
+        "@react-native/codegen": "0.83.6",
+        "@react-native/community-cli-plugin": "0.83.6",
+        "@react-native/gradle-plugin": "0.83.6",
+        "@react-native/js-polyfills": "0.83.6",
+        "@react-native/normalize-colors": "0.83.6",
+        "@react-native/virtualized-lists": "0.83.6",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
         "babel-jest": "^29.7.0",
-        "babel-plugin-syntax-hermes-parser": "0.25.1",
+        "babel-plugin-syntax-hermes-parser": "0.32.0",
         "base64-js": "^1.5.1",
-        "chalk": "^4.0.0",
         "commander": "^12.0.0",
-        "event-target-shim": "^5.0.1",
         "flow-enums-runtime": "^0.0.6",
         "glob": "^7.1.1",
+        "hermes-compiler": "0.14.1",
         "invariant": "^2.2.4",
         "jest-environment-node": "^29.7.0",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.82.0",
-        "metro-source-map": "^0.82.0",
+        "metro-runtime": "^0.83.6",
+        "metro-source-map": "^0.83.6",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
-        "react-devtools-core": "^6.1.1",
+        "react-devtools-core": "^6.1.5",
         "react-refresh": "^0.14.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "0.25.0",
+        "scheduler": "0.27.0",
         "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
-        "ws": "^6.2.3",
+        "ws": "^7.5.10",
         "yargs": "^17.6.2"
       },
       "bin": {
         "react-native": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 20.19.4"
       },
       "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "^19.0.0"
+        "@types/react": "^19.1.1",
+        "react": "^19.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-native-edge-to-edge": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
-      "integrity": "sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
       }
     },
     "node_modules/react-native-is-edge-to-edge": {
@@ -29526,9 +29387,9 @@
       }
     },
     "node_modules/react-native-web": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.20.0.tgz",
-      "integrity": "sha512-OOSgrw+aON6R3hRosCau/xVxdLzbjEcsLysYedka0ZON4ZZe6n9xgeN9ZkoejhARM36oTlUgHIQqxGutEJ9Wxg==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
+      "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
@@ -29563,61 +29424,19 @@
       "integrity": "sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==",
       "license": "MIT"
     },
-    "node_modules/react-native/node_modules/@react-native/codegen": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.5.tgz",
-      "integrity": "sha512-FO5U1R525A1IFpJjy+KVznEinAgcs3u7IbnbRJUG9IH/MBXi2lEU2LtN+JarJ81MCfW4V2p0pg6t/3RGHFRrlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.1",
-        "hermes-parser": "0.25.1",
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1",
-        "yargs": "^17.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
     "node_modules/react-native/node_modules/@react-native/normalize-colors": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.5.tgz",
-      "integrity": "sha512-nGXMNMclZgzLUxijQQ38Dm3IAEhgxuySAWQHnljFtfB0JdaMwpe0Ox9H7Tp2OgrEA+EMEv+Od9ElKlHwGKmmvQ==",
+      "version": "0.83.6",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.83.6.tgz",
+      "integrity": "sha512-bTM24b5v4qN3h52oflnv+OujFORn/kVi06WaWhnQQw14/ycilPqIsqsa+DpIBqdBrXxvLa9fXtCRrQtGATZCEw==",
       "license": "MIT"
     },
-    "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
-      "version": "0.79.5",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.5.tgz",
-      "integrity": "sha512-EUPM2rfGNO4cbI3olAbhPkIt3q7MapwCwAJBzUfWlZ/pu0PRNOnMQ1IvaXTf3TpeozXV52K1OdprLEI/kI5eUA==",
-      "license": "MIT",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@types/react": "^19.0.0",
-        "react": "*",
-        "react-native": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
       "license": "MIT",
       "dependencies": {
-        "hermes-parser": "0.25.1"
+        "hermes-parser": "0.32.0"
       }
     },
     "node_modules/react-native/node_modules/commander": {
@@ -29633,7 +29452,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -29650,11 +29469,20 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/react-native/node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+    "node_modules/react-native/node_modules/hermes-estree": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
+      "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
       "license": "MIT"
+    },
+    "node_modules/react-native/node_modules/hermes-parser": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
+      "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.32.0"
+      }
     },
     "node_modules/react-native/node_modules/semver": {
       "version": "7.7.2",
@@ -29669,12 +29497,24 @@
       }
     },
     "node_modules/react-native/node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
       "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -29756,30 +29596,23 @@
       "link": true
     },
     "node_modules/react-test-renderer": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.0.0.tgz",
-      "integrity": "sha512-oX5u9rOQlHzqrE/64CNr0HB0uWxkCQmZNSfozlYvwE71TLVgeZxVf0IjouGEr1v7r1kcDifdAJBeOhdhxsG/DA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.6.tgz",
+      "integrity": "sha512-GbS6V23YduFTPiWJ5xICbKEjRcqx1Z90js/V5miqhz7qp/d6xSe9Dd6NjSQODFRdzdsqRMPW82E/sFpPRbY5Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "react-is": "^19.0.0",
-        "scheduler": "^0.25.0"
+        "react-is": "^19.2.6",
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.0.0"
+        "react": "^19.2.6"
       }
     },
     "node_modules/react-test-renderer/node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-test-renderer/node_modules/scheduler": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
-      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
+      "version": "19.2.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
+      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
       "dev": true,
       "license": "MIT"
     },
@@ -30694,28 +30527,6 @@
         "node": "*"
       }
     },
-    "node_modules/requireg": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/requireg/-/requireg-0.2.2.tgz",
-      "integrity": "sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==",
-      "dependencies": {
-        "nested-error-stacks": "~2.0.1",
-        "rc": "~1.2.7",
-        "resolve": "~1.7.1"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/requireg/node_modules/resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-      "license": "MIT",
-      "dependencies": {
-        "path-parse": "^1.0.5"
-      }
-    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -30787,15 +30598,16 @@
       }
     },
     "node_modules/resolve-workspace-root": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.0.tgz",
-      "integrity": "sha512-IsaBUZETJD5WsI11Wt8PKHwaIe45or6pwNc8yflvLJ4DWtImK9kuLoH5kUva/2Mmx/RdIyr4aONNSa2v9LTJsw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.1.tgz",
+      "integrity": "sha512-nR23LHAvaI6aHtMg6RWoaHpdR4D881Nydkzi2CixINyg9T00KgaJdJI6Vwty+Ps8WLxZHuxsS0BseWjxSA4C+w==",
       "license": "MIT"
     },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
       "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -31216,9 +31028,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.1.tgz",
-      "integrity": "sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
@@ -31227,13 +31039,13 @@
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "statuses": "~2.0.2"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -31263,6 +31075,26 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/send/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/send/node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -31276,9 +31108,9 @@
       }
     },
     "node_modules/send/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -31645,16 +31477,6 @@
         "@img/sharp-win32-x64": "0.34.3"
       }
     },
-    "node_modules/sharp/node_modules/detect-libc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
-      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/sharp/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -31917,9 +31739,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
-      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+      "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -32233,6 +32055,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -32247,12 +32070,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -32462,6 +32287,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -32595,81 +32421,6 @@
       "integrity": "sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==",
       "license": "MIT"
     },
-    "node_modules/sucrase": {
-      "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "commander": "^4.0.0",
-        "glob": "^10.3.10",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-        "ts-interface-checker": "^0.1.9"
-      },
-      "bin": {
-        "sucrase": "bin/sucrase",
-        "sucrase-node": "bin/sucrase-node"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/sucrase/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/sucrase/node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/sucrase/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/sucrase/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -32763,47 +32514,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tar": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
-      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.0.1",
-        "mkdirp": "^3.0.1",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/tar/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/temp": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
@@ -32815,15 +32525,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/temp-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
-      "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/temp/node_modules/glob": {
@@ -33016,27 +32717,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "license": "MIT"
     },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/throat": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
@@ -33218,6 +32898,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toqr": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/toqr/-/toqr-0.1.1.tgz",
+      "integrity": "sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==",
+      "license": "MIT"
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -33310,12 +32996,6 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
-    },
-    "node_modules/ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "license": "Apache-2.0"
     },
     "node_modules/tsconfck": {
       "version": "3.1.6",
@@ -33873,15 +33553,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.17"
-      }
-    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
@@ -33965,18 +33636,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/unique-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
-      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
-      "license": "MIT",
-      "dependencies": {
-        "crypto-random-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/unist-util-find-after": {
@@ -34918,28 +34577,11 @@
         "node": ">=12"
       }
     },
-    "node_modules/whatwg-url-without-unicode": {
-      "version": "8.0.0-3",
-      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
-      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.4.3",
-        "punycode": "^2.1.1",
-        "webidl-conversions": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/whatwg-url-without-unicode/node_modules/webidl-conversions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/whatwg-url-minimum": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/whatwg-url-minimum/-/whatwg-url-minimum-0.1.2.tgz",
+      "integrity": "sha512-XPEm0XFQWNVG292lII1PrRRJl3sItrs7CettZ4ncYxuDVpLyy+NwlGyut2hXI0JswcJUxeCH+CyOJK0ZzAXD6A==",
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -35104,12 +34746,6 @@
       "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
       "license": "MIT"
     },
-    "node_modules/wonka": {
-      "version": "6.3.5",
-      "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
-      "integrity": "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw==",
-      "license": "MIT"
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -35141,6 +34777,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -35158,12 +34795,14 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -35173,6 +34812,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -35279,6 +34919,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
       "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -35472,7 +35113,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -35592,8 +35232,8 @@
         "@rollup/plugin-commonjs": "^26.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@testing-library/react": "^16.3.0",
-        "react": "~19.0.0",
-        "react-dom": "~19.0.0",
+        "react": "~19.2.0",
+        "react-dom": "~19.2.0",
         "rollup": "^4.22.4"
       },
       "peerDependencies": {
@@ -35620,9 +35260,9 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.7",
         "@testing-library/react": "^16.3.0",
-        "react": "~19.0.0",
-        "react-dom": "~19.0.0",
-        "react-test-renderer": "~19.0.0",
+        "react": "~19.2.0",
+        "react-dom": "~19.2.0",
+        "react-test-renderer": "~19.2.0",
         "rollup": "^4.22.4"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "patch-package": "^8.0.0",
     "prettier": "^3.3.3",
     "prettier-plugin-hermes-parser": "0.36.1",
+    "react": "~19.2.0",
+    "react-dom": "~19.2.0",
+    "react-test-renderer": "~19.2.0",
     "yargs": "17.7.2"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "patch-package": "^8.0.0",
     "prettier": "^3.3.3",
     "prettier-plugin-hermes-parser": "0.36.1",
-    "react": "~19.2.0",
-    "react-dom": "~19.2.0",
-    "react-test-renderer": "~19.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-test-renderer": "^19.0.0",
     "yargs": "17.7.2"
   },
   "engines": {

--- a/packages/react-strict-animated/package.json
+++ b/packages/react-strict-animated/package.json
@@ -37,8 +37,8 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@testing-library/react": "^16.3.0",
-    "react": "~19.0.0",
-    "react-dom": "~19.0.0",
+    "react": "~19.2.0",
+    "react-dom": "~19.2.0",
     "rollup": "^4.22.4"
   },
   "peerDependencies": {

--- a/packages/react-strict-animated/package.json
+++ b/packages/react-strict-animated/package.json
@@ -37,13 +37,13 @@
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@testing-library/react": "^16.3.0",
-    "react": "~19.2.0",
-    "react-dom": "~19.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
     "rollup": "^4.22.4"
   },
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-native": ">=0.79.5"
+    "react-native": ">=0.82.0"
   }
 }

--- a/packages/react-strict-dom/CHANGELOG.md
+++ b/packages/react-strict-dom/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Breaking changes
+
+* [Native] Bumped `react-native` peer dependency to `>=0.82.0`. The native build now relies on the stable DOM Node APIs shipped in React Native 0.82.
+
+### Internal
+
+* [Native] `useStrictDOMElement` now wraps the underlying React Native host node in a thin `Proxy` instead of cloning it via `Object.create` and `Object.defineProperties`. Strict-dom continues to override `nodeName` (returns uppercase DOM names like `'DIV'`), to scale `getBoundingClientRect` and length properties by the active viewport scale, to polyfill `<img>.complete`, and to polyfill the `setSelectionRange` / `selectionStart` / `selectionEnd` trio on `<input>` / `<textarea>`. All other DOM Node properties and methods (`ownerDocument`, `getRootNode`, `children`, `childNodes`, `parentNode`, `parentElement`, `contains`, `compareDocumentPosition`, pointer-capture methods, legacy `measure*`, etc.) now pass through directly from the underlying RN node.
+
 ## 0.0.55 (Jan 9, 2026)
 
 ### New features

--- a/packages/react-strict-dom/CHANGELOG.md
+++ b/packages/react-strict-dom/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Internal
 
-* [Native] `useStrictDOMElement` now wraps the underlying React Native host node in a thin `Proxy` instead of cloning it via `Object.create` and `Object.defineProperties`. Strict-dom continues to override `nodeName` (returns uppercase DOM names like `'DIV'`), to scale `getBoundingClientRect` and length properties by the active viewport scale, to polyfill `<img>.complete`, and to polyfill the `setSelectionRange` / `selectionStart` / `selectionEnd` trio on `<input>` / `<textarea>`. All other DOM Node properties and methods (`ownerDocument`, `getRootNode`, `children`, `childNodes`, `parentNode`, `parentElement`, `contains`, `compareDocumentPosition`, pointer-capture methods, legacy `measure*`, etc.) now pass through directly from the underlying RN node.
+* [Native] `useStrictDOMElement` now wraps the RN host node via `Object.create(node)` and defines only strict-dom's overrides as own properties. Non-overridden reads resolve through the prototype chain to the real node, keeping a static hidden class Hermes can optimize. Overrides unchanged: uppercase `nodeName`, viewport-scaled `getBoundingClientRect` and length properties, `<img>.complete`, and `setSelectionRange` / `selectionStart` / `selectionEnd` on `<input>` / `<textarea>`.
 
 ## 0.0.55 (Jan 9, 2026)
 

--- a/packages/react-strict-dom/CHANGELOG.md
+++ b/packages/react-strict-dom/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Breaking changes
 
-* [Native] Bumped `react-native` peer dependency to `>=0.82.0`. The native build now relies on the stable DOM Node APIs shipped in React Native 0.82.
+* [Native] React Strict DOM and React Strict Animated now require `react-native >=0.82.0` for native builds that use RN DOM Node APIs.
 
 ### Internal
 
-* [Native] `useStrictDOMElement` now wraps the RN host node via `Object.create(node)` and defines only strict-dom's overrides as own properties. Non-overridden reads resolve through the prototype chain to the real node, keeping a static hidden class Hermes can optimize. Overrides unchanged: uppercase `nodeName`, viewport-scaled `getBoundingClientRect` and length properties, `<img>.complete`, and `setSelectionRange` / `selectionStart` / `selectionEnd` on `<input>` / `<textarea>`.
+* [Native] `useStrictDOMElement` now wraps the RN host node with `Object.create(node)` and defines only strict-dom overrides as own properties.
 
 ## 0.0.55 (Jan 9, 2026)
 

--- a/packages/react-strict-dom/package.json
+++ b/packages/react-strict-dom/package.json
@@ -51,9 +51,9 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
     "@testing-library/react": "^16.3.0",
-    "react": "~19.0.0",
-    "react-dom": "~19.0.0",
-    "react-test-renderer": "~19.0.0",
+    "react": "~19.2.0",
+    "react-dom": "~19.2.0",
+    "react-test-renderer": "~19.2.0",
     "rollup": "^4.22.4"
   },
   "peerDependencies": {

--- a/packages/react-strict-dom/package.json
+++ b/packages/react-strict-dom/package.json
@@ -51,15 +51,15 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.7",
     "@testing-library/react": "^16.3.0",
-    "react": "~19.2.0",
-    "react-dom": "~19.2.0",
-    "react-test-renderer": "~19.2.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-test-renderer": "^19.0.0",
     "rollup": "^4.22.4"
   },
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-native": ">=0.79.5"
+    "react-native": ">=0.82.0"
   },
   "engines": {
     "node": ">=20.11.0"

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -26,12 +26,9 @@ type StrictProps = Readonly<{
   children?: React.Node | ((ReactNativeProps) => React.Node)
 }>;
 
-const AnimatedPressable = ReactNative.Animated.createAnimatedComponent<
-  // $FlowFixMe[invalid-component-prop]
-  React.ElementConfig<typeof ReactNative.Pressable>,
-  typeof ReactNative.Pressable
-  // $FlowFixMe[incompatible-type]
->(ReactNative.Pressable);
+const AnimatedPressable = ReactNative.Animated.createAnimatedComponent(
+  ReactNative.Pressable
+);
 
 export function createStrictDOMComponent<T, P extends StrictProps>(
   tagName: string,

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
@@ -124,7 +124,10 @@ export function createStrictDOMImageComponent<
       typeof props.children === 'function' ? (
         props.children(nativeProps)
       ) : (
+        // strict-dom's wide ReactNativeProps spreads onto RN 0.83's exact
+        // ImageProps; harmless extras are ignored at runtime.
         // $FlowFixMe[incompatible-type]
+        // $FlowFixMe[incompatible-use]
         <NativeComponent {...nativeProps} />
       );
 

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMTextInputComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMTextInputComponent.js
@@ -18,11 +18,9 @@ import { mergeRefs } from '../../shared/mergeRefs';
 import { useNativeProps } from './useNativeProps';
 import { useStrictDOMElement } from './useStrictDOMElement';
 
-const AnimatedTextInput = ReactNative.Animated.createAnimatedComponent<
-  React.ElementConfig<typeof ReactNative.TextInput>,
-  typeof ReactNative.TextInput
-  // $FlowFixMe[incompatible-type]: React Native animated component typing issue
->(ReactNative.TextInput);
+const AnimatedTextInput = ReactNative.Animated.createAnimatedComponent(
+  ReactNative.TextInput
+);
 
 // $FlowFixMe[unclear-type]
 type Node = any;
@@ -250,7 +248,10 @@ export function createStrictDOMTextInputComponent<
       typeof props.children === 'function' ? (
         props.children(nativeProps)
       ) : (
+        // strict-dom's wide ReactNativeProps spreads onto RN 0.83's exact
+        // TextInputProps; harmless extras are ignored at runtime.
         // $FlowFixMe[incompatible-type]
+        // $FlowFixMe[incompatible-use]
         <NativeComponent {...nativeProps} />
       );
 

--- a/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
+++ b/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
@@ -11,7 +11,6 @@ import type { CallbackRef } from '../../types/react';
 
 import * as React from 'react';
 
-import { errorMsg } from '../../shared/logUtils';
 import { useElementCallback } from '../../shared/useElementCallback';
 import { useViewportScale } from './ContextViewportScale';
 
@@ -22,9 +21,9 @@ type Options = {
 // $FlowFixMe[unclear-type]
 type Node = any;
 
-const memoizedStrictRefs: WeakMap<Node, unknown> = new WeakMap();
+const memoizedStrictRefs: WeakMap<Node, Node> = new WeakMap();
 
-const lengthPropertySet = new Set([
+const lengthPropertySet: ReadonlySet<string> = new Set([
   'clientHeight',
   'clientLeft',
   'clientTop',
@@ -40,132 +39,89 @@ const lengthPropertySet = new Set([
 ]);
 
 /**
- * Copying the node is necessary because getBoundingClientRect is replaced to
- * polyfill viewport scaling. It means we have to forward private fields
- * to improve compatibility with most React Native code.
- *
- * We're not modifying child nodes to account for viewport scaling. Reading
- * values from those nodes after traversal is not recommended.
+ * Wraps a React Native host node in a Proxy so strict-dom can override the
+ * remaining DOM APIs it polyfills while forwarding RN's DOM Node APIs.
+ * Methods are bound to the host node so RN internals receive the expected
+ * `this` value.
  */
 function getOrCreateStrictRef(
   node: Node,
   tagName: string,
   viewportScale: number
-) {
+): Node {
   const ref = memoizedStrictRefs.get(node);
   if (ref != null) {
     return ref;
-  } else {
-    try {
-      // Create object with prototype chain intact (preserves instanceof)
-      const strictRef = Object.create(Object.getPrototypeOf(node));
-
-      // Copy all own properties including React Native internals
-      const descriptors = Object.getOwnPropertyDescriptors(node);
-      Object.defineProperties(strictRef, descriptors);
-
-      const scale = (number: number) => number / viewportScale;
-
-      // Override getBoundingClientRect for viewport-scaling
-      const getBoundingClientRect = node?.getBoundingClientRect;
-      if (getBoundingClientRect) {
-        // $FlowFixMe[prop-missing]
-        Object.defineProperty(strictRef, 'getBoundingClientRect', {
-          value: () => {
-            const rect = getBoundingClientRect.call(node);
-            if (viewportScale !== 1) {
-              return new DOMRect(
-                scale(rect.x),
-                scale(rect.y),
-                scale(rect.width),
-                scale(rect.height)
-              );
-            }
-            return rect;
-          },
-          configurable: true,
-          writable: true
-        });
-      }
-
-      // Override length properties for viewport-scaling
-      for (const prop of lengthPropertySet) {
-        if (prop in strictRef) {
-          if (viewportScale !== 1) {
-            // $FlowFixMe[prop-missing]
-            Object.defineProperty(strictRef, prop, {
-              get() {
-                const value = node[prop];
-                return typeof value === 'number' ? scale(value) : value;
-              }
-            });
-          }
-        }
-      }
-
-      // $FlowFixMe[prop-missing]
-      Object.defineProperty(strictRef, 'nodeName', {
-        get() {
-          return tagName.toUpperCase();
-        }
-      });
-      if (tagName === 'img') {
-        // $FlowFixMe[prop-missing]
-        Object.defineProperty(strictRef, 'complete', {
-          get() {
-            if (node?.complete == null) {
-              return false;
-            } else {
-              return node.complete;
-            }
-          }
-        });
-      } else if (tagName === 'input' || tagName === 'textarea') {
-        const setSelectionRange = node?.setSelectionRange;
-        if (setSelectionRange == null) {
-          // $FlowFixMe[prop-missing]
-          Object.defineProperty(strictRef, 'setSelectionRange', {
-            value: (a: number, b: number) => {
-              node.setSelection(a, b);
-              // Update cached selection state
-              node._selectionStart = a;
-              node._selectionEnd = b;
-            },
-            configurable: true,
-            writable: true
-          });
-        }
-        const selectionStart = node?.selectionStart;
-        if (selectionStart == null) {
-          // $FlowFixMe[prop-missing]
-          Object.defineProperty(strictRef, 'selectionStart', {
-            get() {
-              return node._selectionStart ?? 0;
-            }
-          });
-        }
-        const selectionEnd = node?.selectionEnd;
-        if (selectionEnd == null) {
-          // $FlowFixMe[prop-missing]
-          Object.defineProperty(strictRef, 'selectionEnd', {
-            get() {
-              return node._selectionEnd ?? 0;
-            }
-          });
-        }
-      }
-
-      memoizedStrictRefs.set(node, strictRef);
-      return strictRef;
-    } catch (e) {
-      // Fallback to original node if copying fails
-      if (__DEV__) {
-        errorMsg('failed to create strict ref. Falling back to original node');
-        console.error(e);
-      }
-      return node;
-    }
   }
+
+  const isImg = tagName === 'img';
+  const isTextInput = tagName === 'input' || tagName === 'textarea';
+  const upperTagName = tagName.toUpperCase();
+  const scaled = (n: number) => n / viewportScale;
+
+  // $FlowFixMe[unclear-type] - ProxyHandler is not in Flow's built-in types.
+  const handler: any = {
+    get(target, prop, _receiver) {
+      if (prop === 'nodeName') {
+        return upperTagName;
+      }
+      if (prop === 'getBoundingClientRect') {
+        const fn = target.getBoundingClientRect;
+        if (typeof fn !== 'function') {
+          return fn;
+        }
+        return () => {
+          const rect = fn.call(target);
+          if (viewportScale !== 1) {
+            return new DOMRect(
+              scaled(rect.x),
+              scaled(rect.y),
+              scaled(rect.width),
+              scaled(rect.height)
+            );
+          }
+          return rect;
+        };
+      }
+      if (
+        viewportScale !== 1 &&
+        typeof prop === 'string' &&
+        lengthPropertySet.has(prop)
+      ) {
+        const raw = target[prop];
+        return typeof raw === 'number' ? scaled(raw) : raw;
+      }
+      if (isImg && prop === 'complete') {
+        return target.complete ?? false;
+      }
+      if (isTextInput) {
+        if (prop === 'setSelectionRange' && target.setSelectionRange == null) {
+          return (a: number, b: number) => {
+            target.setSelection(a, b);
+            target._selectionStart = a;
+            target._selectionEnd = b;
+          };
+        }
+        if (prop === 'selectionStart' && target.selectionStart == null) {
+          return target._selectionStart ?? 0;
+        }
+        if (prop === 'selectionEnd' && target.selectionEnd == null) {
+          return target._selectionEnd ?? 0;
+        }
+      }
+      // $FlowFixMe[unclear-type]
+      const value: any = Reflect.get(target, prop, target);
+      if (typeof value === 'function') {
+        return value.bind(target);
+      }
+      return value;
+    }
+  };
+
+  // $FlowFixMe[invalid-constructor] - Flow types Proxy strictly here.
+  const strictRef: Node = new Proxy(node, handler);
+  memoizedStrictRefs.set(node, strictRef);
+  return strictRef;
 }
 
 export function useStrictDOMElement<T>(

--- a/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
+++ b/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
@@ -39,10 +39,12 @@ const lengthPropertySet: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Wraps a React Native host node in a Proxy so strict-dom can override the
- * remaining DOM APIs it polyfills while forwarding RN's DOM Node APIs.
- * Methods are bound to the host node so RN internals receive the expected
- * `this` value.
+ * Uses the RN host node as the wrapper's prototype so non-overridden reads
+ * resolve via the prototype chain — including the symbol-keyed internals
+ * RN's prototype methods consult via `this`. Keeps a static hidden class so
+ * Hermes can optimize access; a Proxy cannot.
+ *
+ * Descendants are not wrapped; values read after traversal are not scaled.
  */
 function getOrCreateStrictRef(
   node: Node,
@@ -54,72 +56,87 @@ function getOrCreateStrictRef(
     return ref;
   }
 
-  const isImg = tagName === 'img';
-  const isTextInput = tagName === 'input' || tagName === 'textarea';
-  const upperTagName = tagName.toUpperCase();
-  const scaled = (n: number) => n / viewportScale;
+  const strictRef: Node = Object.create(node);
 
-  // $FlowFixMe[unclear-type] - ProxyHandler is not in Flow's built-in types.
-  const handler: any = {
-    get(target, prop, _receiver) {
-      if (prop === 'nodeName') {
-        return upperTagName;
-      }
-      if (prop === 'getBoundingClientRect') {
-        const fn = target.getBoundingClientRect;
-        if (typeof fn !== 'function') {
-          return fn;
-        }
-        return () => {
-          const rect = fn.call(target);
-          if (viewportScale !== 1) {
-            return new DOMRect(
-              scaled(rect.x),
-              scaled(rect.y),
-              scaled(rect.width),
-              scaled(rect.height)
-            );
-          }
-          return rect;
-        };
-      }
-      if (
-        viewportScale !== 1 &&
-        typeof prop === 'string' &&
-        lengthPropertySet.has(prop)
-      ) {
-        const raw = target[prop];
-        return typeof raw === 'number' ? scaled(raw) : raw;
-      }
-      if (isImg && prop === 'complete') {
-        return target.complete ?? false;
-      }
-      if (isTextInput) {
-        if (prop === 'setSelectionRange' && target.setSelectionRange == null) {
-          return (a: number, b: number) => {
-            target.setSelection(a, b);
-            target._selectionStart = a;
-            target._selectionEnd = b;
-          };
-        }
-        if (prop === 'selectionStart' && target.selectionStart == null) {
-          return target._selectionStart ?? 0;
-        }
-        if (prop === 'selectionEnd' && target.selectionEnd == null) {
-          return target._selectionEnd ?? 0;
-        }
-      }
-      // $FlowFixMe[unclear-type]
-      const value: any = Reflect.get(target, prop, target);
-      if (typeof value === 'function') {
-        return value.bind(target);
-      }
-      return value;
+  // $FlowFixMe[prop-missing]
+  Object.defineProperty(strictRef, 'nodeName', {
+    value: tagName.toUpperCase(),
+    configurable: true
+  });
+
+  if (viewportScale !== 1) {
+    const scale = (n: number) => n / viewportScale;
+
+    if (typeof node.getBoundingClientRect === 'function') {
+      // $FlowFixMe[prop-missing]
+      Object.defineProperty(strictRef, 'getBoundingClientRect', {
+        value: () => {
+          const rect = node.getBoundingClientRect();
+          return new DOMRect(
+            scale(rect.x),
+            scale(rect.y),
+            scale(rect.width),
+            scale(rect.height)
+          );
+        },
+        configurable: true
+      });
     }
-  };
 
-  // $FlowFixMe[invalid-constructor] - Flow types Proxy strictly here.
-  const strictRef: Node = new Proxy(node, handler);
+    for (const prop of lengthPropertySet) {
+      if (prop in node) {
+        // $FlowFixMe[prop-missing]
+        Object.defineProperty(strictRef, prop, {
+          get() {
+            const value = node[prop];
+            return typeof value === 'number' ? scale(value) : value;
+          },
+          configurable: true
+        });
+      }
+    }
+  }
+
+  if (tagName === 'img') {
+    // $FlowFixMe[prop-missing]
+    Object.defineProperty(strictRef, 'complete', {
+      get() {
+        return node.complete ?? false;
+      },
+      configurable: true
+    });
+  } else if (tagName === 'input' || tagName === 'textarea') {
+    if (node.setSelectionRange == null) {
+      // $FlowFixMe[prop-missing]
+      Object.defineProperty(strictRef, 'setSelectionRange', {
+        value: (a: number, b: number) => {
+          node.setSelection(a, b);
+          node._selectionStart = a;
+          node._selectionEnd = b;
+        },
+        configurable: true
+      });
+    }
+    if (node.selectionStart == null) {
+      // $FlowFixMe[prop-missing]
+      Object.defineProperty(strictRef, 'selectionStart', {
+        get() {
+          return node._selectionStart ?? 0;
+        },
+        configurable: true
+      });
+    }
+    if (node.selectionEnd == null) {
+      // $FlowFixMe[prop-missing]
+      Object.defineProperty(strictRef, 'selectionEnd', {
+        get() {
+          return node._selectionEnd ?? 0;
+        },
+        configurable: true
+      });
+    }
+  }
+
   memoizedStrictRefs.set(node, strictRef);
   return strictRef;
 }
@@ -130,33 +147,27 @@ export function useStrictDOMElement<T>(
 ): CallbackRef<T> {
   const { scale: viewportScale } = useViewportScale();
 
-  const elementCallback = useElementCallback(
+  return useElementCallback(
     React.useCallback(
       // $FlowFixMe[unclear-type]
       (node: any) => {
-        if (ref == null) {
-          return undefined;
-        } else {
-          const strictRef = getOrCreateStrictRef(node, tagName, viewportScale);
-          if (typeof ref === 'function') {
-            // $FlowFixMe[incompatible-type] - Flow does not understand ref cleanup.
-            const cleanup: void | (() => void) = ref(strictRef);
-            return typeof cleanup === 'function'
-              ? cleanup
-              : () => {
-                  ref(null);
-                };
-          } else {
-            ref.current = strictRef;
-            return () => {
-              ref.current = null;
-            };
-          }
+        if (ref == null) return undefined;
+        const strictRef = getOrCreateStrictRef(node, tagName, viewportScale);
+        if (typeof ref === 'function') {
+          // $FlowFixMe[incompatible-type] - Flow does not understand ref cleanup.
+          const cleanup: void | (() => void) = ref(strictRef);
+          return typeof cleanup === 'function'
+            ? cleanup
+            : () => {
+                ref(null);
+              };
         }
+        ref.current = strictRef;
+        return () => {
+          ref.current = null;
+        };
       },
       [ref, tagName, viewportScale]
     )
   );
-
-  return elementCallback;
 }

--- a/packages/react-strict-dom/tests/html/html-refs-test.native.js
+++ b/packages/react-strict-dom/tests/html/html-refs-test.native.js
@@ -6,10 +6,56 @@
  */
 
 import * as React from 'react';
-import { html } from 'react-strict-dom';
+import { contexts, html } from 'react-strict-dom';
 import { act, create } from 'react-test-renderer';
 
+global.DOMRect = class DOMRect {
+  constructor(x, y, width, height) {
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+  }
+};
+
+/**
+ * Builds a fake host node mimicking the shape RN 0.82 exposes via element-node
+ * refs. Properties present here pass through useStrictDOMElement; properties
+ * intentionally omitted (setSelectionRange, selectionStart, selectionEnd,
+ * complete) are the gaps strict-dom still polyfills.
+ */
+function buildHostNodeMock(overrides) {
+  const ownerDocument = {
+    nodeName: '#document',
+    nodeType: 9
+  };
+  const node = {
+    blur: () => {},
+    focus: () => {},
+    offsetWidth: 15,
+    offsetHeight: 10,
+    scrollTop: 0,
+    setSelection: jest.fn(),
+    ownerDocument,
+    childNodes: [],
+    children: [],
+    parentNode: null,
+    getRootNode() {
+      return ownerDocument;
+    },
+    getBoundingClientRect() {
+      return new DOMRect(1, 2, 15, 10);
+    }
+  };
+  if (overrides != null) {
+    Object.assign(node, overrides);
+  }
+  return node;
+}
+
 describe('<html.*> refs', () => {
+  const { ViewportProvider } = contexts;
+
   beforeEach(() => {
     // avoid console messages for these tests
     jest.spyOn(console, 'error');
@@ -25,19 +71,11 @@ describe('<html.*> refs', () => {
   });
 
   describe('imperative api', () => {
-    const setSelectionMock = jest.fn();
-
-    // This mock should only built-in host element APIs (React Native)
-    function createNodeMock(element) {
-      const obj = {};
-      obj.blur = () => {};
-      obj.focus = () => {};
-      obj.offsetWidth = 15;
-      obj.setSelection = setSelectionMock;
-      return obj;
-    }
-
-    test('node is defined', () => {
+    test('input ref polyfills selection range', () => {
+      const setSelectionMock = jest.fn();
+      function createNodeMock() {
+        return buildHostNodeMock({ setSelection: setSelectionMock });
+      }
       act(() => {
         create(
           <html.input
@@ -56,8 +94,7 @@ describe('<html.*> refs', () => {
       });
     });
 
-    // We shouldn't create a handle if there is no underlying node
-    test('node is null', () => {
+    test('input ref does not throw when host node is null', () => {
       act(() => {
         create(
           <html.input
@@ -66,6 +103,170 @@ describe('<html.*> refs', () => {
             }}
           />,
           { createNodeMock: () => null }
+        );
+      });
+    });
+  });
+
+  describe('DOM node shape', () => {
+    test('nodeName returns uppercase tag for html.div', () => {
+      function createNodeMock() {
+        return buildHostNodeMock({ tagName: 'RN:View' });
+      }
+      act(() => {
+        create(
+          <html.div
+            ref={(node) => {
+              expect(node.nodeName).toBe('DIV');
+            }}
+          />,
+          { createNodeMock }
+        );
+      });
+    });
+
+    test('nodeName returns uppercase tag for html.span', () => {
+      function createNodeMock() {
+        return buildHostNodeMock({ tagName: 'RN:View' });
+      }
+      act(() => {
+        create(
+          <html.span
+            ref={(node) => {
+              expect(node.nodeName).toBe('SPAN');
+            }}
+          />,
+          { createNodeMock }
+        );
+      });
+    });
+
+    test('getBoundingClientRect passes through when viewport scale is 1', () => {
+      function createNodeMock() {
+        return buildHostNodeMock();
+      }
+      act(() => {
+        create(
+          <html.div
+            ref={(node) => {
+              const rect = node.getBoundingClientRect();
+              expect(rect.x).toBe(1);
+              expect(rect.y).toBe(2);
+              expect(rect.width).toBe(15);
+              expect(rect.height).toBe(10);
+            }}
+          />,
+          { createNodeMock }
+        );
+      });
+    });
+
+    test('getBoundingClientRect is scaled when viewport scale is not 1', () => {
+      function createNodeMock() {
+        return buildHostNodeMock();
+      }
+      const SCALE = 2;
+      act(() => {
+        create(
+          <ViewportProvider viewportWidth={1000}>
+            <html.div
+              ref={(node) => {
+                const rect = node.getBoundingClientRect();
+                // useWindowDimensions mock returns width: 2000.
+                // viewportScale = 2000 / 1000 = 2, so values are halved.
+                expect(rect.x).toBe(1 / SCALE);
+                expect(rect.y).toBe(2 / SCALE);
+                expect(rect.width).toBe(15 / SCALE);
+                expect(rect.height).toBe(10 / SCALE);
+              }}
+            />
+          </ViewportProvider>,
+          { createNodeMock }
+        );
+      });
+    });
+
+    test('ownerDocument, getRootNode, childNodes, children pass through', () => {
+      let underlyingNode;
+      function createNodeMock() {
+        underlyingNode = buildHostNodeMock();
+        return underlyingNode;
+      }
+      act(() => {
+        create(
+          <html.div
+            ref={(node) => {
+              expect(node.ownerDocument).toBe(underlyingNode.ownerDocument);
+              expect(node.getRootNode()).toBe(underlyingNode.ownerDocument);
+              expect(node.childNodes).toBe(underlyingNode.childNodes);
+              expect(node.children).toBe(underlyingNode.children);
+              expect(node.parentNode).toBe(null);
+            }}
+          />,
+          { createNodeMock }
+        );
+      });
+    });
+
+    test('strict ref identity is stable for the same underlying node', () => {
+      const captured = [];
+      let underlyingNode;
+      function createNodeMock() {
+        // react-test-renderer reuses the same mock node across renders
+        // when the element tree shape is unchanged, so this is one node
+        // observed twice.
+        underlyingNode = underlyingNode ?? buildHostNodeMock();
+        return underlyingNode;
+      }
+      const refCallback = (node) => {
+        if (node != null) {
+          captured.push(node);
+        }
+      };
+      let renderer;
+      act(() => {
+        renderer = create(<html.div key="a" ref={refCallback} />, {
+          createNodeMock
+        });
+      });
+      act(() => {
+        renderer.update(<html.div key="b" ref={refCallback} />);
+      });
+      expect(captured.length).toBeGreaterThanOrEqual(2);
+      expect(captured[0]).toBe(captured[captured.length - 1]);
+    });
+
+    test('html.img ref returns complete=false when underlying node omits it', () => {
+      function createNodeMock() {
+        return buildHostNodeMock();
+        // `complete` deliberately omitted
+      }
+      act(() => {
+        create(
+          <html.img
+            ref={(node) => {
+              expect(node.complete).toBe(false);
+            }}
+            src="x"
+          />,
+          { createNodeMock }
+        );
+      });
+    });
+
+    test('html.img ref passes through complete when underlying node exposes it', () => {
+      function createNodeMock() {
+        return buildHostNodeMock({ complete: true });
+      }
+      act(() => {
+        create(
+          <html.img
+            ref={(node) => {
+              expect(node.complete).toBe(true);
+            }}
+            src="x"
+          />,
+          { createNodeMock }
         );
       });
     });


### PR DESCRIPTION
## Summary

Bumps `react-native` peer dep to `>=0.82.0` and adopts the stable DOM Node APIs from RN 0.82. The native ref polyfill becomes an overlay on top of RN's host node instead of a parallel object that re-implements DOM traversal.

The first commit on this branch (4a49d1f) wrapped the node in a `Proxy`. After review feedback that Hermes can't inline through Proxy traps, follow-up 8fbae4f replaces it with `Object.create(node)` prototype delegation: strict-dom defines its overrides as own properties on the wrapper, and everything else delegates to the node via the prototype chain. Same observable behavior, static hidden class Hermes can optimize, no per-access bound-function allocations.

Tracks #462.

## What's still polyfilled

- `nodeName`: uppercase DOM name. RN exposes `tagName` as `'RN:View'`.
- `getBoundingClientRect` and the length getters (`offsetWidth`, `clientHeight`, ...): divided by the active `viewportScale`. Only installed when scale isn't 1, so the common path skips them.
- `<img>.complete`: returns `false` when the underlying Image node doesn't expose it.
- `<input>` / `<textarea>` `setSelectionRange` / `selectionStart` / `selectionEnd`: polyfilled over `setSelection`. Each one is gated on the underlying property being missing, so the polyfill switches itself off the day RN exposes the W3C API.

## What forwards to the RN node

`ownerDocument`, `getRootNode`, `parentNode`, `parentElement`, `children`, `childNodes`, sibling navigation, `contains`, `compareDocumentPosition`, pointer-capture, legacy `measure*` and `setNativeProps`. With the node as the wrapper's prototype, RN's prototype methods invoked on the wrapper see `this === wrapper`; the symbol-keyed internals they consult (`INSTANCE_HANDLE_KEY`, `OWNER_DOCUMENT_KEY` from `NodeInternals.js`) are reachable through the chain back to the node, so RN's implementations resolve their backing state correctly.

`instanceof` keeps working. The chain is `wrapper → node → ReactNativeElement.prototype → ReadOnlyElement.prototype → ReadOnlyNode.prototype`, one link longer than the pre-PR clone but the class prototypes are still on it. Verified on a live iPad simulator (`wrapper.constructor.name === 'ReactNativeElement'`) and in Chrome (`'HTMLDivElement'`).

Identity caching via `WeakMap<Node, Node>` is preserved, so the same RN node yields the same wrapped ref across renders.

## Descriptor flags

`configurable: true` is set on every override so `Object.defineProperty` can redefine them later (tests, devtools, or a future fix to viewport-scale memoization). Value descriptors (`nodeName`, `getBoundingClientRect`, `setSelectionRange`) are not `writable`, matching the DOM spec for read-only properties. Strict-mode assignments like `wrapper.setSelectionRange = ...` now throw `TypeError` instead of silently shadowing. Demoed live in the example apps.

## Breaking

Peer dep `react-native >=0.79.5` → `>=0.82.0`. Apps on older RN stay on the previous react-strict-dom release.

## Notes for reviewers

- **Hermes / Proxy concern.** Addressed in 8fbae4f. The delegation variant has a 1-to-15 own-property hidden class (size depends on viewport scale and tag), no traps, no per-access binding. The CSS benchmarks in `benchmarks/` don't exercise the ref read path, so the existing numbers aren't informative for this change. Happy to add a targeted micro-benchmark if useful.

- **Expo SDK.** No SDK pairs exactly with RN 0.82 (SDK 53 = 0.79, SDK 54 ≈ 0.81, SDK 55 = 0.83). The example apps move to SDK 55 / RN 0.83.6, which satisfies the new peer dep and ships the same DOM Node surface.

- **React devDeps.** RN 0.82+ requires React `>=19.1.1`. The workspace root and library packages' devDependencies pin `react` / `react-dom` / `react-test-renderer` to `~19.2.0` to keep a single React instance across the monorepo.

- **Flow types in 0.83.** `Animated.createAnimatedComponent` is now a single-type-arg generic; fixed by dropping the over-specified two-type-arg form. `ImageProps` / `TextInputProps` became exact; the wide spread of strict-dom's `ReactNativeProps` is covered by two targeted `$FlowFixMe` annotations. Narrowing that spread properly is a separate follow-up.

- **Ten ref tests** in `tests/html/html-refs-test.native.js` pin every wrapped-ref behavior: uppercase nodeName, gBCR pass-through at scale 1 and scaled at non-1, DOM Node API pass-through (`ownerDocument`, `getRootNode`, `childNodes`, `children`), strict-ref identity stability, `<img>.complete` fallback and pass-through, and the input selection trio. All ten pass against both the original Proxy commit and the prototype-delegation follow-up.

- **One pre-existing latent issue noted.** `memoizedStrictRefs` is keyed only on `node`, not on `(node, viewportScale)`. A node rendered first outside `ViewportProvider` and then inside (or with a changing scale) keeps the wrapper from the first wrap. Predates this PR; calling out for a follow-up. Not blocking. I worked around it locally in a realtime demo by putting `key={viewportWidth}` on the inner reporter to force a remount.