### PR TITLE
Use correct RSD website URL in README.md

### DIFF
--- a/packages/react-strict-dom/README.md
+++ b/packages/react-strict-dom/README.md
@@ -11,7 +11,7 @@
 
 ## Documentation
 
-Please refer to the [React Strict DOM website](https://facebook.github.io/react-strict-dom/) for detailed documentation. The API section includes detailed compatibility tables for native. Please read the linked issues for details on the most significant issues, and register your interest (e.g., thumbsup reaction) in supporting these features on native platforms.
+Please refer to the [React Strict DOM website](https://react.github.io/react-strict-dom/) for detailed documentation. The API section includes detailed compatibility tables for native. Please read the linked issues for details on the most significant issues, and register your interest (e.g., thumbsup reaction) in supporting these features on native platforms.
 
 ## Example
 


### PR DESCRIPTION
All `facebook.github.io` links now redirect to the root `opensource.fb.com` website, where you need to search for the RSD project to find the correct `react.github.io` project page.

This PR puts the correct link in the README