### PR TITLE
[react-strict-animated] Fix incorrect error message for invalid mass in SpringAnimation

### DIFF
--- a/packages/react-strict-animated/src/web/__tests__/SpringAnimation-test.js
+++ b/packages/react-strict-animated/src/web/__tests__/SpringAnimation-test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import SpringAnimation from '../animations/SpringAnimation';
+
+describe('SpringAnimation (web)', () => {
+  test('rejects a non-positive stiffness value', () => {
+    expect(
+      () => new SpringAnimation({ toValue: 1, stiffness: 0, damping: 10, mass: 1 })
+    ).toThrow('Stiffness value must be greater than 0');
+  });
+
+  test('rejects a non-positive damping value', () => {
+    expect(
+      () => new SpringAnimation({ toValue: 1, stiffness: 100, damping: 0, mass: 1 })
+    ).toThrow('Damping value must be greater than 0');
+  });
+
+  test('rejects a non-positive mass value', () => {
+    expect(
+      () => new SpringAnimation({ toValue: 1, stiffness: 100, damping: 10, mass: 0 })
+    ).toThrow('Mass value must be greater than 0');
+  });
+});

--- a/packages/react-strict-animated/src/web/animations/SpringAnimation.js
+++ b/packages/react-strict-animated/src/web/animations/SpringAnimation.js
@@ -109,7 +109,7 @@ export default class SpringAnimation implements AnimatedAnimation {
       throw new Error('Damping value must be greater than 0');
     }
     if (this.#mass <= 0) {
-      throw new Error('Damping value must be greater than 0');
+      throw new Error('Mass value must be greater than 0');
     }
   }
 


### PR DESCRIPTION
## Summary

The `mass` validation in the `SpringAnimation` constructor throws the wrong error message. It reports a damping problem when an invalid mass is supplied, because the message was copy-pasted from the preceding damping check.

```js
if (this.#damping <= 0) {
  throw new Error('Damping value must be greater than 0');
}
if (this.#mass <= 0) {
  throw new Error('Damping value must be greater than 0'); // should be Mass
}
```

A user passing `mass: 0` (or a negative mass) gets told their damping value is wrong, which points them at the wrong config field. React Native's equivalent `SpringAnimation` throws `'Mass value must be greater than 0'` here.

## Fix

Use the correct message for the mass check.

## Test

Added `SpringAnimation-test.js` covering all three constructor validations (stiffness, damping, mass). The mass case fails on `main` (asserts `'Mass value must be greater than 0'`) and passes with the fix.

`flow check` and `eslint` are clean.