### PR TITLE
Avoid ref overhead when not needed

### DIFF
--- a/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMComponent.js
@@ -41,7 +41,7 @@ function applyViewProps(
   tagName: string,
   isPressable: boolean,
   disabled: boolean,
-  elementRef: CallbackRef<HostInstance>,
+  elementRef: ?CallbackRef<HostInstance>,
   displayInsideValue: 'flow' | 'flex'
 ): 'flow' | 'flex' {
   // Tag-specific props
@@ -63,7 +63,9 @@ function applyViewProps(
     nativeProps.focusable = false;
   }
 
-  nativeProps.ref = elementRef;
+  if (elementRef != null) {
+    nativeProps.ref = elementRef;
+  }
 
   // Workaround: React Native doesn't support raw text children of View
   // Sometimes we can auto-fix this

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
@@ -26,7 +26,7 @@ import * as css from '../css';
 function applyImageProps(
   nativeProps: ReactNativeProps,
   props: StrictReactDOMImageProps,
-  elementRef: CallbackRef<HostInstance>
+  elementRef: ?CallbackRef<HostInstance>
 ): void {
   const {
     alt,
@@ -85,7 +85,9 @@ function applyImageProps(
 
   // Component-specific props
 
-  nativeProps.ref = elementRef;
+  if (elementRef != null) {
+    nativeProps.ref = elementRef;
+  }
 }
 
 export function createStrictDOMImageComponent<

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMImageComponent.js
@@ -109,12 +109,12 @@ export function createStrictDOMImageComponent<
      * Resolve global HTML and style props
      */
 
-    const defaultProps = {
-      style: [
-        _defaultProps?.style,
-        height != null && width != null && styles.aspectRatio(width, height)
-      ]
-    };
+    const defaultProps =
+      height != null && width != null
+        ? {
+            style: [_defaultProps?.style, styles.aspectRatio(width, height)]
+          }
+        : _defaultProps;
 
     const { nativeProps } = useNativeProps(defaultProps, props, {
       provideInheritableStyle: false,

--- a/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
+++ b/packages/react-strict-dom/src/native/modules/createStrictDOMTextComponent.js
@@ -38,7 +38,7 @@ function applyTextProps(
   nativeProps: ReactNativeProps,
   props: StrictProps,
   tagName: string,
-  elementRef: CallbackRef<HostInstance>
+  elementRef: ?CallbackRef<HostInstance>
 ): void {
   const { href, label } = props;
 
@@ -70,7 +70,9 @@ function applyTextProps(
 
   // Component-specific props
 
-  nativeProps.ref = elementRef;
+  if (elementRef != null) {
+    nativeProps.ref = elementRef;
+  }
 
   // Workaround: Android doesn't support ellipsis truncation if Text is selectable
   // See #136

--- a/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
+++ b/packages/react-strict-dom/src/native/modules/useStrictDOMElement.js
@@ -12,7 +12,6 @@ import type { HostInstance } from '../../types/renderer.native';
 
 import * as React from 'react';
 
-import { useElementCallback } from '../../shared/useElementCallback';
 import { useViewportScale } from './ContextViewportScale';
 
 type Options = {
@@ -168,32 +167,41 @@ function getOrCreateStrictRef(
 export function useStrictDOMElement<T>(
   ref: React.RefSetter<T>,
   { tagName }: Options
-): CallbackRef<HostInstance> {
+): ?CallbackRef<HostInstance> {
   const { scale: viewportScale } = useViewportScale();
 
-  return useElementCallback<HostInstance>(
-    React.useCallback(
-      (node: HostInstance) => {
-        if (ref == null) return undefined;
-        const strictRef = getOrCreateStrictRef(node, tagName, viewportScale);
-        if (typeof ref === 'function') {
-          // Public ref type is the DOM element `T` (web/native parity); at
-          // runtime we hand over the RN-backed strict wrapper.
-          // $FlowFixMe[incompatible-type] - Flow does not understand ref cleanup.
-          const cleanup: void | (() => void) = ref(strictRef as $FlowFixMe);
-          return typeof cleanup === 'function'
-            ? cleanup
+  return React.useMemo(() => {
+    if (ref == null) {
+      return null;
+    }
+    let cleanup: void | (() => void);
+    return (node: HostInstance | null) => {
+      if (cleanup != null) {
+        cleanup();
+        cleanup = undefined;
+      }
+      if (node == null) {
+        return;
+      }
+      const strictRef = getOrCreateStrictRef(node, tagName, viewportScale);
+      if (typeof ref === 'function') {
+        // Public ref type is the DOM element `T` (web/native parity); at
+        // runtime we hand over the RN-backed strict wrapper.
+        // $FlowFixMe[incompatible-type] - Flow does not understand ref cleanup.
+        const refCleanup: void | (() => void) = ref(strictRef as $FlowFixMe);
+        cleanup =
+          typeof refCleanup === 'function'
+            ? refCleanup
             : () => {
                 ref(null);
               };
-        }
-        // $FlowFixMe[incompatible-type] - see the ref-callback note above.
-        ref.current = strictRef;
-        return () => {
-          ref.current = null;
-        };
-      },
-      [ref, tagName, viewportScale]
-    )
-  );
+        return;
+      }
+      // $FlowFixMe[incompatible-type] - see the ref-callback note above.
+      ref.current = strictRef;
+      cleanup = () => {
+        ref.current = null;
+      };
+    };
+  }, [ref, tagName, viewportScale]);
 }

--- a/packages/react-strict-dom/tests/compat/__snapshots__/compat-test.native.js.snap
+++ b/packages/react-strict-dom/tests/compat/__snapshots__/compat-test.native.js.snap
@@ -3,7 +3,6 @@
 exports[`<compat.native> "as" equals "div": as=div 1`] = `
 <View
   accessibilityLabel="label"
-  ref={[Function]}
   style={
     {
       "paddingHorizontal": 32,
@@ -15,7 +14,6 @@ exports[`<compat.native> "as" equals "div": as=div 1`] = `
 exports[`<compat.native> "as" equals "img": as=img 1`] = `
 <Image
   accessibilityLabel="label"
-  ref={[Function]}
   srcSet="1x.img, 2x.img 2x"
   style={
     {
@@ -40,7 +38,6 @@ exports[`<compat.native> "as" equals "span": as=span 1`] = `
 <Text
   accessibilityLabel="label"
   numberOfLines={3}
-  ref={[Function]}
   style={
     {
       "color": "blue",
@@ -65,7 +62,6 @@ exports[`<compat.native> "as" equals "textarea": as=textarea 1`] = `
 exports[`<compat.native> default: default 1`] = `
 <Pressable
   accessibilityLabel="label"
-  ref={[Function]}
   style={
     {
       "paddingHorizontal": 32,
@@ -77,11 +73,9 @@ exports[`<compat.native> default: default 1`] = `
 exports[`<compat.native> nested: nested 1`] = `
 <View
   accessibilityLabel="label"
-  ref={[Function]}
   style={{}}
 >
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -99,7 +93,6 @@ exports[`<compat.native> nested: nested 1`] = `
 exports[`<compat.native> styled: styled 1`] = `
 <Pressable
   accessibilityLabel="label"
-  ref={[Function]}
   style={
     [
       {

--- a/packages/react-strict-dom/tests/contexts/__snapshots__/contexts-ThemeProvider-test.native.js.snap
+++ b/packages/react-strict-dom/tests/contexts/__snapshots__/contexts-ThemeProvider-test.native.js.snap
@@ -2,7 +2,6 @@
 
 exports[`<contexts.*> <ThemeProvider> css variable declaration inside a media query 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -17,7 +16,6 @@ exports[`<contexts.*> <ThemeProvider> css variable declaration inside a media qu
 exports[`<contexts.*> <ThemeProvider> defines global custom properties 1`] = `
 [
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -29,7 +27,6 @@ exports[`<contexts.*> <ThemeProvider> defines global custom properties 1`] = `
     Expect color:green
   </Text>,
   <Text
-    ref={[Function]}
     style={
       {
         "backgroundColor": "red",
@@ -48,7 +45,6 @@ exports[`<contexts.*> <ThemeProvider> defines global custom properties 1`] = `
 exports[`<contexts.*> <ThemeProvider> kebab case string var to camel case 1`] = `
 [
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -59,7 +55,6 @@ exports[`<contexts.*> <ThemeProvider> kebab case string var to camel case 1`] = 
     }
   />,
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -74,7 +69,6 @@ exports[`<contexts.*> <ThemeProvider> kebab case string var to camel case 1`] = 
 
 exports[`<contexts.*> <ThemeProvider> number var lookup works 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "borderWidth": 10,
@@ -88,7 +82,6 @@ exports[`<contexts.*> <ThemeProvider> number var lookup works 1`] = `
 exports[`<contexts.*> <ThemeProvider> number var value lookup with reference to another var 1`] = `
 [
   <ViewNativeComponent
-    ref={[Function]}
     style={
       {
         "borderWidth": 10,
@@ -98,7 +91,6 @@ exports[`<contexts.*> <ThemeProvider> number var value lookup with reference to 
     }
   />,
   <ViewNativeComponent
-    ref={[Function]}
     style={
       {
         "borderWidth": 10,
@@ -113,7 +105,6 @@ exports[`<contexts.*> <ThemeProvider> number var value lookup with reference to 
 exports[`<contexts.*> <ThemeProvider> rgb(a) function with args applied through a single var 1`] = `
 [
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -124,7 +115,6 @@ exports[`<contexts.*> <ThemeProvider> rgb(a) function with args applied through 
     }
   />,
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -139,7 +129,6 @@ exports[`<contexts.*> <ThemeProvider> rgb(a) function with args applied through 
 
 exports[`<contexts.*> <ThemeProvider> rgba function with args applied through multiple (& nested) vars 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -153,7 +142,6 @@ exports[`<contexts.*> <ThemeProvider> rgba function with args applied through mu
 
 exports[`<contexts.*> <ThemeProvider> string var 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -168,7 +156,6 @@ exports[`<contexts.*> <ThemeProvider> string var 1`] = `
 
 exports[`<contexts.*> <ThemeProvider> string var and falls back to a default value containing spaces and embedded var 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -182,7 +169,6 @@ exports[`<contexts.*> <ThemeProvider> string var and falls back to a default val
 
 exports[`<contexts.*> <ThemeProvider> string var and falls back to default value containing a var 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -196,7 +182,6 @@ exports[`<contexts.*> <ThemeProvider> string var and falls back to default value
 
 exports[`<contexts.*> <ThemeProvider> string var value lookup with em prop conversion 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "borderWidth": 160,
@@ -209,7 +194,6 @@ exports[`<contexts.*> <ThemeProvider> string var value lookup with em prop conve
 
 exports[`<contexts.*> <ThemeProvider> string var value lookup with pixel prop conversion 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "borderWidth": 10,
@@ -223,7 +207,6 @@ exports[`<contexts.*> <ThemeProvider> string var value lookup with pixel prop co
 exports[`<contexts.*> <ThemeProvider> string var with a default value 1`] = `
 [
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -234,7 +217,6 @@ exports[`<contexts.*> <ThemeProvider> string var with a default value 1`] = `
     }
   />,
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -250,7 +232,6 @@ exports[`<contexts.*> <ThemeProvider> string var with a default value 1`] = `
 exports[`<contexts.*> <ThemeProvider> string var with a default value containing spaces 1`] = `
 [
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -261,7 +242,6 @@ exports[`<contexts.*> <ThemeProvider> string var with a default value containing
     }
   />,
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -276,7 +256,6 @@ exports[`<contexts.*> <ThemeProvider> string var with a default value containing
 
 exports[`<contexts.*> <ThemeProvider> textShadow with nested/multiple vars 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -295,7 +274,6 @@ exports[`<contexts.*> <ThemeProvider> textShadow with nested/multiple vars 1`] =
 
 exports[`<contexts.*> <ThemeProvider> transform with nested/multiple vars 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",

--- a/packages/react-strict-dom/tests/contexts/__snapshots__/contexts-ViewportProvider-test.native.js.snap
+++ b/packages/react-strict-dom/tests/contexts/__snapshots__/contexts-ViewportProvider-test.native.js.snap
@@ -2,7 +2,6 @@
 
 exports[`<contexts.*> <ViewportProvider> all CSS lengths are scaled according to viewport width: scaled lengths 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "borderWidth": 0.75,
@@ -24,7 +23,6 @@ exports[`<contexts.*> <ViewportProvider> all CSS lengths are scaled according to
   }
 >
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -38,7 +36,6 @@ exports[`<contexts.*> <ViewportProvider> all CSS lengths are scaled according to
     Scaled content
   </Text>
   <Text
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",

--- a/packages/react-strict-dom/tests/css/__snapshots__/css-create-test.native.js.snap
+++ b/packages/react-strict-dom/tests/css/__snapshots__/css-create-test.native.js.snap
@@ -285,7 +285,6 @@ exports[`css.create() properties boxSizing: content-box 1`] = `
 exports[`css.create() properties caretColor: red caret color 1`] = `
 {
   "cursorColor": "red",
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "position": "static",
@@ -296,7 +295,6 @@ exports[`css.create() properties caretColor: red caret color 1`] = `
 exports[`css.create() properties caretColor: transparent caret color 1`] = `
 {
   "caretHidden": true,
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "position": "static",
@@ -306,7 +304,6 @@ exports[`css.create() properties caretColor: transparent caret color 1`] = `
 
 exports[`css.create() properties caretColor: unsupported caret color 1`] = `
 {
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "position": "static",
@@ -545,7 +542,6 @@ exports[`css.create() properties inset: insetInlineStart 1`] = `
 
 exports[`css.create() properties isolation 1`] = `
 {
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "isolation": "isolate",
@@ -558,7 +554,6 @@ exports[`css.create() properties isolation 1`] = `
 exports[`css.create() properties lineClamp 1`] = `
 <Text
   numberOfLines={3}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -703,7 +698,6 @@ exports[`css.create() properties mixBlendMode 1`] = `
 
 exports[`css.create() properties objectFit: contain 1`] = `
 {
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "objectFit": "contain",
@@ -714,7 +708,6 @@ exports[`css.create() properties objectFit: contain 1`] = `
 
 exports[`css.create() properties objectFit: cover 1`] = `
 {
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "objectFit": "cover",
@@ -725,7 +718,6 @@ exports[`css.create() properties objectFit: cover 1`] = `
 
 exports[`css.create() properties objectFit: fill 1`] = `
 {
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "objectFit": "fill",
@@ -736,7 +728,6 @@ exports[`css.create() properties objectFit: fill 1`] = `
 
 exports[`css.create() properties objectFit: none 1`] = `
 {
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "objectFit": "scale-down",
@@ -747,7 +738,6 @@ exports[`css.create() properties objectFit: none 1`] = `
 
 exports[`css.create() properties objectFit: scaleDown 1`] = `
 {
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "objectFit": "scale-down",
@@ -1240,7 +1230,6 @@ exports[`css.create() properties visibility: collapse 1`] = `
   "focusable": false,
   "importantForAccessibility": "no-hide-descendants",
   "pointerEvents": "none",
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "opacity": 0,
@@ -1255,7 +1244,6 @@ exports[`css.create() properties visibility: hidden 1`] = `
   "focusable": false,
   "importantForAccessibility": "no-hide-descendants",
   "pointerEvents": "none",
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "opacity": 0,
@@ -1266,7 +1254,6 @@ exports[`css.create() properties visibility: hidden 1`] = `
 
 exports[`css.create() properties visibility: visible 1`] = `
 {
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "position": "static",
@@ -1276,7 +1263,6 @@ exports[`css.create() properties visibility: visible 1`] = `
 
 exports[`css.create() properties willChange 1`] = `
 {
-  "ref": [Function],
   "renderToHardwareTextureAndroid": true,
   "style": {
     "boxSizing": "content-box",
@@ -1288,7 +1274,6 @@ exports[`css.create() properties willChange 1`] = `
 exports[`css.create() properties: "transition" backgroundColor transition: end 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "backgroundColor": {
@@ -1311,7 +1296,6 @@ exports[`css.create() properties: "transition" backgroundColor transition: end 1
 exports[`css.create() properties: "transition" backgroundColor transition: start 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "backgroundColor": "rgba(0,0,0,0.1)",
@@ -1325,7 +1309,6 @@ exports[`css.create() properties: "transition" backgroundColor transition: start
 exports[`css.create() properties: "transition" cubic-bezier() timing function: end 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1348,7 +1331,6 @@ exports[`css.create() properties: "transition" cubic-bezier() timing function: e
 exports[`css.create() properties: "transition" cubic-bezier() timing function: start 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1361,7 +1343,6 @@ exports[`css.create() properties: "transition" cubic-bezier() timing function: s
 
 exports[`css.create() properties: "transition" default: default 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "backgroundColor": "red",
@@ -1375,7 +1356,6 @@ exports[`css.create() properties: "transition" default: default 1`] = `
 exports[`css.create() properties: "transition" opacity transition: end 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1398,7 +1378,6 @@ exports[`css.create() properties: "transition" opacity transition: end 1`] = `
 exports[`css.create() properties: "transition" opacity transition: start 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1414,7 +1393,6 @@ exports[`css.create() properties: "transition" other element types 1`] = `"Anima
 exports[`css.create() properties: "transition" other transforms: rotate 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1477,7 +1455,6 @@ exports[`css.create() properties: "transition" other transforms: rotate 1`] = `
 exports[`css.create() properties: "transition" other transforms: scale 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1540,7 +1517,6 @@ exports[`css.create() properties: "transition" other transforms: scale 1`] = `
 exports[`css.create() properties: "transition" other transforms: skew 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1579,7 +1555,6 @@ exports[`css.create() properties: "transition" other transforms: skew 1`] = `
 exports[`css.create() properties: "transition" other transforms: translate 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1618,7 +1593,6 @@ exports[`css.create() properties: "transition" other transforms: translate 1`] =
 exports[`css.create() properties: "transition" spring() timing function: end 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1641,7 +1615,6 @@ exports[`css.create() properties: "transition" spring() timing function: end 1`]
 exports[`css.create() properties: "transition" spring() timing function: start 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1655,7 +1628,6 @@ exports[`css.create() properties: "transition" spring() timing function: start 1
 exports[`css.create() properties: "transition" transform transition: end 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1694,7 +1666,6 @@ exports[`css.create() properties: "transition" transform transition: end 1`] = `
 exports[`css.create() properties: "transition" transform transition: start 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1715,7 +1686,6 @@ exports[`css.create() properties: "transition" transform transition: start 1`] =
 exports[`css.create() properties: "transition" transition all properties (opacity and transform): end 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1776,7 +1746,6 @@ exports[`css.create() properties: "transition" transition all properties (opacit
 exports[`css.create() properties: "transition" transition all properties (opacity and transform): start 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1801,7 +1770,6 @@ exports[`css.create() properties: "transition" transition all properties (opacit
 exports[`css.create() properties: "transition" transition multiple properties: end 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "backgroundColor": {
@@ -1839,7 +1807,6 @@ exports[`css.create() properties: "transition" transition multiple properties: e
 exports[`css.create() properties: "transition" transition multiple properties: start 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "backgroundColor": "red",
@@ -1859,7 +1826,6 @@ exports[`css.create() properties: "transition" transition multiple properties: s
 exports[`css.create() properties: "transition" transition with missing properties 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1872,7 +1838,6 @@ exports[`css.create() properties: "transition" transition with missing propertie
 exports[`css.create() properties: "transition" transition with missing properties 2`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1916,7 +1881,6 @@ exports[`css.create() properties: "transition" transitionProperty 1`] = `
 exports[`css.create() properties: "transition" update triggers transition: green to blue 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "backgroundColor": {
@@ -1939,7 +1903,6 @@ exports[`css.create() properties: "transition" update triggers transition: green
 exports[`css.create() properties: "transition" update triggers transition: red to green 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "backgroundColor": {
@@ -1962,7 +1925,6 @@ exports[`css.create() properties: "transition" update triggers transition: red t
 exports[`css.create() properties: "transition" width transition: end 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1985,7 +1947,6 @@ exports[`css.create() properties: "transition" width transition: end 1`] = `
 exports[`css.create() properties: "transition" width transition: start 1`] = `
 <Animated.View
   animated={true}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1999,7 +1960,6 @@ exports[`css.create() properties: "transition" width transition: start 1`] = `
 exports[`css.create() pseudo-elements ::placeholder syntax: placeholderTextColor 1`] = `
 {
   "placeholderTextColor": "red",
-  "ref": [Function],
   "style": {
     "boxSizing": "content-box",
     "overflow": "visible",

--- a/packages/react-strict-dom/tests/css/__snapshots__/css-themes-test.native.js.snap
+++ b/packages/react-strict-dom/tests/css/__snapshots__/css-themes-test.native.js.snap
@@ -32,7 +32,6 @@ exports[`css.* themes handles undefined variables 1`] = `
 exports[`css.* themes inherited themes 1`] = `
 [
   <Text
-    ref={[Function]}
     style={
       {
         "backgroundColor": "pink",
@@ -46,7 +45,6 @@ exports[`css.* themes inherited themes 1`] = `
     Expect color:red
   </Text>,
   <Text
-    ref={[Function]}
     style={
       {
         "backgroundColor": "pink",
@@ -73,7 +71,6 @@ exports[`css.* themes inherited themes 1`] = `
     }
   />,
   <ViewNativeComponent
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -82,7 +79,6 @@ exports[`css.* themes inherited themes 1`] = `
     }
   >
     <Text
-      ref={[Function]}
       style={
         {
           "backgroundColor": "pink",
@@ -109,7 +105,6 @@ exports[`css.* themes inherited themes 1`] = `
       }
     />
     <ViewNativeComponent
-      ref={[Function]}
       style={
         {
           "boxSizing": "content-box",
@@ -118,7 +113,6 @@ exports[`css.* themes inherited themes 1`] = `
       }
     >
       <Text
-        ref={[Function]}
         style={
           {
             "backgroundColor": "pink",
@@ -147,7 +141,6 @@ exports[`css.* themes inherited themes 1`] = `
     </ViewNativeComponent>
   </ViewNativeComponent>,
   <Text
-    ref={[Function]}
     style={
       {
         "backgroundColor": "pink",

--- a/packages/react-strict-dom/tests/html/__snapshots__/html-test.js.snap-native
+++ b/packages/react-strict-dom/tests/html/__snapshots__/html-test.js.snap-native
@@ -2,7 +2,6 @@
 
 exports[`<html.*> "a" default rendering 1`] = `
 <Text
-  ref={[Function]}
   role="link"
   style={
     {
@@ -18,7 +17,6 @@ exports[`<html.*> "a" default rendering 1`] = `
 
 exports[`<html.*> "a" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   role="link"
   style={
     {
@@ -35,7 +33,6 @@ exports[`<html.*> "a" ignores and warns about unsupported attributes 1`] = `
 exports[`<html.*> "a" supports additional anchor attributes 1`] = `
 <Text
   onPress={[Function]}
-  ref={[Function]}
   role="link"
   style={
     {
@@ -82,7 +79,6 @@ exports[`<html.*> "a" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -129,7 +125,6 @@ exports[`<html.*> "a" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="link"
   style={
     {
@@ -145,7 +140,6 @@ exports[`<html.*> "a" supports inline event handlers 1`] = `
 
 exports[`<html.*> "article" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -157,7 +151,6 @@ exports[`<html.*> "article" default rendering 1`] = `
 
 exports[`<html.*> "article" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -200,7 +193,6 @@ exports[`<html.*> "article" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -251,7 +243,6 @@ exports[`<html.*> "article" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -263,7 +254,6 @@ exports[`<html.*> "article" supports inline event handlers 1`] = `
 
 exports[`<html.*> "aside" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -275,7 +265,6 @@ exports[`<html.*> "aside" default rendering 1`] = `
 
 exports[`<html.*> "aside" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -318,7 +307,6 @@ exports[`<html.*> "aside" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -369,7 +357,6 @@ exports[`<html.*> "aside" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -381,7 +368,6 @@ exports[`<html.*> "aside" supports inline event handlers 1`] = `
 
 exports[`<html.*> "b" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -395,7 +381,6 @@ exports[`<html.*> "b" default rendering 1`] = `
 
 exports[`<html.*> "b" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -440,7 +425,6 @@ exports[`<html.*> "b" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -486,7 +470,6 @@ exports[`<html.*> "b" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -500,7 +483,6 @@ exports[`<html.*> "b" supports inline event handlers 1`] = `
 
 exports[`<html.*> "bdi" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -513,7 +495,6 @@ exports[`<html.*> "bdi" default rendering 1`] = `
 
 exports[`<html.*> "bdi" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -557,7 +538,6 @@ exports[`<html.*> "bdi" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -602,7 +582,6 @@ exports[`<html.*> "bdi" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -615,7 +594,6 @@ exports[`<html.*> "bdi" supports inline event handlers 1`] = `
 
 exports[`<html.*> "bdo" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -628,7 +606,6 @@ exports[`<html.*> "bdo" default rendering 1`] = `
 
 exports[`<html.*> "bdo" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -672,7 +649,6 @@ exports[`<html.*> "bdo" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -717,7 +693,6 @@ exports[`<html.*> "bdo" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -730,7 +705,6 @@ exports[`<html.*> "bdo" supports inline event handlers 1`] = `
 
 exports[`<html.*> "blockquote" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -742,7 +716,6 @@ exports[`<html.*> "blockquote" default rendering 1`] = `
 
 exports[`<html.*> "blockquote" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -785,7 +758,6 @@ exports[`<html.*> "blockquote" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -836,7 +808,6 @@ exports[`<html.*> "blockquote" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -848,7 +819,6 @@ exports[`<html.*> "blockquote" supports inline event handlers 1`] = `
 
 exports[`<html.*> "br" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "overflow": "visible",
@@ -862,7 +832,6 @@ exports[`<html.*> "br" default rendering 1`] = `
 
 exports[`<html.*> "br" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "overflow": "visible",
@@ -907,7 +876,6 @@ exports[`<html.*> "br" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -951,7 +919,6 @@ exports[`<html.*> "br" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "overflow": "visible",
@@ -965,7 +932,6 @@ exports[`<html.*> "br" supports inline event handlers 1`] = `
 
 exports[`<html.*> "button" default rendering 1`] = `
 <Pressable
-  ref={[Function]}
   role="button"
   style={
     {
@@ -979,7 +945,6 @@ exports[`<html.*> "button" default rendering 1`] = `
 
 exports[`<html.*> "button" ignores and warns about unsupported attributes 1`] = `
 <Pressable
-  ref={[Function]}
   role="button"
   style={
     {
@@ -995,7 +960,6 @@ exports[`<html.*> "button" supports additional button attributes 1`] = `
 <Pressable
   disabled={true}
   focusable={false}
-  ref={[Function]}
   role="button"
   style={
     {
@@ -1040,7 +1004,6 @@ exports[`<html.*> "button" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -1092,7 +1055,6 @@ exports[`<html.*> "button" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="button"
   style={
     {
@@ -1106,7 +1068,6 @@ exports[`<html.*> "button" supports inline event handlers 1`] = `
 
 exports[`<html.*> "code" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1120,7 +1081,6 @@ exports[`<html.*> "code" default rendering 1`] = `
 
 exports[`<html.*> "code" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1165,7 +1125,6 @@ exports[`<html.*> "code" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -1211,7 +1170,6 @@ exports[`<html.*> "code" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1225,7 +1183,6 @@ exports[`<html.*> "code" supports inline event handlers 1`] = `
 
 exports[`<html.*> "del" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1239,7 +1196,6 @@ exports[`<html.*> "del" default rendering 1`] = `
 
 exports[`<html.*> "del" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1284,7 +1240,6 @@ exports[`<html.*> "del" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -1330,7 +1285,6 @@ exports[`<html.*> "del" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1344,7 +1298,6 @@ exports[`<html.*> "del" supports inline event handlers 1`] = `
 
 exports[`<html.*> "div" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1356,7 +1309,6 @@ exports[`<html.*> "div" default rendering 1`] = `
 
 exports[`<html.*> "div" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1399,7 +1351,6 @@ exports[`<html.*> "div" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -1450,7 +1401,6 @@ exports[`<html.*> "div" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1462,7 +1412,6 @@ exports[`<html.*> "div" supports inline event handlers 1`] = `
 
 exports[`<html.*> "em" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1476,7 +1425,6 @@ exports[`<html.*> "em" default rendering 1`] = `
 
 exports[`<html.*> "em" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1521,7 +1469,6 @@ exports[`<html.*> "em" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -1567,7 +1514,6 @@ exports[`<html.*> "em" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1581,7 +1527,6 @@ exports[`<html.*> "em" supports inline event handlers 1`] = `
 
 exports[`<html.*> "fieldset" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1593,7 +1538,6 @@ exports[`<html.*> "fieldset" default rendering 1`] = `
 
 exports[`<html.*> "fieldset" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1636,7 +1580,6 @@ exports[`<html.*> "fieldset" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -1687,7 +1630,6 @@ exports[`<html.*> "fieldset" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1699,7 +1641,6 @@ exports[`<html.*> "fieldset" supports inline event handlers 1`] = `
 
 exports[`<html.*> "footer" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1711,7 +1652,6 @@ exports[`<html.*> "footer" default rendering 1`] = `
 
 exports[`<html.*> "footer" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1754,7 +1694,6 @@ exports[`<html.*> "footer" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -1805,7 +1744,6 @@ exports[`<html.*> "footer" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1817,7 +1755,6 @@ exports[`<html.*> "footer" supports inline event handlers 1`] = `
 
 exports[`<html.*> "form" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1829,7 +1766,6 @@ exports[`<html.*> "form" default rendering 1`] = `
 
 exports[`<html.*> "form" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1872,7 +1808,6 @@ exports[`<html.*> "form" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -1923,7 +1858,6 @@ exports[`<html.*> "form" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1935,7 +1869,6 @@ exports[`<html.*> "form" supports inline event handlers 1`] = `
 
 exports[`<html.*> "h1" default rendering 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -1951,7 +1884,6 @@ exports[`<html.*> "h1" default rendering 1`] = `
 
 exports[`<html.*> "h1" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -1998,7 +1930,6 @@ exports[`<html.*> "h1" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -2045,7 +1976,6 @@ exports[`<html.*> "h1" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2061,7 +1991,6 @@ exports[`<html.*> "h1" supports inline event handlers 1`] = `
 
 exports[`<html.*> "h2" default rendering 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2077,7 +2006,6 @@ exports[`<html.*> "h2" default rendering 1`] = `
 
 exports[`<html.*> "h2" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2124,7 +2052,6 @@ exports[`<html.*> "h2" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -2171,7 +2098,6 @@ exports[`<html.*> "h2" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2187,7 +2113,6 @@ exports[`<html.*> "h2" supports inline event handlers 1`] = `
 
 exports[`<html.*> "h3" default rendering 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2203,7 +2128,6 @@ exports[`<html.*> "h3" default rendering 1`] = `
 
 exports[`<html.*> "h3" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2250,7 +2174,6 @@ exports[`<html.*> "h3" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -2297,7 +2220,6 @@ exports[`<html.*> "h3" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2313,7 +2235,6 @@ exports[`<html.*> "h3" supports inline event handlers 1`] = `
 
 exports[`<html.*> "h4" default rendering 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2329,7 +2250,6 @@ exports[`<html.*> "h4" default rendering 1`] = `
 
 exports[`<html.*> "h4" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2376,7 +2296,6 @@ exports[`<html.*> "h4" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -2423,7 +2342,6 @@ exports[`<html.*> "h4" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2439,7 +2357,6 @@ exports[`<html.*> "h4" supports inline event handlers 1`] = `
 
 exports[`<html.*> "h5" default rendering 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2455,7 +2372,6 @@ exports[`<html.*> "h5" default rendering 1`] = `
 
 exports[`<html.*> "h5" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2502,7 +2418,6 @@ exports[`<html.*> "h5" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -2549,7 +2464,6 @@ exports[`<html.*> "h5" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2565,7 +2479,6 @@ exports[`<html.*> "h5" supports inline event handlers 1`] = `
 
 exports[`<html.*> "h6" default rendering 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2581,7 +2494,6 @@ exports[`<html.*> "h6" default rendering 1`] = `
 
 exports[`<html.*> "h6" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2628,7 +2540,6 @@ exports[`<html.*> "h6" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -2675,7 +2586,6 @@ exports[`<html.*> "h6" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="heading"
   style={
     {
@@ -2691,7 +2601,6 @@ exports[`<html.*> "h6" supports inline event handlers 1`] = `
 
 exports[`<html.*> "header" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   role="header"
   style={
     {
@@ -2704,7 +2613,6 @@ exports[`<html.*> "header" default rendering 1`] = `
 
 exports[`<html.*> "header" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   role="header"
   style={
     {
@@ -2748,7 +2656,6 @@ exports[`<html.*> "header" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -2799,7 +2706,6 @@ exports[`<html.*> "header" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="header"
   style={
     {
@@ -2812,7 +2718,6 @@ exports[`<html.*> "header" supports inline event handlers 1`] = `
 
 exports[`<html.*> "hr" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "backgroundColor": "black",
@@ -2826,7 +2731,6 @@ exports[`<html.*> "hr" default rendering 1`] = `
 
 exports[`<html.*> "hr" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "backgroundColor": "black",
@@ -2871,7 +2775,6 @@ exports[`<html.*> "hr" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -2924,7 +2827,6 @@ exports[`<html.*> "hr" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "backgroundColor": "black",
@@ -2938,7 +2840,6 @@ exports[`<html.*> "hr" supports inline event handlers 1`] = `
 
 exports[`<html.*> "i" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2952,7 +2853,6 @@ exports[`<html.*> "i" default rendering 1`] = `
 
 exports[`<html.*> "i" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -2997,7 +2897,6 @@ exports[`<html.*> "i" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -3043,7 +2942,6 @@ exports[`<html.*> "i" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3057,7 +2955,6 @@ exports[`<html.*> "i" supports inline event handlers 1`] = `
 
 exports[`<html.*> "img" default rendering 1`] = `
 <Image
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3070,7 +2967,6 @@ exports[`<html.*> "img" default rendering 1`] = `
 
 exports[`<html.*> "img" ignores and warns about unsupported attributes 1`] = `
 <Image
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3088,7 +2984,6 @@ exports[`<html.*> "img" supports additional image attributes 1`] = `
   height={100}
   onError={[Function]}
   onLoad={[Function]}
-  ref={[Function]}
   referrerPolicy="no-referrer"
   src="https://src.jpg"
   srcSet="https://srcSet-1x.jpg 1x, https://srcSet-2x.jpg 2x"
@@ -3139,7 +3034,6 @@ exports[`<html.*> "img" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -3183,7 +3077,6 @@ exports[`<html.*> "img" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3344,7 +3237,6 @@ exports[`<html.*> "input" supports inline event handlers 1`] = `
 
 exports[`<html.*> "ins" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3358,7 +3250,6 @@ exports[`<html.*> "ins" default rendering 1`] = `
 
 exports[`<html.*> "ins" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3403,7 +3294,6 @@ exports[`<html.*> "ins" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -3449,7 +3339,6 @@ exports[`<html.*> "ins" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3463,7 +3352,6 @@ exports[`<html.*> "ins" supports inline event handlers 1`] = `
 
 exports[`<html.*> "kbd" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3477,7 +3365,6 @@ exports[`<html.*> "kbd" default rendering 1`] = `
 
 exports[`<html.*> "kbd" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3522,7 +3409,6 @@ exports[`<html.*> "kbd" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -3568,7 +3454,6 @@ exports[`<html.*> "kbd" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3582,7 +3467,6 @@ exports[`<html.*> "kbd" supports inline event handlers 1`] = `
 
 exports[`<html.*> "label" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3595,7 +3479,6 @@ exports[`<html.*> "label" default rendering 1`] = `
 
 exports[`<html.*> "label" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3608,7 +3491,6 @@ exports[`<html.*> "label" ignores and warns about unsupported attributes 1`] = `
 
 exports[`<html.*> "label" supports additional label attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3652,7 +3534,6 @@ exports[`<html.*> "label" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -3697,7 +3578,6 @@ exports[`<html.*> "label" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3710,7 +3590,6 @@ exports[`<html.*> "label" supports inline event handlers 1`] = `
 
 exports[`<html.*> "li" supports list item attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   role="listitem"
   style={
     {
@@ -3723,7 +3602,6 @@ exports[`<html.*> "li" supports list item attributes 1`] = `
 
 exports[`<html.*> "main" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3735,7 +3613,6 @@ exports[`<html.*> "main" default rendering 1`] = `
 
 exports[`<html.*> "main" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3778,7 +3655,6 @@ exports[`<html.*> "main" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -3829,7 +3705,6 @@ exports[`<html.*> "main" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3841,7 +3716,6 @@ exports[`<html.*> "main" supports inline event handlers 1`] = `
 
 exports[`<html.*> "mark" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "backgroundColor": "yellow",
@@ -3856,7 +3730,6 @@ exports[`<html.*> "mark" default rendering 1`] = `
 
 exports[`<html.*> "mark" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "backgroundColor": "yellow",
@@ -3902,7 +3775,6 @@ exports[`<html.*> "mark" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -3949,7 +3821,6 @@ exports[`<html.*> "mark" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "backgroundColor": "yellow",
@@ -3964,7 +3835,6 @@ exports[`<html.*> "mark" supports inline event handlers 1`] = `
 
 exports[`<html.*> "nav" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -3976,7 +3846,6 @@ exports[`<html.*> "nav" default rendering 1`] = `
 
 exports[`<html.*> "nav" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4019,7 +3888,6 @@ exports[`<html.*> "nav" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -4070,7 +3938,6 @@ exports[`<html.*> "nav" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4082,7 +3949,6 @@ exports[`<html.*> "nav" supports inline event handlers 1`] = `
 
 exports[`<html.*> "ol" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   role="list"
   style={
     {
@@ -4095,7 +3961,6 @@ exports[`<html.*> "ol" default rendering 1`] = `
 
 exports[`<html.*> "ol" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   role="list"
   style={
     {
@@ -4139,7 +4004,6 @@ exports[`<html.*> "ol" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -4190,7 +4054,6 @@ exports[`<html.*> "ol" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="list"
   style={
     {
@@ -4203,7 +4066,6 @@ exports[`<html.*> "ol" supports inline event handlers 1`] = `
 
 exports[`<html.*> "ol" supports list attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   role="list"
   style={
     {
@@ -4216,7 +4078,6 @@ exports[`<html.*> "ol" supports list attributes 1`] = `
 
 exports[`<html.*> "optgroup" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4228,7 +4089,6 @@ exports[`<html.*> "optgroup" default rendering 1`] = `
 
 exports[`<html.*> "optgroup" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4271,7 +4131,6 @@ exports[`<html.*> "optgroup" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -4322,7 +4181,6 @@ exports[`<html.*> "optgroup" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4334,7 +4192,6 @@ exports[`<html.*> "optgroup" supports inline event handlers 1`] = `
 
 exports[`<html.*> "option" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4347,7 +4204,6 @@ exports[`<html.*> "option" default rendering 1`] = `
 
 exports[`<html.*> "option" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4391,7 +4247,6 @@ exports[`<html.*> "option" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -4434,7 +4289,6 @@ exports[`<html.*> "option" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4447,7 +4301,6 @@ exports[`<html.*> "option" supports inline event handlers 1`] = `
 
 exports[`<html.*> "option" supports input attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4462,7 +4315,6 @@ exports[`<html.*> "option" supports input attributes 1`] = `
 
 exports[`<html.*> "p" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4475,7 +4327,6 @@ exports[`<html.*> "p" default rendering 1`] = `
 
 exports[`<html.*> "p" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4519,7 +4370,6 @@ exports[`<html.*> "p" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -4564,7 +4414,6 @@ exports[`<html.*> "p" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4577,7 +4426,6 @@ exports[`<html.*> "p" supports inline event handlers 1`] = `
 
 exports[`<html.*> "pre" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4591,7 +4439,6 @@ exports[`<html.*> "pre" default rendering 1`] = `
 
 exports[`<html.*> "pre" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4636,7 +4483,6 @@ exports[`<html.*> "pre" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -4682,7 +4528,6 @@ exports[`<html.*> "pre" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4696,7 +4541,6 @@ exports[`<html.*> "pre" supports inline event handlers 1`] = `
 
 exports[`<html.*> "s" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4710,7 +4554,6 @@ exports[`<html.*> "s" default rendering 1`] = `
 
 exports[`<html.*> "s" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4755,7 +4598,6 @@ exports[`<html.*> "s" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -4801,7 +4643,6 @@ exports[`<html.*> "s" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4815,7 +4656,6 @@ exports[`<html.*> "s" supports inline event handlers 1`] = `
 
 exports[`<html.*> "section" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4827,7 +4667,6 @@ exports[`<html.*> "section" default rendering 1`] = `
 
 exports[`<html.*> "section" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4870,7 +4709,6 @@ exports[`<html.*> "section" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -4921,7 +4759,6 @@ exports[`<html.*> "section" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4933,7 +4770,6 @@ exports[`<html.*> "section" supports inline event handlers 1`] = `
 
 exports[`<html.*> "select" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4945,7 +4781,6 @@ exports[`<html.*> "select" default rendering 1`] = `
 
 exports[`<html.*> "select" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -4957,7 +4792,6 @@ exports[`<html.*> "select" ignores and warns about unsupported attributes 1`] = 
 
 exports[`<html.*> "select" supports additional select attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5000,7 +4834,6 @@ exports[`<html.*> "select" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -5051,7 +4884,6 @@ exports[`<html.*> "select" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5063,7 +4895,6 @@ exports[`<html.*> "select" supports inline event handlers 1`] = `
 
 exports[`<html.*> "span" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5076,7 +4907,6 @@ exports[`<html.*> "span" default rendering 1`] = `
 
 exports[`<html.*> "span" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5120,7 +4950,6 @@ exports[`<html.*> "span" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -5165,7 +4994,6 @@ exports[`<html.*> "span" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5178,7 +5006,6 @@ exports[`<html.*> "span" supports inline event handlers 1`] = `
 
 exports[`<html.*> "strong" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5192,7 +5019,6 @@ exports[`<html.*> "strong" default rendering 1`] = `
 
 exports[`<html.*> "strong" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5237,7 +5063,6 @@ exports[`<html.*> "strong" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -5283,7 +5108,6 @@ exports[`<html.*> "strong" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5297,7 +5121,6 @@ exports[`<html.*> "strong" supports inline event handlers 1`] = `
 
 exports[`<html.*> "sub" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5310,7 +5133,6 @@ exports[`<html.*> "sub" default rendering 1`] = `
 
 exports[`<html.*> "sub" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5354,7 +5176,6 @@ exports[`<html.*> "sub" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -5399,7 +5220,6 @@ exports[`<html.*> "sub" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5412,7 +5232,6 @@ exports[`<html.*> "sub" supports inline event handlers 1`] = `
 
 exports[`<html.*> "sup" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5425,7 +5244,6 @@ exports[`<html.*> "sup" default rendering 1`] = `
 
 exports[`<html.*> "sup" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5469,7 +5287,6 @@ exports[`<html.*> "sup" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -5514,7 +5331,6 @@ exports[`<html.*> "sup" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5685,7 +5501,6 @@ exports[`<html.*> "textarea" supports inline event handlers 1`] = `
 
 exports[`<html.*> "u" default rendering 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5699,7 +5514,6 @@ exports[`<html.*> "u" default rendering 1`] = `
 
 exports[`<html.*> "u" ignores and warns about unsupported attributes 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5744,7 +5558,6 @@ exports[`<html.*> "u" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -5790,7 +5603,6 @@ exports[`<html.*> "u" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -5804,7 +5616,6 @@ exports[`<html.*> "u" supports inline event handlers 1`] = `
 
 exports[`<html.*> "ul" default rendering 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   role="list"
   style={
     {
@@ -5817,7 +5628,6 @@ exports[`<html.*> "ul" default rendering 1`] = `
 
 exports[`<html.*> "ul" ignores and warns about unsupported attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   role="list"
   style={
     {
@@ -5861,7 +5671,6 @@ exports[`<html.*> "ul" supports global attributes 1`] = `
   focusable={true}
   importantForAccessibility="no-hide-descendants"
   nativeID="some-id"
-  ref={[Function]}
   role="article"
   style={
     {
@@ -5912,7 +5721,6 @@ exports[`<html.*> "ul" supports inline event handlers 1`] = `
   onTouchEnd={[Function]}
   onTouchMove={[Function]}
   onTouchStart={[Function]}
-  ref={[Function]}
   role="list"
   style={
     {
@@ -5925,7 +5733,6 @@ exports[`<html.*> "ul" supports inline event handlers 1`] = `
 
 exports[`<html.*> "ul" supports list attributes 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   role="list"
   style={
     {
@@ -5938,7 +5745,6 @@ exports[`<html.*> "ul" supports list attributes 1`] = `
 
 exports[`<html.*> temporary data-* props support 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",

--- a/packages/react-strict-dom/tests/html/__snapshots__/html-test.native.js.snap
+++ b/packages/react-strict-dom/tests/html/__snapshots__/html-test.native.js.snap
@@ -2,7 +2,6 @@
 
 exports[`<html.*> (native polyfills) auto-wraps raw strings: auto-wrap raw strings 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -27,7 +26,6 @@ exports[`<html.*> (native polyfills) opt in to strict layout conformance: strict
   mode="strict"
 >
   <ViewNativeComponent
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -40,7 +38,6 @@ exports[`<html.*> (native polyfills) opt in to strict layout conformance: strict
 
 exports[`<html.*> (native polyfills) polyfills: inheritence inherited styles 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "borderColor": "red",
@@ -50,7 +47,6 @@ exports[`<html.*> (native polyfills) polyfills: inheritence inherited styles 1`]
   }
 >
   <ViewNativeComponent
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -59,7 +55,6 @@ exports[`<html.*> (native polyfills) polyfills: inheritence inherited styles 1`]
     }
   >
     <Text
-      ref={[Function]}
       style={
         {
           "boxSizing": "content-box",
@@ -102,7 +97,6 @@ exports[`<html.*> (native polyfills) polyfills: inheritence inherited styles 1`]
 
 exports[`<html.*> (native polyfills) polyfills: inheritence inherited styles for auto-fix of raw strings 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -111,7 +105,6 @@ exports[`<html.*> (native polyfills) polyfills: inheritence inherited styles for
   }
 >
   <ViewNativeComponent
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -136,7 +129,6 @@ exports[`<html.*> (native polyfills) polyfills: inheritence inherited styles for
 
 exports[`<html.*> (native polyfills) polyfills: layout block layout override of flex layout: block layout override of flex 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "alignItems": "stretch",
@@ -152,7 +144,6 @@ exports[`<html.*> (native polyfills) polyfills: layout block layout override of 
   }
 >
   <ViewNativeComponent
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -165,7 +156,6 @@ exports[`<html.*> (native polyfills) polyfills: layout block layout override of 
 
 exports[`<html.*> (native polyfills) polyfills: layout default block layout: block layout 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -177,7 +167,6 @@ exports[`<html.*> (native polyfills) polyfills: layout default block layout: blo
 
 exports[`<html.*> (native polyfills) polyfills: layout default flex layout: flex layout 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "alignContent": "stretch",
@@ -194,7 +183,6 @@ exports[`<html.*> (native polyfills) polyfills: layout default flex layout: flex
   }
 >
   <ViewNativeComponent
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -204,7 +192,6 @@ exports[`<html.*> (native polyfills) polyfills: layout default flex layout: flex
     }
   />
   <ViewNativeComponent
-    ref={[Function]}
     style={
       {
         "boxSizing": "content-box",
@@ -219,7 +206,6 @@ exports[`<html.*> (native polyfills) polyfills: layout default flex layout: flex
 exports[`<html.*> (native polyfills) polyfills: props <img> "src" prop with loading props 1`] = `
 <Image
   crossOrigin="use-credentials"
-  ref={[Function]}
   referrerPolicy="no-referrer"
   src="https://src.jpg"
   style={
@@ -235,7 +221,6 @@ exports[`<html.*> (native polyfills) polyfills: props <img> "src" prop with load
 exports[`<html.*> (native polyfills) polyfills: props <img> "srcSet" prop with loading props 1`] = `
 <Image
   crossOrigin="use-credentials"
-  ref={[Function]}
   referrerPolicy="no-referrer"
   srcSet="https://src.jpg 1x, https://srcx2.jpg 2x"
   style={
@@ -995,7 +980,6 @@ exports[`<html.*> (native polyfills) polyfills: props <textarea> "rows" prop 1`]
 
 exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "auto" block 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1007,7 +991,6 @@ exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "auto" 
 
 exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "auto" text 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1021,7 +1004,6 @@ exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "auto" 
 
 exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "ltr" block 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1034,7 +1016,6 @@ exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "ltr" b
 
 exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "ltr" text 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1049,7 +1030,6 @@ exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "ltr" t
 
 exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "rtl" block 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1062,7 +1042,6 @@ exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "rtl" b
 
 exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "rtl" text 1`] = `
 <Text
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1077,7 +1056,6 @@ exports[`<html.*> (native polyfills) polyfills: props global "dir" prop: "rtl" t
 
 exports[`<html.*> (native polyfills) polyfills: props global "hidden" prop 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "boxSizing": "content-box",
@@ -1178,7 +1156,6 @@ exports[`<html.*> (native polyfills) polyfills: props global "hidden" prop: "unt
 
 exports[`<html.*> (native polyfills) polyfills: props global "hidden" prop: display set 1`] = `
 <ViewNativeComponent
-  ref={[Function]}
   style={
     {
       "alignContent": "stretch",


### PR DESCRIPTION
This reduces RSD's memory overhead in React Native. Measured with https://github.com/ixf/rsd-bench - in this bench it drops retained memory and render times by a couple percent (~5%)

- `useStrictDOMElement` doesn't need to create a callback ref if no ref was passed to the component
- replace `useCallback` + `useElementCallback` (`useCallback` + `useRef`) with one `useMemo`
- reuse default props for images when no aspect ratio needs to be added