### PR TITLE
Allow outline* styles on stable React Native

### DIFF
--- a/packages/react-strict-dom/src/native/css/isAllowedStyleKey.js
+++ b/packages/react-strict-dom/src/native/css/isAllowedStyleKey.js
@@ -7,8 +7,6 @@
  * @flow strict
  */
 
-import { version } from '../modules/version';
-
 const allowedStyleKeySet = new Set<string>([
   'alignContent',
   'alignItems',
@@ -122,6 +120,10 @@ const allowedStyleKeySet = new Set<string>([
   'mixBlendMode',
   'objectFit',
   'opacity',
+  'outlineColor',
+  'outlineOffset',
+  'outlineStyle',
+  'outlineWidth',
   'overflow',
   'padding',
   'paddingBlock',
@@ -166,13 +168,6 @@ const allowedStyleKeySet = new Set<string>([
   // Pseudo-element keys
   '::placeholder'
 ]);
-
-if (version.experimental) {
-  allowedStyleKeySet.add('outlineColor');
-  allowedStyleKeySet.add('outlineOffset');
-  allowedStyleKeySet.add('outlineStyle');
-  allowedStyleKeySet.add('outlineWidth');
-}
 
 export function isAllowedStyleKey(key: string): boolean {
   return (

--- a/packages/react-strict-dom/src/native/css/isLengthStyleKey.js
+++ b/packages/react-strict-dom/src/native/css/isLengthStyleKey.js
@@ -7,8 +7,6 @@
  * @flow strict
  */
 
-import { version } from '../modules/version';
-
 export const lengthStyleKeySet: Set<string> = new Set([
   'blockSize',
   'borderBottomLeftRadius',
@@ -65,6 +63,8 @@ export const lengthStyleKeySet: Set<string> = new Set([
   'minHeight',
   'minInlineSize',
   'minWidth',
+  'outlineOffset',
+  'outlineWidth',
   'padding',
   'paddingBlock',
   'paddingBlockEnd',
@@ -81,8 +81,3 @@ export const lengthStyleKeySet: Set<string> = new Set([
   'top',
   'width'
 ]);
-
-if (version.experimental) {
-  lengthStyleKeySet.add('outlineOffset');
-  lengthStyleKeySet.add('outlineWidth');
-}


### PR DESCRIPTION
Closes #467

## Root cause

The `outlineColor`/`outlineOffset`/`outlineStyle`/`outlineWidth` keys were gated behind `version.experimental` in `isAllowedStyleKey.js` (and `outlineOffset`/`outlineWidth` in `isLengthStyleKey.js`). Any style key not in the allow-list is silently dropped, so these props never reached React Native on a published release.

`version.experimental` is **not** a user-facing flag. It is derived from the RN version at runtime

https://github.com/facebook/react-strict-dom/blob/c4e69e0fa486ba8df835a2e3f396206070c17153/packages/react-strict-dom/src/native/modules/version.js#L13-L20

It is `true` **only** on HEAD/nightly builds and `false` on every published RN release (e.g. 0.84.0). So the documented `outline*` support was unreachable for normal apps, with no way to opt in.

## Why it was a stale gate

The `outline*` keys were originally added alongside `boxShadow`, `filter`, and `mixBlendMode` in the same experimental block. Those three were later graduated into the always-allowed set; the four `outline*` keys were left behind by oversight. RN has supported `outline*` since 0.77, and RSD's minimum is `react-native >=0.82.0`, so the props are safe to allow unconditionally for every supported version.

## Why tests didn't catch it

The test suite mocks the RN version as `major: 1000` (`tests/__mocks__/react-native/index.js`), which forces `experimental === true`. The existing `outline*` test therefore passed in CI while the same code dropped the props for users on stable RN.

## The fix

Graduated the keys out of the experimental gate (same treatment already given to `boxShadow`/`filter`/`mixBlendMode`):

- `isAllowedStyleKey.js` — moved `outlineColor`, `outlineOffset`, `outlineStyle`, `outlineWidth` into the main allow-list; removed the now-empty `if (version.experimental)` block and its unused `version` import.
- `isLengthStyleKey.js` — moved `outlineOffset`, `outlineWidth` into the main length-key set; removed the experimental block and unused import.

## Result

`outline*` now resolves on all supported RN versions, the documentation becomes accurate with no changes, the existing test now exercises the real (non-experimental) path, Flow passes, and the full CSS suite (141 tests) is green.