### PR TITLE
Add disabled prop to StrictReactDOMSelectProps

### DIFF
--- a/packages/react-strict-dom/src/types/StrictReactDOMSelectProps.js
+++ b/packages/react-strict-dom/src/types/StrictReactDOMSelectProps.js
@@ -13,6 +13,7 @@ export type StrictReactDOMSelectProps = Readonly<{
   ...StrictReactDOMProps,
   autoComplete?: AutoComplete,
   defaultValue?: ?(Stringish | Array<Stringish>),
+  disabled?: ?boolean,
   multiple?: ?boolean,
   name?: ?string,
   required?: ?boolean,


### PR DESCRIPTION
The `disabled` prop was missing from `StrictReactDOMSelectProps` while present on input, textarea, button, option, and optgroup. `<select disabled>` is valid HTML and already worked at runtime (it's in the prop allowlist and handled by the native renderer), so typed consumers hit a false type error. This adds the type declaration; the generated `.d.ts` now exposes it to TS consumers too.

Solves https://github.com/facebook/react-strict-dom/issues/465