### PR TITLE
Fix native-driver detection for skew transforms in transitions

### DIFF
--- a/packages/react-strict-dom/src/native/modules/useStyleTransition.js
+++ b/packages/react-strict-dom/src/native/modules/useStyleTransition.js
@@ -54,8 +54,15 @@ function canUseNativeDriver(
     if (
       property === 'transform' &&
       Array.isArray(value) &&
-      // $FlowFixMe[incompatible-type]
-      !value.includes('skew')
+      // The transform value is an array of transform objects (e.g.
+      // `[{ skewX: '10deg' }]`), so detect skew by inspecting each object's
+      // keys. Skew transforms are not supported by the native driver.
+      !value.some(
+        // $FlowFixMe[incompatible-use]
+        (transform) =>
+          transform != null &&
+          (transform.skewX != null || transform.skewY != null)
+      )
     ) {
       continue;
     }

--- a/packages/react-strict-dom/tests/css/css-create-test.native.js
+++ b/packages/react-strict-dom/tests/css/css-create-test.native.js
@@ -1746,6 +1746,32 @@ describe('css.create()', () => {
       );
     });
 
+    test('skew transform transition does not use the native driver', () => {
+      const skewStyles = css.create({
+        skew: (transform) => ({
+          transform: transform ?? 'skewX(0deg)',
+          transitionDelay: 0,
+          transitionDuration: 1000,
+          transitionProperty: 'transform',
+          transitionTimingFunction: 'ease-out'
+        })
+      });
+      let root;
+      act(() => {
+        root = create(<html.div style={skewStyles.skew()} />);
+      });
+      act(() => {
+        root.update(<html.div style={skewStyles.skew('skewX(45deg)')} />);
+      });
+      // Skew transforms are not supported by the native animation driver.
+      expect(Animated.timing).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          useNativeDriver: false
+        })
+      );
+    });
+
     test('width transition', () => {
       let root;
       // width transition


### PR DESCRIPTION
## Summary

`canUseNativeDriver` in `useStyleTransition` decides whether a CSS transition can run on React Native's native animation driver. For the `transform` property it tried to exclude skew transforms with:

```js
property === 'transform' && Array.isArray(value) && !value.includes('skew')
```

But `value` is an array of transform **objects** (e.g. `[{ skewX: '10deg' }]`), not strings, so `value.includes('skew')` is always `false`. The skew guard was therefore a dead no-op, and a transition involving `skewX`/`skewY` was incorrectly marked as native-driver compatible. The native driver does not support skew, so these transitions must fall back to the JS driver.

## Fix

Detect skew by inspecting each transform object's keys (`skewX`/`skewY`) instead of doing a string `includes` on the array.

## Test plan

Added a regression test under `css.create() > properties: "transition"` that animates a `skewX` transform and asserts `Animated.timing` is called with `useNativeDriver: false` (fails before the fix — it was `true` — and passes after). Existing transform/opacity transition tests (which should keep `useNativeDriver: true`) still pass. Full jest suite passes (902 tests), `flow check` reports no errors, and `eslint` is clean.