### PR TITLE
Fix inherited text color on native

### DIFF
--- a/packages/benchmarks/perf/mocks/AnimatedNode.js
+++ b/packages/benchmarks/perf/mocks/AnimatedNode.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const animatedNodeMarker = Symbol('AnimatedNode');
+
+export function createAnimatedNode(config) {
+  return Object.defineProperty({ ...config }, animatedNodeMarker, {
+    value: true
+  });
+}
+
+export default class AnimatedNode {
+  static [Symbol.hasInstance](value) {
+    return Boolean(value?.[animatedNodeMarker]);
+  }
+}

--- a/packages/benchmarks/perf/mocks/react-native.js
+++ b/packages/benchmarks/perf/mocks/react-native.js
@@ -9,6 +9,8 @@
  * React Native mock for Node.js benchmarks
  */
 
+import { createAnimatedNode } from './AnimatedNode';
+
 export const AccessibilityInfo = {
   addEventListener: () => ({
     remove: () => {}
@@ -25,7 +27,7 @@ export const Animated = {
   Text: 'Animated.Text',
   Value: () => {
     return {
-      interpolate: (value) => value
+      interpolate: (value) => createAnimatedNode(value)
     };
   },
   timing: () => {

--- a/packages/benchmarks/perf/rollup.config.mjs
+++ b/packages/benchmarks/perf/rollup.config.mjs
@@ -43,6 +43,10 @@ const config = [
               __dirname,
               './mocks/ViewNativeComponent.js'
             )
+          },
+          {
+            find: 'react-native/Libraries/Animated/nodes/AnimatedNode',
+            replacement: path.resolve(__dirname, './mocks/AnimatedNode.js')
           }
         ]
       }),

--- a/packages/react-strict-dom/src/native/modules/useStyleProps.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleProps.js
@@ -8,8 +8,11 @@
  */
 
 import type { CustomProperties, Style } from '../../types/styles';
-import type { ReactNativeProps } from '../../types/renderer.native';
-import type { ReactNativeStyle } from '../../types/renderer.native';
+import type {
+  ReactNativeProps,
+  ReactNativeStyle,
+  ReactNativeStyleValue
+} from '../../types/renderer.native';
 
 import * as css from '../css';
 import * as ReactNative from '../react-native';
@@ -74,6 +77,10 @@ function resolveUnitlessLineHeight(style: ReactNativeStyle): ReactNativeStyle {
     style.lineHeight = parseFloat(style.lineHeight) * fontSize;
   }
   return style;
+}
+
+function isAnimatedNode(value: ?ReactNativeStyleValue): boolean {
+  return value instanceof ReactNative.AnimatedNode;
 }
 
 /**
@@ -208,6 +215,9 @@ export function useStyleProps(
       val = inheritedValue;
     }
     if (val != null) {
+      if (isAnimatedNode(val)) {
+        styleProps.animated = true;
+      }
       hasInheritableStyle = true;
       inheritableStyle[key] = val;
       styleProps.style[key] = val;

--- a/packages/react-strict-dom/src/native/react-native/AnimatedNode.js
+++ b/packages/react-strict-dom/src/native/react-native/AnimatedNode.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import AnimatedNode from 'react-native/Libraries/Animated/nodes/AnimatedNode';
+export { AnimatedNode };

--- a/packages/react-strict-dom/src/native/react-native/index.js
+++ b/packages/react-strict-dom/src/native/react-native/index.js
@@ -17,6 +17,7 @@ export {
   Text,
   TextInput
 } from 'react-native';
+export { AnimatedNode } from './AnimatedNode';
 export { LayoutConformance } from './LayoutConformance';
 export { TextAncestorContext } from './TextAncestorContext';
 export { ViewNativeComponent } from './ViewNativeComponent';

--- a/packages/react-strict-dom/tests/__mocks__/react-native/Libraries/Animated/nodes/AnimatedNode.js
+++ b/packages/react-strict-dom/tests/__mocks__/react-native/Libraries/Animated/nodes/AnimatedNode.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const animatedNodeMarker = Symbol('AnimatedNode');
+
+export function createAnimatedNode(config) {
+  return Object.defineProperty({ ...config }, animatedNodeMarker, {
+    value: true
+  });
+}
+
+export default class AnimatedNode {
+  static [Symbol.hasInstance](value) {
+    return Boolean(value?.[animatedNodeMarker]);
+  }
+}

--- a/packages/react-strict-dom/tests/__mocks__/react-native/index.js
+++ b/packages/react-strict-dom/tests/__mocks__/react-native/index.js
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { createAnimatedNode } from './Libraries/Animated/nodes/AnimatedNode';
+
 export const AccessibilityInfo = {
   addEventListener: jest.fn().mockReturnValue({ remove: jest.fn() }),
   isReduceMotionEnabled: jest.fn().mockReturnValue(Promise.resolve(false))
@@ -19,7 +21,9 @@ export const Animated = {
   Text: 'Animated.Text',
   Value: jest.fn(() => {
     return {
-      interpolate: jest.fn().mockImplementation((value) => value)
+      interpolate: jest
+        .fn()
+        .mockImplementation((value) => createAnimatedNode(value))
     };
   }),
   timing: jest.fn(() => {

--- a/packages/react-strict-dom/tests/html/html-test.native.js
+++ b/packages/react-strict-dom/tests/html/html-test.native.js
@@ -593,6 +593,66 @@ describe('<html.*> (native polyfills)', () => {
       expect(getFontSize(secondSecond)).toBe(1.5 * 3 * 16);
     });
 
+    test('inherited color from transitioned parent', () => {
+      const styles = css.create({
+        container: {
+          padding: '32px',
+          transitionProperty: 'backgroundColor, color',
+          transitionDuration: '300ms',
+          backgroundColor: {
+            default: 'blue',
+            ':active': 'darkblue'
+          },
+          color: {
+            default: 'white',
+            ':active': 'green'
+          }
+        },
+        text: {
+          fontSize: '24px',
+          color: 'inherit'
+        }
+      });
+
+      let root;
+      act(() => {
+        root = create(
+          <html.button style={styles.container}>
+            <html.span style={styles.text}>Alert Banner</html.span>
+          </html.button>
+        );
+      });
+
+      let button = root.toJSON();
+      let span = button.children[0];
+      expect(span.type).toBe('Text');
+      expect(span.props.style.color).toBe('white');
+
+      act(() => {
+        button.props.onPointerDown();
+      });
+
+      button = root.toJSON();
+      span = button.children[0];
+      expect(span.type).toBe('Animated.Text');
+      expect(span.props.style.color).toEqual({
+        inputRange: [0, 1],
+        outputRange: ['white', 'green']
+      });
+
+      act(() => {
+        button.props.onPointerUp();
+      });
+
+      button = root.toJSON();
+      span = button.children[0];
+      expect(span.type).toBe('Animated.Text');
+      expect(span.props.style.color).toEqual({
+        inputRange: [0, 1],
+        outputRange: ['green', 'white']
+      });
+    });
+
     test('inherited lineHeight (unitless)', () => {
       const styles = css.create({
         root: {


### PR DESCRIPTION
## Summary

Fixes #426.

Fixes inherited animated text color on native when a parent has a color transition and a child uses `color: inherit`.

The inherited style path already copied the resolved parent color into the child style, but it did not mark the child as needing an Animated renderer when the inherited value was animated. That meant a child text node could receive an animated color value while still rendering as regular `Text` instead of `Animated.Text`.

This updates inherited style resolution to detect inherited `AnimatedNode` values and set the internal `animated` flag so the native renderer selects the Animated component.

## Why this happens

Transitions create animated style values with `Animated.Value().interpolate(...)`.

For direct styles, the transition path already causes the component to render with an Animated renderer. The bug appears when the animated value is inherited:

1. The parent computes an animated `color`.
2. The child has `color: inherit`.
3. `useStyleProps` resolves the inherited value and assigns it to the child style.
4. Before this change, that inherited animated value did not mark the child style props as animated.
5. The child rendered as plain `Text`, even though its `color` style was animated.

## Why this fix

The native renderer needs to know whether the resolved style contains a real React Native animated node.  So we add and export AnimatedNode from react-native.

The `AnimatedNode` deep import is wrapped through `src/native/react-native`, matching the existing convention for React Native internals.

## Test plan

- `npm run jest --workspace react-strict-dom -- --selectProjects "react-strict-dom (Native)" tests/html/html-test.native.js --runInBand --watchman=false`
- `npx flow focus-check packages/react-strict-dom/src/native/react-native/AnimatedNode.js packages/react-strict-dom/src/native/react-native/index.js packages/react-strict-dom/src/native/modules/useStyleProps.js packages/react-strict-dom/tests/html/html-test.native.js`
- `npm run lint:report -- --quiet packages/benchmarks/perf/rollup.config.mjs packages/benchmarks/perf/mocks/react-native.js packages/benchmarks/perf/mocks/AnimatedNode.js`
- `npm run build --workspace react-strict-dom`
- `npm run perf --workspace benchmarks -- -o /tmp/rsd-perf-pr490.json`
- `git diff --check origin/main...HEAD`