### PR TITLE
Fix text-shadow parsing: negative/decimal lengths and color ordering

### DIFF
--- a/packages/react-strict-dom/src/native/css/__tests__/parseTextShadow-test.js
+++ b/packages/react-strict-dom/src/native/css/__tests__/parseTextShadow-test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { parseTextShadow } from '../parseTextShadow';
+
+describe('parseTextShadow', () => {
+  test('parses offsets, blur radius and color', () => {
+    expect(parseTextShadow('1px 2px 3px red')).toEqual({
+      textShadowColor: 'red',
+      textShadowOffset: { width: 1, height: 2 },
+      textShadowRadius: 3
+    });
+  });
+
+  test('parses a trailing color with a negative offset', () => {
+    expect(parseTextShadow('1px -2px 3px red')).toEqual({
+      textShadowColor: 'red',
+      textShadowOffset: { width: 1, height: -2 },
+      textShadowRadius: 3
+    });
+  });
+
+  test('parses a negative offset when no color is provided', () => {
+    // The vertical offset is negative and is the last token. It must be
+    // treated as a length, not as a color.
+    expect(parseTextShadow('1px -2px')).toEqual({
+      textShadowColor: null,
+      textShadowOffset: { width: 1, height: -2 },
+      textShadowRadius: undefined
+    });
+  });
+
+  test('parses a decimal blur radius when no color is provided', () => {
+    // The blur radius is a decimal length and is the last token. It must be
+    // treated as a length, not as a color.
+    expect(parseTextShadow('1px 1px 2.5px')).toEqual({
+      textShadowColor: null,
+      textShadowOffset: { width: 1, height: 1 },
+      textShadowRadius: 2.5
+    });
+  });
+});

--- a/packages/react-strict-dom/src/native/css/__tests__/parseTextShadow-test.js
+++ b/packages/react-strict-dom/src/native/css/__tests__/parseTextShadow-test.js
@@ -34,6 +34,15 @@ describe('parseTextShadow', () => {
     });
   });
 
+  test('parses a color that precedes the offset values', () => {
+    // CSS allows the color to be specified before or after the offsets.
+    expect(parseTextShadow('red 1px 2px 3px')).toEqual({
+      textShadowColor: 'red',
+      textShadowOffset: { width: 1, height: 2 },
+      textShadowRadius: 3
+    });
+  });
+
   test('parses a decimal blur radius when no color is provided', () => {
     // The blur radius is a decimal length and is the last token. It must be
     // treated as a length, not as a color.

--- a/packages/react-strict-dom/src/native/css/parseTextShadow.js
+++ b/packages/react-strict-dom/src/native/css/parseTextShadow.js
@@ -26,13 +26,13 @@ function toMaybeNum(v: string): number | string {
 function parseValue(str: string) {
   const parts = str.split(PARTS_REG);
   const inset = parts.includes('inset');
-  const last = parts.slice(-1)[0];
-  const color = !isLength(last) ? last : null;
+  const tokens = parts.filter((n) => n !== 'inset');
+  // The color is the single token that is not a length value. CSS allows it to
+  // be specified either before or after the offset values, so search all tokens
+  // rather than assuming it is last.
+  const color = tokens.find((n) => !isLength(n)) ?? null;
 
-  const nums = parts
-    .filter((n) => n !== 'inset')
-    .filter((n) => n !== color)
-    .map(toMaybeNum);
+  const nums = tokens.filter((n) => n !== color).map(toMaybeNum);
 
   const [offsetX, offsetY, blurRadius, spreadRadius] = nums;
 

--- a/packages/react-strict-dom/src/native/css/parseTextShadow.js
+++ b/packages/react-strict-dom/src/native/css/parseTextShadow.js
@@ -11,7 +11,7 @@ import { warnMsg } from '../../shared/logUtils';
 
 const VALUES_REG = /,(?![^(]*\))/;
 const PARTS_REG = /\s(?![^(]*\))/;
-const LENGTH_REG = /^[0-9]+[a-zA-Z%]+?$/;
+const LENGTH_REG = /^-?(?:[0-9]*\.)?[0-9]+[a-zA-Z%]+$/;
 
 function isLength(v: string): boolean {
   return v === '0' || LENGTH_REG.test(v);


### PR DESCRIPTION
## Summary

Fixes a few related correctness bugs in `parseTextShadow` (native), all stemming from how the parser distinguishes a *length* token from the *color* token.

### 1. Negative and decimal lengths
`LENGTH_REG` only matched non-negative integer lengths (e.g. `3px`). When the last token was a **negative offset** or a **decimal blur radius** with no explicit color, it was misclassified as the color — dropping the offset/blur and producing a bogus color value:
- `text-shadow: 1px -2px` → vertical offset dropped, `textShadowColor` set to `"-2px"`
- `text-shadow: 1px 1px 2.5px` → blur dropped, `textShadowColor` set to `"2.5px"`

Fixed by allowing an optional leading minus sign and decimals in `LENGTH_REG`, matching the pattern already used by `CSSLengthUnitValue`.

### 2. Color specified before the offsets
CSS allows the color to appear either before or after the offset values, but `parseValue` only inspected the last token. A leading color was misparsed:
- `text-shadow: red 1px 2px 3px` → color dropped, `offsetX` became `"red"`

Fixed by detecting the color as the single non-length token regardless of position.

## Test plan

Added unit tests covering negative offsets, decimal blur radii, and color-before/after ordering (failing before, passing after). Full jest suite passes (901 tests), `flow check` reports no errors, and `eslint` is clean.