### PR TITLE
Ignore undefined style values on native

### DIFF
--- a/packages/react-strict-dom/src/native/css/processStyle.js
+++ b/packages/react-strict-dom/src/native/css/processStyle.js
@@ -73,6 +73,14 @@ export function processStyle(
   for (const propName in style) {
     const styleValue = style[propName];
 
+    // Drop "undefined" values so they don't reach the underlying style
+    // resolver, which only accepts strings, numbers, objects or null. This
+    // mirrors web behavior, where undefined values are ignored, and lets
+    // inline style functions return undefined to opt out of a property.
+    if (styleValue === undefined) {
+      continue;
+    }
+
     if (skipValidation !== true && !isAllowedStyleKey(propName)) {
       if (__DEV__) {
         warnMsg(`unsupported style property "${propName}"`);

--- a/packages/react-strict-dom/tests/css/css-create-test.native.js
+++ b/packages/react-strict-dom/tests/css/css-create-test.native.js
@@ -2102,6 +2102,22 @@ describe('css.create()', () => {
       });
       expect(root.toJSON().props.style).toMatchSnapshot();
     });
+
+    test('undefined values are ignored', () => {
+      const styles = css.create({
+        root: (gap) => ({
+          rowGap: gap
+        })
+      });
+      let root;
+      act(() => {
+        root = create(<html.div style={styles.root(undefined)} />);
+      });
+      const { style } = root.toJSON().props;
+      // The property is dropped rather than passed through as undefined,
+      // which would otherwise be rejected by the style resolver.
+      expect(Object.prototype.hasOwnProperty.call(style, 'rowGap')).toBe(false);
+    });
   });
 
   /**


### PR DESCRIPTION
Fixes #452

On native, returning `undefined` for a property from an inline style function (or any style object with an undefined value) leaks that key through `processStyle` and into the style resolver, which throws `styleq: <cssAtom> typeof undefined is not "string" or "null"`. This is a regression; these values used to be dropped, and on web undefined values are simply ignored.

The loop in `processStyle` branches on `object`/`string`/`number`, so an undefined value falls through to the catch-all assignment and ends up in the result as `{ rowGap: undefined }`. This adds an early `continue` for undefined values so the property is omitted, matching web behavior and letting inline style functions return undefined to opt out of a property.

`null` is left untouched since the resolver accepts it.

Testing: added a regression test under `css.create() > values: general` that asserts the property is absent when the inline function returns undefined. Confirmed it fails on `main` and passes with the fix. Full native + web jest suites pass (888 tests, 711 snapshots unchanged), Flow and ESLint clean.


---

Reopening this. I closed it by accident during a bulk cleanup of my stale forks and cannot reopen the original because the fork was deleted, so this is the same branch restored. Sorry for the noise @MoOx.
