### PR TITLE
Improve native createTheme token normalization

### DIFF
--- a/packages/react-strict-dom/src/native/css/index.js
+++ b/packages/react-strict-dom/src/native/css/index.js
@@ -50,7 +50,7 @@ function _create<S extends { +[string]: { +[string]: unknown } }>(styles: S): {
 }
 export const create: IStyleX['create'] = _create as $FlowFixMe;
 
-const RE_CAPTURE_VAR_NAME = /^var\(--(.*)\)$/;
+const VAR_FUNCTION_PREFIX = 'var(--';
 export const createTheme = (
   baseTokens: Tokens,
   overrides: CustomProperties
@@ -58,7 +58,10 @@ export const createTheme = (
   const result: MutableCustomProperties = { $$theme: 'theme' };
   for (const key in baseTokens) {
     const varName: string = baseTokens[key];
-    const normalizedKey = varName.replace(RE_CAPTURE_VAR_NAME, '$1');
+    const normalizedKey =
+      varName.startsWith(VAR_FUNCTION_PREFIX) && varName.endsWith(')')
+        ? varName.slice(VAR_FUNCTION_PREFIX.length, -1)
+        : varName;
     result[normalizedKey] = overrides[key];
   }
   return result;


### PR DESCRIPTION
# Replace regex in native createTheme token normalization

## Summary

Native `css.createTheme` no longer uses a regex to strip `var(--` and `)` from tokens returned by `css.defineVars`. The code now checks for the generated prefix/suffix and slices the token name directly.

This relies on the existing `createTheme` contract: the first argument is the return value of `defineVars`. Native `defineVars` emits tokens as `var(--${name})`.

## Test Plan

- `npm i`
- `npm run flow`
- `npm test`
- `npm run perf --workspace benchmarks`
- `npm run size --workspace benchmarks`
